### PR TITLE
Say how big the download actually is

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Restart the client and list your MCP servers. `stealth` should be there with
 thirteen tools attached. Ask for one small thing first, like opening a page and
 taking a screenshot.
 
-The first launch downloads a few hundred megabytes and looks like a hang. It is
+The first launch downloads the browser, about 700 MB, and looks like a hang. It is
 cached after that. If the server never appears at all, `uvx` is not on the PATH
 your client sees, which is not always the PATH your shell sees.
 


### PR DESCRIPTION
Measured twice, in two virgin environments with an empty engine cache: 697 MB.

"A few hundred megabytes" is not false but it reads as two or three, and on a slow connection the difference between three hundred and seven hundred is the difference between waiting and giving up.