### PR TITLE
Tighten the gap under the FEATURED IN label

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 **Born as an AI web agent that applied to jobs in bulk. Becoming a general one: an agent you point at the web and tell what to do.**
 
 <sub>FEATURED IN</sub>
-
 [**Business Insider**](https://www.businessinsider.com/aihawk-applies-jobs-for-you-linkedin-risks-inaccuracies-mistakes-2024-11) ·
 [**TechCrunch**](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/) ·
 [**Semafor**](https://www.semafor.com/article/09/12/2024/linkedins-have-nots-and-have-bots) ·


### PR DESCRIPTION
The label and the press row were separate paragraphs, so they rendered a paragraph apart. They are one paragraph now with a single line break between them, checked through the GitHub markdown API rather than guessed: all eight links still render and the picture element survives.