### PR TITLE
Replace the committed API key with a placeholder

### DIFF
--- a/data_folder/secrets.yaml
+++ b/data_folder/secrets.yaml
@@ -1,1 +1,1 @@
-llm_api_key: 'sk-11KRr4uuTwpRGfeRTfj1T9BlbkFJjP8QTrswHU1yGruru2FR'
+llm_api_key: 'YOUR_API_KEY_HERE'

--- a/data_folder_example/secrets.yaml
+++ b/data_folder_example/secrets.yaml
@@ -1,1 +1,1 @@
-llm_api_key: 'sk-11KRr4uuTwpRGfeRTfj1T9BlbkFJjP8QTrswHU1yGruru2FR'
+llm_api_key: 'YOUR_API_KEY_HERE'


### PR DESCRIPTION
data_folder/secrets.yaml and the example beside it both shipped a real-looking OpenAI key. It is dead and answers 401, but it should not have been in the repository, and anyone copying the file inherits a broken default instead of a clear instruction to put their own key there.

No history rewrite. Thousands of forks, a force push breaks all of them, and the old blob stays reachable by SHA anyway.