### PR TITLE
Put the explicit line break back under the label

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **Born as an AI web agent that applied to jobs in bulk. Becoming a general one: an agent you point at the web and tell what to do.**
 
-<sub>FEATURED IN</sub>
+<sub>FEATURED IN</sub><br>
 [**Business Insider**](https://www.businessinsider.com/aihawk-applies-jobs-for-you-linkedin-risks-inaccuracies-mistakes-2024-11) ·
 [**TechCrunch**](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/) ·
 [**Semafor**](https://www.semafor.com/article/09/12/2024/linkedins-have-nots-and-have-bots) ·


### PR DESCRIPTION
The label and the press row ended up on one line. The break was removed on the strength of a render from the /markdown API in gfm mode, which turns single newlines into br. The renderer behind the repository page does not, so on the actual README there was no break left at all. Verified against the rendered repository page this time.