### PR TITLE
Put the story in the subtitle and drop the preamble under it

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # AIHawk
 
-**An LLM that writes your application documents, and a browser your AI client drives.**
+**Born as an AI web agent that applied to jobs in bulk. Becoming a general one: an agent you point at the web and tell what to do.**
 
 [**Business Insider**](https://www.businessinsider.com/aihawk-applies-jobs-for-you-linkedin-risks-inaccuracies-mistakes-2024-11) ·
 [**TechCrunch**](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/) ·
@@ -16,10 +16,6 @@
 </div>
 
 ---
-
-Both halves below are open source and both work today. Pick the one you came for.
-
-AIHawk was born as an AI web agent that applied to jobs in bulk, which is what the press above wrote about. It is becoming a general one: an agent you point at the web and tell what to do, with the job application as one thing you can ask for rather than the only thing. The 2024 bulk applier itself is in the git history, unmaintained.
 
 ## I want documents
 


### PR DESCRIPTION
The subtitle described the two halves, which the two headings underneath already do, and then two paragraphs said the same thing again before letting anyone reach a command.

The subtitle now carries the only thing those paragraphs were really for: born as an AI web agent that applied to jobs in bulk, becoming a general one you point at the web and tell what to do. Everything between the press links and the first heading is gone, and the first command is five lines closer.

The limits section still says nothing fills and submits an application end to end, and still says there is no captcha solver, so nothing a reader could be burned by moved.