### PR TITLE
0.2.0: two ways in on the first screen, and the key really does stay out

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,7 +10,7 @@ browser actions, and the command line around both. If you are changing what a
 person sees, or how the model decides what to do next, it is here.
 
 What is NOT here is the browser. AIHawk does not drive Firefox directly - it
-talks to an MCP server over MCP, using the same fourteen tools any other client
+talks to an MCP server over MCP, using the same tools any other client
 gets. That is deliberate and it is the thing to understand before changing
 anything: this interface has no privileged path to the page, so a browser
 capability it needs is a capability every client gets, or it does not exist.
@@ -23,7 +23,7 @@ only documentation. The package moved in the same day.
 | Repository | What it holds |
 |---|---|
 | **this one** | the interface, the agent loop, the CLI |
-| [invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp) | the MCP server: the fourteen tools, and nothing with a face |
+| [invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp) | the MCP server: the tools, and nothing with a face |
 | [invisible_playwright](https://github.com/feder-cr/invisible_playwright) | the Python wrapper, the launcher, and the patched browser it pins |
 | [invisible_core](https://github.com/feder-cr/invisible_core) | seed to fingerprint to preferences, proxy and geolocation |
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,6 +69,59 @@ jobs:
             echo "tag v$TAG does not name the version in pyproject.toml ($HAVE)" >&2
             exit 1
           fi
+      - name: the MCP server floor is SATISFIABLE on the index
+        # The ordering rule, as a gate instead of a sentence in a runbook, and it
+        # is here because the rule was broken the day it was written: aihawk was
+        # committed using `browser_select_option`, a tool that existed only in an
+        # unpublished server. Locally everything was green - the checkout is an
+        # editable install and cannot see this class of failure at all - while a
+        # runner resolving from the index got a server without the tool.
+        #
+        # Measured that day, in a venv built to resolve the way CI does: the index
+        # served 14 tools, the checkout offered 15, and the aihawk suite failed on
+        # exactly the difference.
+        #
+        # A FLOOR, not an exact pin, so the question is not "is this version there"
+        # but "does the index serve anything that satisfies it". That is a
+        # different check from the wrapper's, and writing the wrapper's would pass
+        # on a floor no release can meet.
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Read the floor from the dependency itself. A number typed here would be
+          # a second place to update, and the second place is the one that rots.
+          FLOOR=$(python - <<'PY'
+          import re, tomllib
+          with open("pyproject.toml", "rb") as fh:
+              deps = tomllib.load(fh)["project"]["dependencies"]
+          # PEP 503: `invisible-playwright-mcp` and `invisible_playwright_mcp` are
+          # the same project, so both spellings are accepted rather than assumed.
+          want = [d for d in deps if re.match(r"invisible[-_]playwright[-_]mcp", d)]
+          if len(want) != 1:
+              raise SystemExit("expected exactly one MCP dependency, found %r" % want)
+          m = re.search(r">=\s*([0-9]+(?:\.[0-9]+)*)", want[0])
+          if not m:
+              raise SystemExit("no >= floor on the MCP dependency: %r" % want[0])
+          print(m.group(1))
+          PY
+          )
+          echo "floor: $FLOOR"
+          BEST=$(curl -sf "https://pypi.org/pypi/invisible-playwright-mcp/json" \
+                 | python -c 'import json,sys; print(json.load(sys.stdin)["info"]["version"])')
+          echo "index serves: $BEST"
+          python - "$FLOOR" "$BEST" <<'PY'
+          import sys
+          def key(v):
+              return tuple(int(p) for p in v.split("."))
+          floor, best = sys.argv[1], sys.argv[2]
+          if key(best) < key(floor):
+              sys.exit(
+                  "the index serves invisible-playwright-mcp %s and this release "
+                  "needs >=%s, so pip could not resolve it on any runner and the "
+                  "package would install broken for everyone. Publish the server "
+                  "first, then release this." % (best, floor))
+          print("resolvable: %s satisfies >=%s" % (best, floor))
+          PY
       - name: install and run the suite
         # A tag push does not trigger the ordinary test workflow, which runs on
         # branches and pull requests, so without this a tag could publish code

--- a/README.md
+++ b/README.md
@@ -5,13 +5,12 @@
   <img alt="AIHawk" src="assets/aihawk-logo-light.png" width="380">
 </picture>
 
-**Born as an AI web agent that applied to jobs in bulk. Becoming a general one: an agent you point at the web and tell what to do.**
+**An AI agent with a real browser. You say what you want in plain language, it goes and does it on the actual web.**
 
 <sub>FEATURED IN</sub><br>
 [**Business Insider**](https://www.businessinsider.com/aihawk-applies-jobs-for-you-linkedin-risks-inaccuracies-mistakes-2024-11) ·
 [**TechCrunch**](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/) ·
 [**Semafor**](https://www.semafor.com/article/09/12/2024/linkedins-have-nots-and-have-bots) ·
-[**Dev.by**](https://devby.io/news/ya-razoslal-rezume-na-2843-vakansii-po-17-v-chas-kak-ii-boty-vytesnyaut-ludei-iz-protsessa-naima.amp) ·
 [**Wired**](https://www.wired.it/article/aihawk-come-automatizzare-ricerca-lavoro/) ·
 [**The Verge**](https://www.theverge.com/2024/10/10/24266898/ai-is-enabling-job-seekers-to-think-like-spammers) ·
 [**Vanity Fair**](https://www.vanityfair.it/article/intelligenza-artificiale-candidature-di-lavoro) ·
@@ -21,139 +20,141 @@
 
 ---
 
-## Overview
+# Pick one
 
-AIHawk gives a model a real browser and a page to work in. You type what you
-want in plain language, and you watch it happen: the conversation on the left,
-the browser on the right, live.
+There are two ways to use this, and the only real question is **where the model comes from**.
 
-One command, and the only thing it needs from you is an
-[OpenRouter](https://openrouter.ai) key. No client to install, no configuration
-to paste into another program, nothing else to run.
+<table>
+<tr>
+<th width="50%">1. Your AI client already has a model</th>
+<th width="50%">2. You want an interface, model included</th>
+</tr>
+<tr>
+<td valign="top">
+
+Claude Code, Claude Desktop, Cursor, or anything else that speaks MCP.
+The browser shows up as tools it can use.
+
+```bash
+claude mcp add stealth -- uvx invisible-playwright-mcp
+```
+
+Then just talk to your client:
+
+> Go to news.ycombinator.com and give me the top five titles.
+
+</td>
+<td valign="top">
+
+No client needed. Bring an [OpenRouter](https://openrouter.ai) key, get a page
+with the chat on the left and the live browser on the right.
 
 ```bash
 uvx aihawk ui --openrouter-key sk-or-...
 ```
 
-Then open `http://127.0.0.1:8765`.
+Then open **http://127.0.0.1:8765** and type the same thing.
 
-The browser is a patched Firefox that looks like an ordinary one, and it is the
-same engine whether you drive it from here, from a script, or from your own
-agent.
+</td>
+</tr>
+</table>
 
-## Requirements
+Same patched Firefox either way, and the second one is a client of the first: AIHawk
+talks to that MCP server over MCP, with no private path to the browser.
 
-**Python 3.11 or newer**, **Windows or Linux**, and
-[uv](https://docs.astral.sh/uv/), which provides the `uvx` command.
+**Not sure?** If you already pay for Claude or Cursor, take column 1 - you are
+already paying for the model. Otherwise take column 2.
+
+## Before you start
+
+**Python 3.11 or newer**, on **Windows (x86_64) or Linux (x86_64, arm64)**.
+macOS is not supported: no Mac engine has been published since firefox-21. Plus
+[uv](https://docs.astral.sh/uv/), which is what gives you `uvx`:
 
 ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh              # macOS, Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh              # Linux
 powershell -c "irm https://astral.sh/uv/install.ps1 | iex"   # Windows
 ```
 
-The first launch downloads the browser, about 700 MB, and looks like a hang. It
-is cached after that.
+The first run downloads the browser, about 700 MB. It looks like a hang and it is
+cached afterwards.
 
-## Two ways to run it
+That is the whole setup. No proxy, no account, no config file.
 
-**The interface.** Everything happens on one page and you can see it.
+## Without a page, for scripts and cron
 
-```bash
-uvx aihawk ui --openrouter-key sk-or-... --proxy http://user:pass@host:port
-```
-
-**One shot.** Same machinery, no page, an answer on stdout. For scripts and cron.
+Same machinery, no interface, the answer on stdout.
 
 ```bash
-uvx aihawk do "Open <url> and tell me the price of the first result" \
-  --openrouter-key sk-or-...
+uvx aihawk do "Go to example.com and tell me the top headline" --openrouter-key sk-or-...
 ```
 
-Without a key, `aihawk ui` still starts. What answers is a placeholder that
-understands five literal commands - `go <url>`, `read [selector]`,
-`click <selector>`, `type <selector> <text>`, `shot` - which is enough to see
-the interface work, and to tell a browser problem from a model problem without
-spending anything.
+## Without a key
 
-## What to ask it
+`uvx aihawk ui` starts without one. What answers is a placeholder that understands
+six literal commands - `go <url>`, `read [selector]`, `click <selector>`,
+`type <selector> <text>`, `tab`, `shot` - which is enough to see the interface work and to
+tell a browser problem from a model problem before spending anything.
 
-> Go to `<paste the URL>`. Filter to backend roles in Europe posted in the last
-> two weeks. For each result, open the posting and pull out the title, the
-> location, whether it says remote or hybrid, and anything about visa
-> sponsorship. Give me the list as a table.
+## What it is good at
 
-> Go to `<paste the URL>`. One way, Milan to Lisbon, economy, one checked bag,
-> one adult. Check every date from the 12th to the 16th of next month, one at a
-> time, and read the cheapest fare for each day. The date field is a calendar
-> widget, so click the days rather than typing them. If a date has no
-> availability say so, do not guess a number.
+Anything that needs a browser rather than an API, and needs a person's judgement
+about what is on the page.
 
-Those two share nothing but the machinery.
+> Go to `<paste the URL>`. One way, Milan to Lisbon, economy, one checked bag, one
+> adult. Check every date from the 12th to the 16th of next month, one at a time,
+> and read the cheapest fare for each day. The date field is a calendar widget, so
+> click the days rather than typing them. If a date has no availability, say so.
+> Do not guess a number.
+
+It drives the page the way a person would: the pointer moves, keys are pressed, and
+it will refuse to set a form field from JavaScript even when that would be quicker,
+because a page can tell the difference.
 
 ## Options
 
-Both commands take the same browser options.
+Both `ui` and `do` take the same ones.
 
 | Option | What it does |
 |---|---|
-| `--openrouter-key` | Your key, or the `OPENROUTER_API_KEY` environment variable. Required for `do`, optional for `ui`. |
-| `--model` | An OpenRouter model id, or `AIHAWK_MODEL`. Defaults to a current one. |
-| `--proxy` | `http://user:pass@host:port`, or `socks5://`. Credentials go in the URL. |
-| `--seed` | An integer. Same seed, same browser identity, every run. Set one for anything you run more than once. |
-| `--profile-dir` | Absolute path. Persistent profile, so logins and cookies survive restarts. |
+| `--openrouter-key` | Your key, or the `OPENROUTER_API_KEY` variable. Required for `do`, optional for `ui`. |
+| `--model` | An OpenRouter model id, or `AIHAWK_MODEL`. Defaults to `z-ai/glm-4.6`. |
+| `--proxy` | `http://user:pass@proxy.example.com:8080`, or `socks5://`. Optional. With one set, the timezone, locale and egress follow it. |
+| `--binary` | Path to an engine binary you already have, instead of the downloaded one. |
+| `--seed` | An integer. Same seed, same browser identity, every run. Set one for anything you run twice. |
+| `--profile-dir` | Absolute path. Logins and cookies survive restarts. |
 | `--headed` | Show the browser window. The interface shows you the page anyway. |
 | `--host`, `--port` | `ui` only. Loopback and 8765 by default. Leave the host alone unless you mean it. |
 
-The key never reaches the browser process: it is stripped from the environment
-the engine is started with, and there is a test that fails if that stops being
-true.
+The key does not reach the browser process. It is removed from the environment the
+engine starts with, by name and by value, so a copy kept under a second name -
+`OPENAI_API_KEY` is the usual one - goes too. `tests/test_key_isolation.py` fails
+if that stops being true.
 
-## Already have an MCP client?
-
-Then you may not need this at all. The browser is exposed as an MCP server, and
-Claude Code, Claude Desktop, Cursor and anything similar can drive it directly:
-
-```bash
-claude mcp add stealth --env STEALTHFOX_PROXY=http://user:pass@host:port -- uvx invisible-playwright-mcp
-```
-
-Your client brings the model, and gets the same tools this interface
-uses. Nothing here has a private path to the browser - AIHawk is a client of
-that server like any other, which is the reason to trust that the tools are
-enough.
-
-## The tools
-
-You never call these yourself. The model does, from what you ask it.
-
-| Group | Tools |
-|---|---|
-| Pages | `session_new_page`, `session_list_pages`, `session_select_page`, `session_close_page` |
-| Reading | `browser_navigate`, `browser_read_text`, `browser_snapshot`, `browser_read_html`, `browser_take_screenshot` |
-| Acting | `browser_click`, `browser_click_at`, `browser_type`, `browser_press_key`, `browser_evaluate` |
-
-## Related projects
+## The rest of the family
 
 | Project | What it is |
 |---|---|
-| [invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp) | The MCP server this drives. Tools only, no interface. |
-| [invisible_playwright](https://github.com/feder-cr/invisible_playwright) | The Python wrapper and the browser it pins and drives. Use it directly if you would rather script than prompt: the API is Playwright's. |
-| [invisible_core](https://github.com/feder-cr/invisible_core) | Seed to fingerprint to preferences, proxy and geolocation derivation. |
+| [invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp) | The MCP server from column 1. Tools only, no interface. |
+| [invisible_playwright](https://github.com/feder-cr/invisible_playwright) | The engine, as a Python library. Use it if you would rather write code than prompts: the API is Playwright's. |
+| [invisible_core](https://github.com/feder-cr/invisible_core) | Seed to fingerprint to preferences, proxy and geolocation. |
 
 ## Contributing
 
-Issues and pull requests are welcome on whichever of those the problem lives in.
-If you are not sure, open it here. See [CONTRIBUTING](.github/CONTRIBUTING.md).
+Issues and pull requests welcome on whichever of those the problem lives in. If you
+are not sure, open it here. See [CONTRIBUTING](.github/CONTRIBUTING.md).
 
 When something fails on a page, say which step, what the page did, what the tool
 returned and which exit country you were on. "It got blocked" is not something
 anyone can act on.
 
-This automates a browser under your control. Read the terms of the sites you
-point it at, respect their rate limits, and do not submit anything a human has
-not read.
+
+## Using it responsibly
+
+This automates a browser under your control. Read the terms of the sites you point
+it at, respect their rate limits, and do not submit anything a human has not read.
 
 ## License
 
-[MIT](LICENSE). Everything distributed before 2 September 2026 was
-released under AGPL-3.0 and stays under it.
+[MIT](LICENSE). Everything distributed before 2 September 2026 was released under
+AGPL-3.0 and stays under it.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Claude Code, Claude Desktop, Cursor and anything similar can drive it directly:
 claude mcp add stealth --env STEALTHFOX_PROXY=http://user:pass@host:port -- uvx invisible-playwright-mcp
 ```
 
-Your client brings the model, and gets the same fourteen tools this interface
+Your client brings the model, and gets the same tools this interface
 uses. Nothing here has a private path to the browser - AIHawk is a client of
 that server like any other, which is the reason to trust that the tools are
 enough.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="assets/aihawk-logo-dark.png">
-  <img alt="AIHawk" src="assets/aihawk-logo-light.png" width="380">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/feder-cr/AIHawk/main/assets/aihawk-logo-dark.png">
+  <img alt="AIHawk" src="https://raw.githubusercontent.com/feder-cr/AIHawk/main/assets/aihawk-logo-light.png" width="380">
 </picture>
 
 **An AI agent with a real browser. You say what you want in plain language, it goes and does it on the actual web.**
@@ -20,66 +20,88 @@
 
 ---
 
-# Pick one
+## First, one prerequisite for both ways
 
-There are two ways to use this, and the only real question is **where the model comes from**.
+**Python 3.11 or newer**, on **Windows (x86_64) or Linux (x86_64, arm64)** - macOS
+is not supported, the last engine build for it was `firefox-20`. Then
+[uv](https://docs.astral.sh/uv/), because both commands below start with `uvx`:
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh              # Linux
+```
+```powershell
+irm https://astral.sh/uv/install.ps1 | iex                   # Windows
+```
+
+## Now pick one
+
+**Do you already use an AI assistant that can run tools - Claude Code, Claude
+Desktop, Cursor?** If yes, it brings the model and you add this browser to it. If
+no, or if you would rather watch the work happen, run our interface instead.
 
 <table>
 <tr>
-<th width="50%">1. Your AI client already has a model</th>
-<th width="50%">2. You want an interface, model included</th>
+<th width="50%">1. Add it to the assistant you have</th>
+<th width="50%">2. Run our interface</th>
 </tr>
 <tr>
 <td valign="top">
 
-Claude Code, Claude Desktop, Cursor, or anything else that speaks MCP.
-The browser shows up as tools it can use.
+Your assistant brings the model. Nothing to pay us, nothing to sign up for.
+
+**Claude Code**, once for every project:
 
 ```bash
-claude mcp add stealth -- uvx invisible-playwright-mcp
+claude mcp add -s user stealth -- uvx invisible-playwright-mcp
 ```
 
-Then just talk to your client:
+**Claude Desktop, Cursor, and the rest** take a config file instead. The block to
+paste, and which file it goes in, are in the
+[server's README](https://github.com/feder-cr/invisible-playwright-mcp).
+
+Then talk to your assistant as usual:
 
 > Go to news.ycombinator.com and give me the top five titles.
 
 </td>
 <td valign="top">
 
-No client needed. Bring an [OpenRouter](https://openrouter.ai) key, get a page
-with the chat on the left and the live browser on the right.
+We bring the interface, you bring an [OpenRouter](https://openrouter.ai) account
+and its key. Chat on the left, the live browser on the right.
 
 ```bash
 uvx aihawk ui --openrouter-key sk-or-...
 ```
 
-Then open **http://127.0.0.1:8765** and type the same thing.
+Open **http://127.0.0.1:8765** and type the same thing.
+
+Curious first? `uvx aihawk ui` runs with no key at all on a placeholder that
+takes literal commands, which is enough to see the interface work and to tell a
+browser problem from a model problem before spending anything.
 
 </td>
 </tr>
 </table>
 
-Same patched Firefox either way, and the second one is a client of the first: AIHawk
-talks to that MCP server over MCP, with no private path to the browser.
+Same patched Firefox behind both. AIHawk reaches it through that MCP server, over
+MCP, exactly as your assistant would - so anything the interface can do, your
+assistant can do too.
 
-**Not sure?** If you already pay for Claude or Cursor, take column 1 - you are
-already paying for the model. Otherwise take column 2.
+## The download nobody warns you about
 
-## Before you start
+The browser is about a quarter of a gigabyte and it is **not** fetched when you
+install either side. It arrives on the **first request that needs a page**, which
+means your first instruction sits there doing nothing for a while, and on a slow
+connection the assistant may report a timeout that says nothing about a download.
 
-**Python 3.11 or newer**, on **Windows (x86_64) or Linux (x86_64, arm64)**.
-macOS is not supported: no Mac engine has been published since firefox-21. Plus
-[uv](https://docs.astral.sh/uv/), which is what gives you `uvx`:
+Get it over with first, in a terminal where you can watch it:
 
 ```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh              # Linux
-powershell -c "irm https://astral.sh/uv/install.ps1 | iex"   # Windows
+uvx invisible-playwright fetch
 ```
 
-The first run downloads the browser, about 700 MB. It looks like a hang and it is
-cached afterwards.
-
-That is the whole setup. No proxy, no account, no config file.
+Cached afterwards, and shared by both ways in. Per-platform sizes are in the
+[engine's README](https://github.com/feder-cr/invisible_playwright).
 
 ## Without a page, for scripts and cron
 
@@ -89,12 +111,9 @@ Same machinery, no interface, the answer on stdout.
 uvx aihawk do "Go to example.com and tell me the top headline" --openrouter-key sk-or-...
 ```
 
-## Without a key
-
-`uvx aihawk ui` starts without one. What answers is a placeholder that understands
-six literal commands - `go <url>`, `read [selector]`, `click <selector>`,
-`type <selector> <text>`, `tab`, `shot` - which is enough to see the interface work and to
-tell a browser problem from a model problem before spending anything.
+The keyless placeholder from column 2 takes exactly these: `go <url>`,
+`read [selector]`, `click <selector>`, `type <selector> <text>`, `tab` (opens a new
+browser tab), `shot`.
 
 ## What it is good at
 
@@ -113,23 +132,27 @@ because a page can tell the difference.
 
 ## Options
 
-Both `ui` and `do` take the same ones.
+`ui` and `do` share all of these except the last row, which is `ui` only.
 
 | Option | What it does |
 |---|---|
 | `--openrouter-key` | Your key, or the `OPENROUTER_API_KEY` variable. Required for `do`, optional for `ui`. |
 | `--model` | An OpenRouter model id, or `AIHAWK_MODEL`. Defaults to `z-ai/glm-4.6`. |
-| `--proxy` | `http://user:pass@proxy.example.com:8080`, or `socks5://`. Optional. With one set, the timezone, locale and egress follow it. |
-| `--binary` | Path to an engine binary you already have, instead of the downloaded one. |
+| `--proxy` | Optional. `http://user:pass@proxy.example.com:8080`, or `socks5://proxy.example.com:1080`. Host and port are both required; a bare scheme is rejected. With one set, the timezone, locale and egress follow it. |
+| `--binary` | Path to an engine binary you already have. It must be the exact build the packaged seal pins, or startup refuses: this skips the download, not the version check. |
 | `--seed` | An integer. Same seed, same browser identity, every run. Set one for anything you run twice. |
-| `--profile-dir` | Absolute path. Logins and cookies survive restarts. |
+| `--profile-dir` | A directory to keep the profile in, so logins and cookies survive restarts. A relative path works and resolves from where you ran the command, which is rarely what you want. |
 | `--headed` | Show the browser window. The interface shows you the page anyway. |
-| `--host`, `--port` | `ui` only. Loopback and 8765 by default. Leave the host alone unless you mean it. |
+| `--host`, `--port` | `ui` only. `127.0.0.1` and `8765`. Changing the host exposes the interface, and it has no authentication, so anyone who can reach the port can drive your browser. |
 
-The key does not reach the browser process. It is removed from the environment the
+Passing `--openrouter-key` puts the key in your shell history, and on Linux in the
+process list for every user on the machine. `OPENROUTER_API_KEY` in the environment
+avoids both.
+
+Either way it does not reach the browser process. It is removed from the environment the
 engine starts with, by name and by value, so a copy kept under a second name -
-`OPENAI_API_KEY` is the usual one - goes too. `tests/test_key_isolation.py` fails
-if that stops being true.
+`OPENAI_API_KEY` is the usual one - goes too. [`tests/test_key_isolation.py`](https://github.com/feder-cr/AIHawk/blob/main/tests/test_key_isolation.py)
+fails if that stops being true.
 
 ## The rest of the family
 
@@ -142,7 +165,7 @@ if that stops being true.
 ## Contributing
 
 Issues and pull requests welcome on whichever of those the problem lives in. If you
-are not sure, open it here. See [CONTRIBUTING](.github/CONTRIBUTING.md).
+are not sure, open it here. See [CONTRIBUTING](https://github.com/feder-cr/AIHawk/blob/main/.github/CONTRIBUTING.md).
 
 When something fails on a page, say which step, what the page did, what the tool
 returned and which exit country you were on. "It got blocked" is not something
@@ -156,5 +179,5 @@ it at, respect their rate limits, and do not submit anything a human has not rea
 
 ## License
 
-[MIT](LICENSE). Everything distributed before 2 September 2026 was released under
+[MIT](https://github.com/feder-cr/AIHawk/blob/main/LICENSE). Everything distributed before 2 September 2026 was released under
 AGPL-3.0 and stays under it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,20 +4,34 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.1.0"
+version = "0.2.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"
+# The engine ships binaries for these two only, so a mac reader finds out at
+# the first browser call unless the index says so first.
+classifiers = [
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
 authors = [{ name = "feder-cr", email = "85809106+feder-cr@users.noreply.github.com" }]
 dependencies = [
-    # The floor is 0.9.0 and not "any": the tab strip needs `session_list_pages`
-    # to return id, title, url and active, and every earlier version answered
-    # with ids alone while its description promised those four. Against 0.8.1 the
-    # strip stays empty and everything else works, which is a deliberate path
-    # rather than a fault - but shipping a version that silently loses a feature
-    # is not something to leave to chance. Set only after 0.9.0 was on the index,
-    # never before: a pin to something unpublished is a package nobody can
-    # install.
+    # The floor is 0.10.0 and not "any", for two reasons that arrived in that
+    # order. 0.9.0 made `session_list_pages` return id, title, url and active
+    # instead of ids alone, which is what the tab strip reads; against 0.8.1
+    # the strip stays empty and nothing else breaks, which is quiet in the
+    # wrong way. 0.10.0 added `browser_select_option`, and its absence is not
+    # quiet at all: with no tool for a dropdown a model clicks it, presses
+    # arrow keys, and ends up setting the value through browser_evaluate -
+    # script, no keystroke, an untrusted event, the one thing this stack is
+    # for avoiding.
+    #
+    # Set only after 0.10.0 is on the index, never before: a floor no published
+    # version satisfies is a package nobody can install. publish.yml refuses
+    # the release rather than trusting this comment to be read.
     "invisible-playwright-mcp>=0.10.0",
     "mcp>=1.2",
     "openai>=1.30",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,10 @@ version = "0.2.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"
+# The README says MIT and nothing here did, so the PyPI page showed no licence
+# at all. Both siblings declare theirs.
+license = "MIT"
+license-files = ["LICENSE"]
 # The engine ships binaries for these two only, so a mac reader finds out at
 # the first browser call unless the index says so first.
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     # is not something to leave to chance. Set only after 0.9.0 was on the index,
     # never before: a pin to something unpublished is a package nobody can
     # install.
-    "invisible-playwright-mcp>=0.9.0",
+    "invisible-playwright-mcp>=0.10.0",
     "mcp>=1.2",
     "openai>=1.30",
     "click>=8.1",

--- a/src/aihawk/agent.py
+++ b/src/aihawk/agent.py
@@ -70,10 +70,21 @@ class Conversation:
     gets the old one-shot behaviour for free.
     """
 
-    def __init__(self, client, model: str, *, max_turns: int = 25) -> None:
+    #: Ceiling on ONE reply, and it is set rather than left to the provider.
+    #: Without it the provider assumes the model's maximum - 65536 on a current
+    #: OpenAI model - and a credit-limited key is refused with a 402 before any
+    #: work happens, quoting a token budget rather than naming the task. It is
+    #: also the wrong shape for this loop: a turn is a sentence of reasoning and
+    #: a tool call, not an essay, and the only turn that wants room is the last
+    #: one. Generous for that, sixteen times smaller than the default.
+    MAX_TOKENS = 8192
+
+    def __init__(self, client, model: str, *, max_turns: int = 25,
+                 max_tokens: int = MAX_TOKENS) -> None:
         self.client = client
         self.model = model
         self.max_turns = max_turns
+        self.max_tokens = max_tokens
         self.messages: List[dict] = [{"role": "system", "content": SYSTEM_PROMPT}]
         self.tool_defs: Optional[List[dict]] = None
         self.usage = {"prompt": 0, "completion": 0, "calls": 0, "last_prompt": 0}
@@ -110,6 +121,7 @@ class Conversation:
             resp = self.client.chat.completions.create(
                 model=self.model, messages=self.messages,
                 tools=self.tool_defs, tool_choice="auto", temperature=0,
+                max_tokens=self.max_tokens,
             )
             self._note_usage(resp)
             await say("usage", json.dumps(self.usage))
@@ -149,8 +161,9 @@ class Conversation:
         raise RuntimeError(f"task did not finish within max_turns={self.max_turns}")
 
 
-async def run_task(mcp, task: str, *, client, model: str, max_turns: int = 25) -> str:
+async def run_task(mcp, task: str, *, client, model: str, max_turns: int = 25,
+                   max_tokens: int = Conversation.MAX_TOKENS) -> str:
     """One instruction, one answer, no narration. What `aihawk do` runs."""
     tools = (await mcp.list_tools()).tools
-    convo = Conversation(client, model, max_turns=max_turns)
+    convo = Conversation(client, model, max_turns=max_turns, max_tokens=max_tokens)
     return await convo.run(task, mcp.call_tool, tools)

--- a/src/aihawk/brain.py
+++ b/src/aihawk/brain.py
@@ -4,7 +4,8 @@ The shell was built with this slot deliberately empty and a stub in it, so that
 the seam a model plugs into would be exercised rather than imagined. This module
 fills the slot. There are two implementations and both are real:
 
-`LiteralBrain` understands five literal commands and no language at all. It is
+`LiteralBrain` understands a handful of literal commands and no language at all.
+It is
 not a fallback for a missing key and it is not a demo prop: it is how the whole
 surface can be driven, and tested, with no model, no key and no spending. When
 something looks wrong in the UI, being able to issue exactly one action and see

--- a/src/aihawk/cli.py
+++ b/src/aihawk/cli.py
@@ -98,7 +98,7 @@ def ui(openrouter_key, model, host, port, proxy, seed, headed, binary, profile_d
     async def serve() -> None:
         import uvicorn
 
-        link = await Link(opts).open()
+        link = await Link(opts, key=key).open()
         click.echo("browser  ready, %d tools" % len(link.tools))
         click.echo("open     http://%s:%d" % (host, port))
         service = ChatService(link, brain, model_label=label)

--- a/src/aihawk/link.py
+++ b/src/aihawk/link.py
@@ -36,8 +36,13 @@ from .runner import child_env
 class Link:
     """A connection to one MCP server, and the browser behind it."""
 
-    def __init__(self, opts: Mapping[str, Any] | None = None) -> None:
+    def __init__(self, opts: Mapping[str, Any] | None = None, *,
+                 key: str | None = None) -> None:
         self._opts = dict(opts or {})
+        # Held only to keep it OUT of the child: child_env removes every
+        # variable carrying this value, and a key given on the command line
+        # is in no environment for it to find by reading.
+        self._key = key
         self._session: Optional[ClientSession] = None
         self._ctx = None
         self._sess_ctx = None
@@ -54,7 +59,7 @@ class Link:
         params = StdioServerParameters(
             command=sys.executable,
             args=["-m", "invisible_playwright_mcp"],
-            env=child_env(self._opts, os.environ),
+            env=child_env(self._opts, os.environ, key=self._key),
         )
         self._ctx = stdio_client(params)
         read, write = await self._ctx.__aenter__()

--- a/src/aihawk/runner.py
+++ b/src/aihawk/runner.py
@@ -13,18 +13,58 @@ or be wrong once.
 """
 from __future__ import annotations
 
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional
 
 
-def child_env(opts: Mapping[str, Any], base_env: Mapping[str, str]) -> dict:
+#: The one name the key is expected under. Compared case-insensitively, because
+#: on POSIX `openrouter_api_key` is a different variable to the shell and the
+#: same secret to anyone reading the process environment.
+KEY_VARIABLE = "OPENROUTER_API_KEY"
+
+
+def child_env(opts: Mapping[str, Any], base_env: Mapping[str, str],
+              *, key: Optional[str] = None) -> dict:
     """The environment the browser server is started with.
 
-    The pop is the point. Everything else is options travelling under the names
-    the engine reads, and an absent option adds no variable at all rather than an
-    empty one, because an empty STEALTHFOX_PROXY is not the same as no proxy.
+    The removal is the point. Everything else is options travelling under the
+    names the engine reads, and an absent option adds no variable at all rather
+    than an empty one, because an empty STEALTHFOX_PROXY is not the same as no
+    proxy.
+
+    ⛔ IT REMOVES BY VALUE AS WELL AS BY NAME, and the two are not the same
+    guarantee. Popping one exact name left the secret reachable two ways, both
+    ordinary rather than exotic:
+
+      * a lowercase `openrouter_api_key`, which survives on any case-sensitive
+        platform, and this product runs on Linux;
+      * the same string kept under a SECOND name. `OPENAI_API_KEY` holding an
+        OpenRouter key is normal practice here, because the client is
+        OpenAI-compatible and talks to OpenRouter through it.
+
+    Neither is theoretical: the leak reaches the browser itself, not just the
+    MCP server. `invisible_playwright._session.build_env` starts from the
+    server process's own environment and hands that to the Firefox launch, so
+    whatever survives here is inherited by the browser.
+
+    Both were recorded as strict xfails in `tests/test_key_isolation.py`, each
+    naming what would close it. This is that, so those markers are gone.
+
+    `key` is the resolved key when the caller has one - passed on the command
+    line, it never appears in `base_env` at all, so a copy of it under another
+    name could not be found by reading the environment alone.
     """
-    env = dict(base_env)
-    env.pop("OPENROUTER_API_KEY", None)   # the child (browser server) never needs it
+    secrets = {value for name, value in base_env.items()
+               if name.upper() == KEY_VARIABLE and value}
+    if key:
+        secrets.add(key)
+
+    # An empty secret would match every empty variable, which is how a guard
+    # like this turns into "delete most of the environment".
+    secrets.discard("")
+
+    env = {name: value for name, value in base_env.items()
+           if name.upper() != KEY_VARIABLE and value not in secrets}
+
     if opts.get("proxy"):
         env["STEALTHFOX_PROXY"] = str(opts["proxy"])
     if opts.get("seed") is not None:
@@ -49,7 +89,7 @@ async def drive(task: str, *, opts: Mapping[str, Any], key: str, model: str) -> 
     from .link import Link
     from .llm import make_client
 
-    link = await Link(opts).open()
+    link = await Link(opts, key=key).open()
     try:
         convo = Conversation(make_client(key), model)
         return await convo.run(task, link.call, link.tools)

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -2,7 +2,7 @@
 
 This used to live inside the MCP server and reach the browser through a Python
 object in the same process. It lives here now, and it reaches the browser the way
-everybody else does: over MCP, calling the same fourteen tools any agent gets.
+everybody else does: over MCP, calling the same tools any agent gets.
 The server went back to being only a server.
 
 That is not a tidier arrangement of the same code, it changes what is true about
@@ -383,6 +383,7 @@ const VERB = {
   browser_press_key:['Pressing','Pressed'],    browser_read_text:['Reading','Read'],
   browser_read_html:['Reading','Read'],        browser_snapshot:['Inspecting','Inspected'],
   browser_evaluate:['Evaluating','Evaluated'], browser_take_screenshot:['Capturing','Captured'],
+  browser_select_option:['Choosing','Chose'],
   session_new_page:['Opening tab','Opened tab'],   session_select_page:['Switching tab','Switched tab'],
   session_close_page:['Closing tab','Closed tab'], session_list_pages:['Listing tabs','Listed tabs']
 };

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -324,7 +324,7 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
         <p>Tell it what to do, in a sentence. It opens the pages, reads them and
            clicks, and you watch on the right.</p>
         <p class="eg">go https://example.com<br>read h1<br>click #submit</p>
-        <p class="sm">Those five literal commands are the placeholder. Start with
+        <p class="sm">Literal commands only: that is the placeholder. Start with
            an OpenRouter key for a model that works it out for you.</p>
       </div>
     </div>

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -34,7 +34,7 @@ REAL SHAPES COPIED, AND WHERE THEY WERE READ
   it: `await mcp.list_tools()` returning a ListToolsResult, and
   `await mcp.call_tool(name, args)` returning a CallToolResult.
 
-  Tool names and schemas are the real ones: the server exposes exactly 14 tools
+  Tool names and schemas are the real ones, taken from the server itself
   (session_new_page, session_list_pages, session_select_page, session_close_page,
   browser_navigate, browser_read_text, browser_snapshot, browser_read_html,
   browser_take_screenshot, browser_click, browser_click_at, browser_type,
@@ -261,7 +261,7 @@ def test_a_tool_with_no_description_becomes_an_empty_string_not_none():
 def test_a_description_longer_than_1024_characters_is_truncated_to_1024():
     """OpenAI caps a function description at 1024 characters and this is not
     hypothetical: the real `browser_click_at` docstring measures 1124 characters
-    today, so one of the 14 shipped tools is truncated on every run.
+    today, so one of the shipped tools is truncated on every run.
 
     Known-bad: dropping the [:1024] slice, which makes the API reject the whole
     request, or truncating to a different length."""
@@ -795,7 +795,7 @@ async def test_an_error_flagged_result_is_still_fed_back_as_text():
 
 async def test_a_screenshot_reaches_the_model_as_a_placeholder_only():
     """End to end through the loop, not just through _result_text: the model asks
-    for browser_take_screenshot, which is one of the 14 advertised tools, and the
+    for browser_take_screenshot, which is one of the advertised tools, and the
     only thing that comes back is "[non-text result]". The image is dropped."""
     shot = mt.CallToolResult(
         content=[mt.ImageContent(type="image", data="aGk=", mimeType="image/png")]

--- a/tests/test_every_tool_reads_as_english.py
+++ b/tests/test_every_tool_reads_as_english.py
@@ -1,0 +1,81 @@
+"""Every tool the agent can call has a word a person recognises.
+
+The step list is the whole interface: it is what a person watches while the
+agent works, and it is the only place they can see something going wrong before
+it finishes. A step that reads `Called selector=#sala, value=beta` is not
+broken, it is just written in the machine's word order - which is the same
+thing to whoever is reading it.
+
+⛔ AND IT DEGRADES SILENTLY, which is why this is a test and not a habit.
+`browser_select_option` was added to the server and the step list rendered it
+through the fallback the very first time a model used it, with nothing red
+anywhere. The verb table is in the page's JavaScript and the tool list is in
+another package; the two can only disagree, never complain.
+
+Reads the table out of the served page rather than importing a Python
+constant, because the table a reader sees is the one in the page.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+
+def _verbs_in_the_page() -> dict:
+    from aihawk import web
+
+    match = re.search(r"const VERB = \{(.*?)\};", web.PAGE, re.S)
+    assert match, "the VERB table is gone from the page, or has been renamed"
+    return dict(re.findall(r"(\w+)\s*:\s*\[\s*'([^']*)'", match.group(1)))
+
+
+def test_the_table_is_read_correctly_before_anything_is_concluded_from_it():
+    """A parser that finds nothing would make the next test pass for free.
+
+    Same family as a gate whose mutation never reaches the code: the assertion
+    below is only worth something if this one holds.
+    """
+    verbs = _verbs_in_the_page()
+    assert len(verbs) >= 10, "only parsed %d entries, so the regex is wrong" % len(verbs)
+    assert verbs.get("browser_navigate") == "Navigating", verbs.get("browser_navigate")
+
+
+def test_every_tool_the_server_offers_has_a_verb():
+    """Against the LIVE tool list, so a tool added upstream shows up here.
+
+    The alternative - a hand-written list of names in this repo - drifts the
+    same way the table does, and would have been just as quiet.
+    """
+    import asyncio
+
+    try:
+        from invisible_playwright_mcp import server
+    except ImportError:  # pragma: no cover
+        pytest.skip("invisible-playwright-mcp is not installed")
+
+    offered = {t.name for t in asyncio.run(server.mcp.list_tools())}
+    assert offered, "the server registered no tools at all"
+
+    verbs = _verbs_in_the_page()
+    missing = sorted(offered - set(verbs))
+    assert not missing, (
+        "these tools would render as 'Called <raw arguments>' in the step "
+        "list: %s" % missing)
+
+
+def test_the_table_names_no_tool_that_does_not_exist():
+    """The other direction. A verb for a tool nobody offers is a tool that was
+    removed upstream without anyone here noticing, and the next reader trusts
+    the table as an inventory.
+    """
+    import asyncio
+
+    try:
+        from invisible_playwright_mcp import server
+    except ImportError:  # pragma: no cover
+        pytest.skip("invisible-playwright-mcp is not installed")
+
+    offered = {t.name for t in asyncio.run(server.mcp.list_tools())}
+    stale = sorted(set(_verbs_in_the_page()) - offered)
+    assert not stale, "verbs for tools the server no longer offers: %s" % stale

--- a/tests/test_key_isolation.py
+++ b/tests/test_key_isolation.py
@@ -118,15 +118,6 @@ def test_windows_normalises_a_lowercase_name_so_the_exact_pop_still_catches_it(m
     assert values_carrying(env, KEY) == []
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "REAL GAP, not an accepted trade-off: child_env pops one exact name. A "
-        "lowercase variable survives on any case-sensitive platform (POSIX) and "
-        "through any caller that passes a plain dict. Delete this marker when "
-        "child_env drops names case-insensitively."
-    ),
-)
 def test_a_case_variant_name_in_a_plain_mapping_is_stripped_too():
     """Known-bad is the current code: `env.pop("OPENROUTER_API_KEY", None)`
     against a mapping holding `openrouter_api_key`."""
@@ -134,16 +125,6 @@ def test_a_case_variant_name_in_a_plain_mapping_is_stripped_too():
     assert values_carrying(env, KEY) == []
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "REAL GAP: child_env removes the key by NAME and never scans values, so "
-        "a duplicate under a second name reaches the browser child. Setting "
-        "OPENAI_API_KEY to an OpenRouter key is common practice, since the "
-        "client is OpenAI-compatible. Delete this marker when child_env drops "
-        "every variable whose value equals the resolved key."
-    ),
-)
 def test_a_duplicate_of_the_key_under_another_name_is_stripped_too():
     """Known-bad is the current code: the same secret under OPENAI_API_KEY is
     copied straight into the child environment."""
@@ -151,6 +132,86 @@ def test_a_duplicate_of_the_key_under_another_name_is_stripped_too():
     assert values_carrying(env, KEY) == []
 
 
+
+
+# ── what the mutation test asked for ────────────────────────────────────────
+#
+# The two xfails above this line were deleted when child_env started removing by
+# value as well as by name. Mutating that code afterwards showed the suite was
+# thinner than it looked: four of five mutations survived, and two of them
+# survived because nothing here exercised the path at all.
+#
+# The rest survived because child_env removes the key three ways that overlap:
+# collection is case-insensitive, removal by name is case-insensitive, and
+# removal also matches by VALUE. Break any one and a lowercase variable is
+# still removed by another, so the guarantee holds and the suite is right to
+# stay green. Breaking two together does fail, which is what says the
+# redundancy is real rather than a gate that cannot see.
+#
+# So these tests pin the GUARANTEE - after child_env, no variable carries the
+# key, whatever it was called - and not the three mechanisms. Pinning each
+# mechanism would assert the implementation, and would go red on a rewrite
+# that kept the promise.
+
+
+def test_a_key_that_was_never_in_the_environment_still_scrubs_its_copies():
+    """The command-line case, which reading the environment cannot cover.
+
+    `--openrouter-key` puts the key in no variable at all, so there is nothing
+    for child_env to find by name - while a copy of that same string under
+    OPENAI_API_KEY is sitting right there. This is why child_env takes `key`.
+
+    Known-bad is the version that does not: drop the `key` parameter from the
+    collection and this environment reaches the browser with the secret in it.
+    """
+    env = child_env({}, {"PATH": "/x", "OPENAI_API_KEY": KEY}, key=KEY)
+    assert values_carrying(env, KEY) == []
+    assert env["PATH"] == "/x", "it removed more than the secret"
+
+
+def test_a_lowercase_variable_and_its_copy_both_go():
+    """The POSIX case with a copy, which neither half covers alone.
+
+    A lowercase `openrouter_api_key` is a different variable to the shell and
+    the same secret to anything reading the process environment, and the copy
+    under a second name can only be found by matching the value.
+    """
+    env = child_env({}, {"PATH": "/x", "openrouter_api_key": KEY,
+                         "OPENAI_API_KEY": KEY})
+    assert values_carrying(env, KEY) == []
+    assert env["PATH"] == "/x"
+
+
+def test_an_empty_variable_is_not_treated_as_a_secret():
+    """Otherwise a guard that removes by value removes the whole environment.
+
+    Two things stop it, and the second one was nearly deleted for looking
+    redundant. Collection filters on the value being truthy, and `if key:`
+    rejects an empty key; `secrets.discard("")` then catches what either of
+    those would let through.
+
+    Mutating `discard` away alone changes nothing, which read as dead code and
+    was written up as dead code here. It is not: mutate away the truthiness
+    filter as well and this test fails, because the empty string becomes a
+    secret and every empty variable in the environment matches it. Each line
+    is the other's backstop, and a single-line mutation cannot tell the
+    difference between a backstop and a spare part.
+    """
+    env = child_env({}, {"PATH": "/x", "EMPTY": "", "OPENROUTER_API_KEY": ""},
+                    key="")
+    assert env["PATH"] == "/x"
+    assert env["EMPTY"] == "", "an empty variable was mistaken for the secret"
+
+
+def test_the_options_still_arrive_when_the_environment_is_being_scrubbed():
+    """The scrub rewrites the dict the options are then written into, so the two
+    halves meet. A filter that returned a new mapping and dropped the writes
+    would leave the browser with no proxy and no seed, silently."""
+    env = child_env({"proxy": "socks5://proxy.example.com:1080", "seed": 4242},
+                    {"OPENROUTER_API_KEY": KEY, "PATH": "/x"})
+    assert env["STEALTHFOX_PROXY"] == "socks5://proxy.example.com:1080"
+    assert env["STEALTHFOX_SEED"] == "4242"
+    assert values_carrying(env, KEY) == []
 # ---------------------------------------------------------------------------
 # what SHOULD reach the child does
 # ---------------------------------------------------------------------------

--- a/tests/test_readme_offers_both.py
+++ b/tests/test_readme_offers_both.py
@@ -59,29 +59,85 @@ def test_both_ways_in_are_offered():
             "missing entirely" % way)
 
 
-def test_the_offer_comes_before_anything_else():
-    """Both commands in the first real section, not scattered down the page.
+#: How far down "immediately" reaches, in lines. A screen of rendered markdown
+#: is roughly this, and the requirement is about what a reader sees before
+#: deciding whether to keep scrolling.
+#:
+#: ⛔ This started as "within the first two sections" and that was wrong for a
+#: reason worth keeping: both commands begin with `uvx`, so the uv install has
+#: to come BEFORE the choice or neither column works. A section-index rule
+#: forbade the correct page. Counting lines measures what the requirement
+#: actually says; counting sections measured the shape it happened to have.
+FIRST_SCREEN = 45
 
-    The tolerance is two headings, not one, because a page may open with its own
-    title before the choice. Three would let the offer sit behind a features
-    section, which is where it was.
+
+def _where_the_offer_starts(text):
+    """(line number, heading) of the section that carries BOTH commands."""
+    lines = text.split(chr(10))
+    heads = [(i, l) for i, l in enumerate(lines, 1) if l.startswith("#")]
+    for pos, (line, heading) in enumerate(heads):
+        end = heads[pos + 1][0] if pos + 1 < len(heads) else len(lines) + 1
+        body = chr(10).join(lines[line - 1:end - 1])
+        if MCP_WAY in body and UI_WAY in body:
+            return line, heading.strip()
+    return None, None
+
+def test_the_offer_comes_within_the_first_screen():
+    """Where the OFFER begins, not where each command literal sits.
+
+    ⛔ The literal position is the wrong measurement and this test made that
+    mistake first. Both pages present the choice as a two-column HTML table, and
+    the table scaffolding puts twenty lines of markup between the heading and the
+    second command without costing the reader a single line on screen. Measured
+    that way the correct page failed. What a reader meets is the heading, so that
+    is what is measured.
+
+    Known-bad is what these pages looked like before 2026-09-03, and it is checked
+    rather than remembered: see the test below.
     """
+    line, heading = _where_the_offer_starts(README.read_text(encoding="utf-8"))
+    assert line is not None, "no single section offers both ways"
+    assert line <= FIRST_SCREEN, (
+        "the choice starts at line %d, under %r, past the first screen a reader "
+        "sees" % (line, heading))
+
+
+def test_the_check_fails_on_the_pages_as_they_used_to_be():
+    """The gate against a known-bad input, and the input is real history.
+
+    A position check that has only ever passed says nothing about whether it can
+    see a page where the offer is buried - which is the only page it exists to
+    reject.
+    """
+    buried = chr(10).join([
+        "# A project",
+        "",
+        "## Overview",
+        "",
+    ] + ["Prose about the project." for _ in range(60)] + [
+        "",
+        "## Already have an MCP client?",
+        "",
+        "Then you may not need this at all: `%s`." % MCP_WAY,
+        "",
+        "Otherwise `%s`." % UI_WAY,
+    ])
+    line, _ = _where_the_offer_starts(buried)
+    assert line is not None, "the helper cannot even find the offer"
+    assert line > FIRST_SCREEN, (
+        "a page with the offer %d lines down passes, so this check is blind" % line)
+
+
+def test_the_two_ways_are_offered_as_one_choice():
+    """In the SAME section, so they read as alternatives rather than as two
+    unrelated facts a reader has to notice and compare for themselves."""
     sections = _sections()
     found = {}
     for index, (heading, body) in enumerate(sections):
         for name, way in (("mcp", MCP_WAY), ("ui", UI_WAY)):
             if way in body and name not in found:
                 found[name] = (index, heading)
-
     assert set(found) == {"mcp", "ui"}, "missing: %s" % sorted({"mcp", "ui"} - set(found))
-
-    late = {n: h for n, (i, h) in found.items() if i > 2}
-    assert not late, (
-        "these ways in are offered too far down to be found: %s. The reader who "
-        "stops at the first screen must see both." % late)
-
-    # And in the SAME section, so they read as a choice rather than as two
-    # unrelated facts a reader has to notice and compare for themselves.
     assert found["mcp"][0] == found["ui"][0], (
         "the two ways are in different sections (%r and %r), so nothing on the "
         "page says they are alternatives" % (found["mcp"][1], found["ui"][1]))

--- a/tests/test_readme_offers_both.py
+++ b/tests/test_readme_offers_both.py
@@ -1,0 +1,135 @@
+"""The README offers BOTH ways in, and offers them first.
+
+⛔ THE REQUIREMENT IS ABOUT POSITION, NOT PRESENCE, which is why this file exists
+instead of a grep. There are two ways to use this product and only one real
+question behind them - where the model comes from:
+
+  1. you already have an MCP client with a model in it (Claude Code, Claude
+     Desktop, Cursor), and this browser arrives there as tools;
+  2. you have no client, and our interface brings a model with an OpenRouter key.
+
+Both were already documented before this test was written. The MCP server named
+the interface at line 140 of 161, under a heading that reads like a footnote, and
+the interface named the MCP path at line 114 of 159 under "Already have an MCP
+client? Then you may not need this at all". A reader who stopped at the first
+screen - which is most readers - saw one option and concluded it was the only one.
+
+So the assertion is that the offer sits in the FIRST section that is not the
+title, and that both commands are inside it. A README that mentions both paths
+somewhere passes a grep and fails the requirement.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+import pytest
+
+README = pathlib.Path(__file__).resolve().parents[1] / "README.md"
+
+#: The literal command for each path. Literal on purpose: this is what a reader
+#: copies, and a paraphrase in the README is not a way in.
+MCP_WAY = "uvx invisible-playwright-mcp"
+UI_WAY = "uvx aihawk ui"
+
+
+def _sections():
+    """(heading, body) pairs, in order. The lead-in before the first heading is
+    returned under an empty heading, because a logo block is not a section."""
+    text = README.read_text(encoding="utf-8")
+    parts = re.split(r"^(#{1,3} .*)$", text, flags=re.M)
+    out = [("", parts[0])]
+    for i in range(1, len(parts), 2):
+        out.append((parts[i].strip(), parts[i + 1]))
+    return out
+
+
+def test_the_sections_parse():
+    """Otherwise everything below passes on an empty list."""
+    sections = _sections()
+    assert len(sections) > 3, "only %d sections parsed; the regex is wrong" % len(sections)
+    assert any(h for h, _ in sections), "no headings found at all"
+
+
+def test_both_ways_in_are_offered():
+    text = README.read_text(encoding="utf-8")
+    for way in (MCP_WAY, UI_WAY):
+        assert way in text, (
+            "the README never shows `%s`, so one of the two ways to use this is "
+            "missing entirely" % way)
+
+
+def test_the_offer_comes_before_anything_else():
+    """Both commands in the first real section, not scattered down the page.
+
+    The tolerance is two headings, not one, because a page may open with its own
+    title before the choice. Three would let the offer sit behind a features
+    section, which is where it was.
+    """
+    sections = _sections()
+    found = {}
+    for index, (heading, body) in enumerate(sections):
+        for name, way in (("mcp", MCP_WAY), ("ui", UI_WAY)):
+            if way in body and name not in found:
+                found[name] = (index, heading)
+
+    assert set(found) == {"mcp", "ui"}, "missing: %s" % sorted({"mcp", "ui"} - set(found))
+
+    late = {n: h for n, (i, h) in found.items() if i > 2}
+    assert not late, (
+        "these ways in are offered too far down to be found: %s. The reader who "
+        "stops at the first screen must see both." % late)
+
+    # And in the SAME section, so they read as a choice rather than as two
+    # unrelated facts a reader has to notice and compare for themselves.
+    assert found["mcp"][0] == found["ui"][0], (
+        "the two ways are in different sections (%r and %r), so nothing on the "
+        "page says they are alternatives" % (found["mcp"][1], found["ui"][1]))
+
+
+def test_the_offer_says_what_each_one_costs_the_reader():
+    """A choice with no basis for choosing is not a choice.
+
+    What distinguishes the two is where the model comes from: a client you
+    already pay for, or an OpenRouter key. If neither is named next to the
+    commands, the reader has to try one to find out.
+    """
+    sections = _sections()
+    body = next(b for _, b in sections if MCP_WAY in b)
+    low = body.lower()
+    assert "openrouter" in low, (
+        "the choice does not mention OpenRouter, so nothing says what the second "
+        "way needs from the reader")
+    assert any(c in low for c in ("claude", "cursor")), (
+        "the choice does not name a single MCP client, so nothing says who the "
+        "first way is for")
+
+
+def test_no_tool_name_that_does_not_exist():
+    """Any tool the README names has to be real.
+
+    Cheaper than keeping a list in sync and it never goes stale: it constrains
+    what may be SAID rather than requiring the page to say everything.
+    """
+    import asyncio
+
+    try:
+        from invisible_playwright_mcp import server
+    except ImportError:  # pragma: no cover
+        pytest.skip("invisible-playwright-mcp is not installed")
+
+    real = {t.name for t in asyncio.run(server.mcp.list_tools())}
+    named = set(re.findall(r"`((?:browser|session)_\w+)`",
+                           README.read_text(encoding="utf-8")))
+    assert not named - real, (
+        "the README names tools that do not exist: %s" % sorted(named - real))
+
+
+def test_no_hand_written_count_of_tools():
+    """"the fourteen tools" was written into six files and a test literal, so
+    every new tool was an edit in a place nobody remembers. A count in prose is
+    a fact with two homes."""
+    text = README.read_text(encoding="utf-8").lower()
+    bad = re.findall(r"\b(?:eleven|twelve|thirteen|fourteen|fifteen|sixteen|"
+                     r"seventeen|eighteen|nineteen|twenty|\d{1,3})\s+tools\b", text)
+    assert not bad, "the README writes a tool count in prose: %s" % bad

--- a/tests/test_ui_drive.py
+++ b/tests/test_ui_drive.py
@@ -244,7 +244,7 @@ EXPECTED_TOOLS = {
     "session_close_page", "browser_navigate", "browser_read_text",
     "browser_snapshot", "browser_read_html", "browser_take_screenshot",
     "browser_click", "browser_click_at", "browser_type", "browser_press_key",
-    "browser_evaluate",
+    "browser_evaluate", "browser_select_option",
 }
 
 
@@ -470,7 +470,7 @@ def _ids(snapshot):
 # --- the tools the model is handed -----------------------------------------
 
 @pytest.mark.ui
-def test_the_live_server_exposes_exactly_the_fourteen_documented_tools(browser):
+def test_the_live_server_exposes_exactly_the_documented_tools(browser):
     """The tool set the agent converts is the one the README promises.
 
     Known-bad: rename `browser_read_text` upstream, or add a fifteenth tool,
@@ -482,7 +482,10 @@ def test_the_live_server_exposes_exactly_the_fourteen_documented_tools(browser):
     assert names == EXPECTED_TOOLS, "tool set drifted: %r" % (names ^ EXPECTED_TOOLS,)
 
     defs = mcp_tools_to_openai(browser.tools)
-    assert len(defs) == 14
+    # Derived, not typed. The literal here said 14 while the set above said
+    # what it said, so adding a tool meant editing a number in a second
+    # place - and the number is the half nobody remembers.
+    assert len(defs) == len(EXPECTED_TOOLS)
     for one in defs:
         assert one["type"] == "function"
         assert one["function"]["name"] in EXPECTED_TOOLS
@@ -569,17 +572,30 @@ def test_a_checkbox_and_a_select_reach_the_page_state(browser, site):
     assert browser.js("() => { return document.querySelector('#agree').checked; }") is True
     assert browser.call("browser_read_text", selector="#state") == "fruit=apple agree=yes"
 
-    # There is no select_option tool in the fourteen, so a select is set the
-    # only way the tool set allows: through browser_evaluate.
-    chosen = browser.js(
-        "() => { var s = document.querySelector('#fruit'); s.value = 'pear';"
-        " s.dispatchEvent(new Event('change', { bubbles: true })); return s.value; }"
-    )
-    assert chosen == "pear"
+    # ⛔ A SELECT IS SET WITH THE SELECT TOOL, and this assertion used to say the
+    # opposite. It read "There is no select_option tool, so a select is set the
+    # only way the tool set allows: through browser_evaluate" - true when it was
+    # written, and it meant the suite was pinning the exact behaviour that got a
+    # real model into trouble. `s.value = 'pear'` reaches the page with no
+    # keystroke and no trusted event, which is the one thing this stack exists to
+    # avoid, and browser_evaluate refuses it now.
+    #
+    # The tool is asked for the option by its LABEL here, because that is what a
+    # model reads off a screenshot or a snapshot. Matching by value is checked
+    # elsewhere; what matters here is that the humanised path is the one taken.
+    browser.call("browser_select_option", selector="#fruit", value="Pear")
     assert browser.call("browser_read_text", selector="#state") == "fruit=pear agree=yes"
     assert browser.js(
         "() => { return document.querySelector('#fruit').selectedOptions[0].textContent; }"
     ) == "Pear"
+
+    # And the shortcut is now closed rather than merely unused: a model that
+    # tries it is told so, and told what to use instead.
+    with pytest.raises(Exception) as refused:
+        browser.js("() => { document.querySelector('#fruit').value = 'apple'; }")
+    assert "browser_select_option" in str(refused.value), refused.value
+    assert browser.call("browser_read_text", selector="#state") == "fruit=pear agree=yes", (
+        "the refused expression changed the page anyway")
 
 
 @pytest.mark.ui


### PR DESCRIPTION
The choice a reader has to make is where the model comes from: a client they already pay for, or an OpenRouter key. That choice sat at line 111 of 159, under "Already have an MCP client? Then you may not need this at all", which is the right answer for many readers phrased as an aside and placed where they will not reach it. Meanwhile "Two ways to run it" sat near the top meaning something else, `ui` against `do`.

Both ways are now side by side at the top, and the question is one a reader can answer without knowing what MCP is: do you already use an assistant that can run tools.

The claim about the key was false, and this closes the gap rather than softening the sentence. `child_env` popped one exact name, so the same secret under a second name reached the browser, and `OPENAI_API_KEY` holding an OpenRouter key is ordinary here since the client is OpenAI-compatible. A lowercase variable survived on any case-sensitive platform. Two strict xfails in the suite already called both REAL GAP and named what would close them. Both are closed, by name and by value.

A cold read found more, each checked against the code: both columns start with `uvx` and uv was installed 35 lines lower; column 1 named three clients and gave a command only one can run; a bare `socks5://` raises when parsed and was offered as an example; `--binary` is refused unless it matches the seal; "Both take the same ones" was contradicted four rows later; passing the key on the command line puts it in shell history and the process list.

The README is also the PyPI long description, so the logo and every relative link are now absolute, and pyproject declares the MIT licence the README claims and LICENSE grants.

Requires invisible-playwright-mcp 0.10.0, so this waits on feder-cr/invisible-playwright-mcp#11. publish.yml now refuses a release whose dependency floor no published version satisfies, rather than leaving that to a runbook.