### PR TITLE
Remove broken documentation link from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,6 @@
 - [Development Setup](#development-setup)
 - [Testing](#testing)
 - [Communication](#communication)
-- [Development Diagrams](./docs/development_diagrams.md)
 
 Thank you for your interest in contributing to Auto_Jobs_Applier_AIHawk. This document provides guidelines for contributing to the project.
 


### PR DESCRIPTION
## Summary

This pull request removes a broken documentation link from `CONTRIBUTING.md`.

## Changes

- Removed the `Development Diagrams` entry from the table of contents because it references `./docs/development_diagrams.md`, which is not present in the repository.

## Reason

The referenced documentation file is missing, causing the link to result in an error page. Removing the broken reference improves the contributor documentation and avoids confusion for new contributors.