### PR TITLE
Put the uv install commands back

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,14 @@ The two tailored options ask for a job posting URL and open it in Chrome. The fi
 
 It installs as a package, `invisible-playwright-mcp` on PyPI. None of it is in this repository, so there is nothing to clone here.
 
-You need [uv](https://docs.astral.sh/uv/) for the `uvx` command, **Python 3.11 or newer**, and **Windows or Linux**. If you use [Claude Code](https://claude.com/claude-code), Claude Desktop, Cursor or anything similar, you already have the client half.
+You need **Python 3.11 or newer**, **Windows or Linux**, and [uv](https://docs.astral.sh/uv/), which provides the `uvx` command:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh              # macOS, Linux
+powershell -c "irm https://astral.sh/uv/install.ps1 | iex"   # Windows
+```
+
+If you use [Claude Code](https://claude.com/claude-code), Claude Desktop, Cursor or anything similar, you already have the client half.
 
 ```bash
 claude mcp add stealth --env STEALTHFOX_PROXY=http://user:pass@host:port -- uvx invisible-playwright-mcp


### PR DESCRIPTION
Verified on a machine without it: uv and uvx are not there, so the install command in this file was not runnable as written. The README linked uv and said you need it, which sends the reader out of the page to work out what to click. Two lines, next to the command that needs them.

The rest of the file was checked the same way today, against a fresh clone and a clean virtualenv, and it holds. The three setup commands work. The first run creates data_folder and names all three files. The menu offers exactly the three documents listed. The MCP server started with the documented command exposes exactly the thirteen tools named, and driving it against a local page navigates, reads the text back and returns a screenshot that renders.

Two claims are not proven and are left alone rather than softened: the first browser launch downloading a few hundred megabytes, which could not be reproduced on a machine where the engine is already cached, and the PDF generation itself, which needs a real OpenAI key.