### PR TITLE
Stop opening the README with what the project no longer does

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@
 
 ---
 
-The 2024 mass-application bot the press wrote about is not in this repository any more. It is still in the git history if you forked it and want to compare, but it is unmaintained and will not work against anything current. What is here now, and what installs beside it, is below.
+Both halves below are open source and both work today. Pick the one you came for.
+
+The 2024 mass-application bot the press wrote about is neither of them. It is in the git history if you forked it, unmaintained, and it will not work against anything current.
 
 ## I want documents
 


### PR DESCRIPTION
The first paragraph a visitor read was a retraction: the bot the press wrote about is gone, unmaintained, will not work. Somebody arriving from one of those 2024 articles learned the thing they came for is dead before learning what is here instead, which is a strange way to greet the people the coverage sends.

The fact stays, because a reader expecting a mass applier has to find out, but it goes second and in one sentence instead of three. The first line now says both halves work and tells them to pick one, which is what the two sections underneath are for.