### PR TITLE
A wiki, and the twenty pages the search data said to write first

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -1,0 +1,68 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# publish-wiki.yml - mirror the docs/ site into the GitHub wiki on every release.
+#
+# The wiki is a SEPARATE git repo (<repo>.wiki.git) with no Jekyll front matter
+# and its own _Sidebar.md navigation, so this is a render, not a copy:
+# scripts/build_wiki.py strips the front matter, rewrites [x](slug.md) internal
+# links to the wiki's extensionless form, names each page by its slug (index.md
+# becomes Home.md), and regenerates _Sidebar.md from the parent/nav_order tree.
+#
+# It runs on a published release (the docs the release ships are what the wiki
+# should show) and on manual dispatch. The wiki checkout is wiped and rebuilt
+# each run so a page deleted from docs/ also disappears from the wiki; nothing
+# but generated output is ever committed.
+#
+# AUTH. Pushing to <repo>.wiki.git needs contents:write. The built-in
+# GITHUB_TOKEN carries it here; if a run ever gets a 403 pushing the wiki
+# (some org policies withhold wiki write from GITHUB_TOKEN), set a PAT with
+# `repo` scope as the secret WIKI_TOKEN and it is used instead. No long-lived
+# credential is committed either way.
+name: publish-wiki
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-wiki
+  cancel-in-progress: true
+
+jobs:
+  publish-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo (docs + the converter)
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Render docs/ into a wiki build directory
+        run: python scripts/build_wiki.py docs wiki_build
+
+      - name: Publish to the wiki
+        env:
+          WIKI_PUSH_TOKEN: ${{ secrets.WIKI_TOKEN != '' && secrets.WIKI_TOKEN || github.token }}
+        run: |
+          set -euo pipefail
+          repo="${{ github.repository }}"
+          git clone "https://x-access-token:${WIKI_PUSH_TOKEN}@github.com/${repo}.wiki.git" wiki
+          # wipe old generated pages (keep .git) so deletions propagate
+          find wiki -maxdepth 1 -name '*.md' -delete
+          cp wiki_build/*.md wiki/
+          cd wiki
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if git diff --cached --quiet; then
+            echo "wiki already up to date"
+          else
+            git commit -m "docs: sync wiki from docs/ (${{ github.ref_name }})"
+            git push origin HEAD:master
+          fi

--- a/docs/agent-retry-loops-rate-limits.md
+++ b/docs/agent-retry-loops-rate-limits.md
@@ -1,0 +1,193 @@
+---
+title: "Agent retry loops trip rate limits, not fingerprints"
+description: "An AI agent's retry and re-plan loop multiplies one task into a burst of requests. Rate limits count that burst; no browser fixes volume. Where the throttle lives."
+parent: "When the Agent Gets Blocked"
+nav_order: 3
+---
+
+
+# Agent retry loops trip rate limits, not fingerprints
+
+An agent whose browser looks like a real person's will still get blocked if it asks
+for the same page thirty times in ten seconds. That block has nothing to do with the
+fingerprint. It is a counter.
+
+This page is about the failure mode a perfect disguise does not touch. When a step
+fails, an AI agent does not give up: the error goes back to the model, the model
+re-plans, and it tries again - a different selector, a reload, a fresh read of the
+page. Every one of those attempts is more requests, and a stack of attempts per
+minute is a volume signal that trips rate limits and quotas long before any
+fingerprint check runs. The fix does not live in the browser. It lives in how the
+loop is bounded and how you use it.
+
+## Why an agent makes more traffic than a person
+
+A person who knows what they want loads a page once. An agent observes, decides,
+acts, and when the action fails it recovers - and recovery is a request multiplier.
+Three things stack:
+
+- **Retries.** A slow load, a selector that missed, a transient error, and the agent
+  tries the step again. One logical action becomes three or five page loads.
+- **Re-planning.** In AIHawk's loop, a failed tool call is not the end of the task:
+  the error text is fed back to the model as the result, and the model decides what
+  to do next. That is what makes it an agent rather than a script, and what it
+  usually decides is to look again - re-read the page, reload it, navigate back to
+  re-orient. Each of those is a fresh visit to a URL a person loaded once.
+- **Exploration.** An agent that does not know a site's layout probes it: opens a
+  page to see what is there, backs out, opens another.
+
+The result is that one instruction - "find the price for each of five dates" - can
+produce ten or twenty page loads, most of them to the same few URLs, in a burst
+measured in seconds. That pattern is trivial to count, and counting is exactly what
+a rate limiter does.
+
+## A rate limit counts; it does not look
+
+A fingerprint check and a rate limit answer different questions. The first reads
+properties of the client - the GPU string, the canvas hash, the network handshake -
+and asks "is this a real browser". The engine under AIHawk is built to make that
+answer yes. The second never opens the browser at all: it counts how many requests
+arrived from this address, this account, or this session, in this window, and
+compares the count to a threshold. The most convincing browser ever built increments
+that counter by exactly one per request.
+
+| Signal | What it reads | Does a real-looking browser help |
+|---|---|---|
+| Fingerprint / driver / network handshake | Properties of the client | Yes - this is what the engine is for |
+| Rate limit / quota | Count of requests over time | No - N requests is N requests |
+| Per-account quota | Actions tied to one identity | No - the account is the unit, not the browser |
+| Behaviour / velocity | Timing and shape of the traffic | No - the loop decides the timing |
+
+The bottom three rows are not fixable from any browser, because the browser only
+controls what one request looks like, not how many are sent or how fast. When a
+clean fingerprint still gets blocked, volume and address are the usual reasons -
+[the engine wiki has a page on exactly that](https://github.com/feder-cr/invisible_playwright/wiki/why-blocked-with-a-clean-fingerprint).
+
+## What bounds the loop in AIHawk
+
+AIHawk's loop carries two bounds worth knowing about, because they shape what a
+runaway task can and cannot do:
+
+- **A turn ceiling.** One instruction runs for at most 25 model turns by default,
+  and when the ceiling is hit the task stops with a plain message instead of
+  looping on. The message tells you the remedy too: narrow the task.
+- **One thing at a time.** Instructions are serialised - one instruction at a time
+  on one browser - and the system prompt tells the model to prefer one clear action
+  per turn over long chains.
+
+Be honest about what a ceiling is, though: it is a stop, not a throttle. It caps how
+big a burst one instruction can become; it does not pace the requests inside the
+burst, and it does not stop *you* from immediately issuing the same instruction
+again. The half that no product can supply is how often you run it.
+
+## The throttle lives in how you drive it
+
+- **Do not re-run a failed task immediately.** The worst response to a block or a
+  failure is the identical request again, faster. Wait, and wait longer each time.
+- **Narrow the task instead of repeating it.** If an instruction hits the turn
+  ceiling, splitting it into smaller instructions with pauses between them produces
+  less traffic than re-running the big one until it fits.
+- **Mind the exit, not the browser count.** The unit a counter sees is requests per
+  address and per account. Several agents behind one exit IP, each politely pacing
+  itself, are one very busy client to the site.
+- **If you script it, budget it.** `aihawk do` makes it easy to put an agent in a
+  script or cron job, which makes it easy to build an accidental refresh storm. Give
+  the script a budget and backoff, because that is the layer that owns the schedule:
+
+```python
+import subprocess, time
+
+def run_with_backoff(task, *, max_attempts=3):
+    for attempt in range(max_attempts):
+        r = subprocess.run(["uvx", "aihawk", "do", task],
+                           capture_output=True, text=True)
+        if r.returncode == 0:
+            return r.stdout
+        time.sleep(60 * 2 ** attempt)   # 1 min, 2 min, 4 min - never instantly
+    raise RuntimeError("giving up instead of hammering")
+```
+
+The agent makes each visit look right; the script decides how many visits happen and
+when. They are separate jobs, and the second one cannot be delegated downward.
+
+## What the browser fixes, and what it does not
+
+The honest split, because overclaiming here is a way to get someone blocked while
+they trust a promise that was never true.
+
+**What the engine handles.** The fingerprint, driver and network layers read as a
+genuine Firefox, so the class of check that asks "is this a real browser" mostly
+answers yes. Same seed, same identity, every run, so a failure is reproducible.
+
+**What you supply.** The engine does not change your address's reputation, does not
+create per-account quota out of nothing, and does not decide how often you run
+tasks. A real-looking browser on a
+[datacenter address is still on a datacenter address](https://github.com/feder-cr/invisible_playwright/wiki/can-websites-detect-a-datacenter-proxy-ip),
+and a counter on the address does not care how good the browser is.
+
+Put plainly: the engine makes each request look like it came from a real person. It
+does not make thirty requests look like one. That second job belongs to whoever
+decides how often the agent runs, which is you.
+
+## Conclusion
+
+Retrying and re-planning are what make an agent an agent, and they are also what
+turn one instruction into a burst of requests. Bursts are counted, and a counter is
+a different defence from a fingerprint check. AIHawk bounds the burst - a turn
+ceiling, serialised instructions - but pacing between runs, backoff after failures
+and a sane request budget live in how you drive it, and a clean exit lives under it.
+The browser's job is to make each request real; keeping the requests few and
+well-spaced is yours.
+
+## Short answers to the questions that lead here
+
+**Will a stealth browser stop my agent from being rate limited?** No. Rate limits
+count requests; they never inspect the browser. A real-looking fingerprint helps
+with detection, not with volume.
+
+**Why does my agent get blocked when doing the same thing by hand works?** Almost
+always because the agent sent many more requests, much faster, than you did.
+Retries, re-reads and reloads multiply traffic a person never generates.
+
+**Does AIHawk retry forever?** No. One instruction is capped at 25 model turns by
+default and then stops with a plain message. But the cap is a stop, not a throttle:
+re-issuing the same instruction immediately is still a retry loop, just with you in
+it.
+
+**Where should backoff live?** In whatever decides when tasks run: your habits at
+the prompt, or the script wrapping `aihawk do`. No browser setting paces a loop that
+was told to try until it succeeds.
+
+**Is a per-account quota a fingerprint problem?** No. A quota is counted against the
+account, not the browser, so a better fingerprint does nothing for it. Budget the
+actions instead.
+
+**How many requests per minute is safe?** There is no universal number; it depends
+on the site. The safe habit is a budget per task, backoff on failure, and never an
+immediate identical re-run.
+
+## Sources
+
+- AIHawk's own source, read 2026-09-03: `src/aihawk/agent.py` (the 25-turn default
+  ceiling and its stop message, tool errors fed back to the model as results, the
+  one-action-at-a-time system prompt) and `src/aihawk/link.py` (one instruction at a
+  time on one browser).
+- The engine wiki's
+  [rate limiting mechanics](https://github.com/feder-cr/invisible_playwright/wiki/how-to-rate-limit-your-scraper-playwright)
+  and its notes on
+  [handling 403 and 429 with backoff](https://github.com/feder-cr/invisible_playwright/wiki/how-to-handle-403-429-backoff-mid-scrape-playwright),
+  which document the same volume signal at the scraping layer.
+
+**See also:** [the timing signal AI agents give off](ai-agent-timing-signal.md) for
+the shape of the traffic rather than its amount,
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md) for the
+layer-by-layer sort, and
+[browser-use getting blocked](browser-use-getting-blocked.md) for the same split in
+another agent framework.
+
+---
+
+*Written while maintaining [AIHawk](https://github.com/feder-cr/AIHawk), an AI agent
+on a Firefox patched at the C++ level. The first velocity flag I ever chased was
+raised by our own test harness hammering one endpoint from one address - the browser
+was innocent, the loop was not.*

--- a/docs/ai-agent-fill-out-forms.md
+++ b/docs/ai-agent-fill-out-forms.md
@@ -1,0 +1,199 @@
+---
+title: "Getting an AI agent to fill out forms"
+description: "What actually happens when an agent fills a form - field reading, selects and date pickers, validation errors, multi-step wizards - and what to check when it fails."
+parent: "Using the Agent"
+nav_order: 1
+---
+
+
+# Getting an AI agent to fill out forms
+
+Filling a form is the task people reach for first with a web agent, and it is both
+easier and harder than it looks: easier because a well-built form is the most
+structured thing on the web, harder because forms are where sites concentrate their
+defenses, their validation and their worst widgets. This page walks what actually
+happens between "fill this out" and a submitted form, using a generic
+registration-style form as the running example: a few text fields, a country
+dropdown, a date of birth, some checkboxes, and a second page after "Continue". No
+hype and no horror stories, just the mechanics and the failure modes in the order
+you will meet them.
+
+If the agent loop itself is new to you,
+[the explainer](ai-web-agent-explained.md) covers it; this page assumes you know
+the agent observes the page, decides one action, and repeats.
+
+## Step one: the agent has to read the form, and forms lie
+
+Before anything is typed, the agent maps fields to meanings. On a well-built form
+this is straightforward, because structure carries the answer: labels are attached
+to inputs, field names say what they are, required fields are marked. This is what
+a structure-reading agent consumes, and it is the reason
+[browser agents](ai-browser-agent-open-source.md) handle forms better than
+screenshot-driven ones, which must infer the same mapping from pixels.
+
+Real forms drift from the ideal in ways that produce specific errors:
+
+- **Placeholder-only fields.** A field whose only description is the grey text
+  inside it, which disappears on focus. Agents usually cope; they occasionally
+  put the phone number in the fax field on forms where four boxes look alike.
+- **Detached labels.** Text near an input but not linked to it. The agent, like a
+  screen reader, is left guessing by proximity, and proximity misleads on
+  multi-column layouts.
+- **Fields that appear on interaction.** "Add another address" rows, sections
+  that expand when a checkbox is ticked. The agent cannot fill what has not been
+  rendered yet, so ordering matters: tick first, observe again, then fill.
+
+Expectation to carry in: on a clean form, field mapping just works. On a messy
+one, the first failure is usually here, and it looks like the right value in the
+wrong box.
+
+## Text is easy; everything else is the actual work
+
+Typing into a text input is the reliable case. The hierarchy of difficulty above
+it, from experience:
+
+- **Native selects and checkboxes** are structured controls with enumerable
+  options; agents handle them well, with one recurring trip: the option text the
+  agent wants ("United States") versus what the list actually holds ("USA"), an
+  exact-match failure a person would never notice making.
+- **Custom dropdowns**, the styled div-based kind, are harder: the options do not
+  exist in the page until the control is opened, so the agent must click, observe
+  the appeared list, then click an option, three loop turns where a native select
+  takes one. Searchable comboboxes add a type-then-wait-then-pick dance.
+- **Date pickers** are the classic. Some accept typed dates; many demand clicks
+  through a calendar widget, and month navigation is where agents wander. If a
+  date field accepts typing, expect success; if it is click-only, expect more
+  steps and more chances to end up in the wrong month. AIHawk's own README uses
+  exactly this case in its example prompt, with the instruction to click the days
+  rather than type, because saying so raises the success rate.
+- **File uploads** need the file to exist on the machine the browser runs on, and
+  a hosted agent may not have your file at all. Know where your agent's browser
+  actually runs before promising it an attachment.
+
+One mechanical note that matters for how the filling happens: a page can
+distinguish a value typed through real input events from a value injected into
+the field by script. AIHawk fills forms through actual key presses and clicks and
+refuses the script shortcut even where it would be faster; whatever agent you
+use, that behavior is worth confirming, both because injected values can skip the
+page's own event handlers (breaking forms that compute things as you type) and
+because it is a detectable difference.
+
+## Validation errors: where decent runs go to die
+
+Submit rarely means done. Browsers enforce built-in constraints, required fields,
+patterns, minimum lengths, before the form even leaves the page, and MDN's
+form-validation guide documents how deliberately these block submission: the form
+does not submit, and a message appears near the offending field. Sites then add
+their own layer, inline checks and server-side rejections with messages rendered
+anywhere on the page.
+
+For an agent this creates a read-back loop: submit, observe what changed, find
+the error text, connect it to a field, fix, resubmit. Where it goes wrong:
+
+- **The error is not seen.** A message rendered far from the field, or only
+  visible after scrolling, can be missed, and the agent resubmits the same data.
+  Two identical rejections in a row in the transcript is the signature.
+- **The error is seen but misread.** "Password must contain a symbol" is easy.
+  "Something went wrong" is not actionable for anyone, agent or human.
+- **Formats fight back.** Phone, date and postal formats are the most common
+  rejection, a field wanted digits only, the agent supplied punctuation. Stating
+  formats in your instruction ("phone as digits only") is cheap insurance.
+
+A validation loop that converges in one or two rounds is normal and fine. One
+that repeats deserves a stop: repeated identical submissions are also a request
+pattern sites notice, which crosses this page into
+[why agents get blocked](why-does-my-ai-agent-get-blocked.md).
+
+## Multi-step wizards: the state problem
+
+Our example form has a "Continue" to page two, and multi-step is where the small
+risks compound. Each step is its own little form with its own validation, so
+everything above happens per step. The specific new failures:
+
+- **Progress loss.** A session that expires or a step that hard-fails can throw
+  away earlier pages. Long wizards on slow sites fail at step four, not step one.
+- **Back-button hazards.** An agent that navigates back to fix something may find
+  earlier answers cleared, and must notice that rather than assume.
+- **Review pages.** The final "check your answers" page is the agent's best
+  checkpoint and yours: it is the one place the whole submission is visible at
+  once.
+
+The rule that keeps all of this safe, and it is AIHawk's own stated position on
+responsible use: do not let anything be submitted that a person has not read.
+Have the agent fill and stop, review the completed form or the review page
+yourself, and make submission the human's click wherever the stakes are real.
+
+## What to check when it fails
+
+In order, because the early ones are cheaper:
+
+1. **Read the transcript before rerunning.** Every decent agent shows what it saw
+   and did per step. The failure is usually legible there, and rerunning without
+   reading spends tokens re-arriving at it. Wrong value in the wrong box points
+   at field mapping; identical resubmissions point at unseen validation errors.
+2. **Do it once by hand.** Two minutes in your own browser reveals what the form
+   really demands, the strict formats, the click-only date picker, which of the
+   look-alike fields is which, and turns into one clarifying sentence in your
+   next instruction.
+3. **Feed facts, not vibes.** Most fill errors trace to information the agent
+   never had. Give exact values and exact formats for anything that matters, and
+   say which optional sections to skip.
+4. **Break the task at wizard boundaries.** "Complete step one and stop" is far
+   more reliable than "finish the whole wizard", and gives you checkpoints for
+   free.
+5. **If the form never loads or rejects instantly, stop debugging the form.**
+   That is not a filling problem; work through
+   [the blocked checklist](why-does-my-ai-agent-get-blocked.md) first, and if the
+   failures involve the agent hammering retries, see
+   [retry loops and rate limits](agent-retry-loops-rate-limits.md).
+
+## Short answers to the questions that lead here
+
+**Can an AI agent fill out web forms reliably?** On clean forms with typed inputs
+and native controls, yes, routinely. Reliability drops with custom widgets,
+click-only date pickers and multi-step wizards, and the fix is usually better
+instructions and smaller steps, not a different agent.
+
+**Why does the agent put the right value in the wrong field?** Field mapping:
+placeholder-only or detached labels leave the agent guessing by proximity. Name
+the fields explicitly in your instruction on forms where boxes look alike.
+
+**How does the agent handle validation errors?** By reading the page after a
+rejected submit and correcting the flagged field. It converges when errors are
+specific and visible; it loops when they are vague or rendered where the agent
+does not look, which is when you supply the format yourself.
+
+**Can it handle dropdowns and date pickers?** Native selects, well. Custom
+dropdowns and calendar widgets, with more steps and more failure chances; if
+typing a date is allowed, that path wins. Saying "click the days rather than
+typing" in the instruction genuinely helps.
+
+**Should I let the agent submit?** Not unattended where stakes are real. Let it
+fill, review the result yourself, and keep the submit click human. That is also
+AIHawk's stated position for its own users.
+
+**Do forms detect agents?** Forms are where detection concentrates, and filling
+speed and rhythm are part of what gets read. A form filled in under a second
+reads as what it is; the wider picture is on
+[the timing-signal page](ai-agent-timing-signal.md).
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [MDN: Client-side form validation](https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Forms/Form_validation),
+  for the built-in constraint attributes and how browsers block submission and
+  surface messages.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README in this
+  repository, for the real-input-events behavior, the calendar-widget example
+  prompt, and the responsible-use position quoted above.
+
+**See also:** [what is an AI web agent?](ai-web-agent-explained.md),
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md), and the
+rest of [Using the Agent](guides-using-the-agent.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki, written from
+transcripts of its agent doing exactly this. The advice to keep the submit click
+human is not a disclaimer, it is how the maintainer runs it.*

--- a/docs/ai-agent-timing-signal.md
+++ b/docs/ai-agent-timing-signal.md
@@ -1,0 +1,191 @@
+---
+title: "The timing signal AI agents give off"
+description: "An AI agent's think-act loop emits machine-regular gaps, model-latency pauses and dead-centre clicks. Why no fingerprint work fixes that, and what pacing actually helps."
+parent: "When the Agent Gets Blocked"
+nav_order: 2
+---
+
+
+# The timing signal AI agents give off
+
+The browser under your agent can be flawless - a real engine, a real fingerprint, a
+clean driver surface - and the session can still read as automated for a reason that
+has nothing to do with the browser: the rhythm of the loop driving it.
+
+Every AI agent, AIHawk included, runs a think-act cycle. It looks at the page, sends
+what it sees to a model, waits for the model to decide, performs the action, and looks
+again. That cycle has a shape, and the shape is measurable from the other side of the
+connection. If your agent gets through the first page load fine and gets challenged a
+few interactions later, this page is probably about your problem: the block that
+arrives after actions, not before them, is usually a behaviour verdict, not a
+fingerprint one.
+
+## What the rhythm looks like from the site's side
+
+A behavioural check does not read the GPU string or the canvas hash. It reads the
+stream of events a session produces over time, and an agent loop left to its own
+timing produces four things a person does not:
+
+- **Gaps that cluster.** Between one action and the next sits a wait for the model.
+  That wait is not random the way a human pause is: it clusters around the model's
+  inference latency, step after step, run after run. A person's pauses spread wide
+  and ragged - a one-second glance here, an eight-second read there. The individual
+  number is not the tell; the shape of the distribution is.
+- **Stillness inside the pause.** A person reading a page drifts the pointer, scrolls
+  a little, hovers over things. An agent's pointer sits perfectly still for two
+  seconds and then arrives exactly where it needs to be.
+- **Actions that land dead centre, instantly.** Coordinates computed from page
+  structure or from a screenshot land on the centre of the target, with no approach,
+  no overshoot, no correction, and no reading time in front of the click.
+- **No wasted actions.** People scroll past things, open the wrong tab, hover over
+  what they never click, change their minds. An agent performs exactly the actions
+  the task needs and nothing else, which is efficient and visible.
+
+None of that appears in any fingerprint report, which is exactly why it deserves its
+own page: it is a separate signal, read by a separate part of a detection system, and
+it survives every fingerprint fix.
+
+## Why a perfect fingerprint does not touch it
+
+A fingerprint is a photograph; behaviour is a motion study. Making the photograph
+perfect does nothing to the motion study.
+
+AIHawk runs on a Firefox patched at the C++ level (the
+[invisible_playwright](https://github.com/feder-cr/invisible_playwright) engine), and
+that engine's job is the photograph: the rendering, the driver surface and the network
+handshake read as a genuine Firefox rather than an automated build. That is real, and
+it is most of what agents are blocked for. It is also not everything, and the honest
+boundary matters: the engine controls what the browser *is*, not the cadence at which
+the loop above it decides to act. The cadence is produced by the model and the
+harness calling it, above the browser, out of the engine's reach. The engine wiki's
+[testing method](https://github.com/feder-cr/invisible_playwright/wiki/how-to-test-bot-detection)
+lists behaviour among the things no in-page test suite covers, for the same reason.
+
+## What the layer under AIHawk already covers
+
+Part of the motion problem does live below the loop, and that part is handled there,
+so you should know which part it is before trying to fix it yourself.
+
+- **The pointer path.** When the agent clicks, the engine arcs the pointer to the
+  target on a curved, human-shaped path rather than teleporting it. An individual
+  click's motion is covered; the gap before the click is not, because the loop decides
+  when the click happens. The boundary between pointer realism and fingerprint realism
+  is drawn in detail on
+  [the engine wiki](https://github.com/feder-cr/invisible_playwright/wiki/ghost-cursor-human-mouse).
+- **Real input, not script shortcuts.** AIHawk drives the page the way a person would:
+  the pointer moves and keys are pressed, and it refuses to set a form field from
+  JavaScript even when that would be quicker, because a page can tell the difference.
+- **Read before act.** AIHawk's system prompt instructs the model to inspect the page
+  before acting on it and to prefer one clear action at a time over long chains. That
+  produces read-shaped traffic in front of actions instead of blind action bursts.
+
+What none of that covers is the distribution of gaps between steps. That is the
+model's latency wearing a trench coat, and it is visible no matter how good each
+individual action looks.
+
+## What actually helps
+
+Be clear-eyed about what you control. If you run an off-the-shelf agent - AIHawk's
+interface, or an assistant driving the browser over MCP - the loop's internal timing
+is not a knob you turn. What you control is everything around the loop, and that is
+where the wins are:
+
+- **Fewer, larger tasks.** One instruction that reads five prices in one visit
+  produces one session with a natural arc. Five separate instructions produce five
+  bursts, each starting cold on the same site.
+- **No fixed schedule.** Running the same task from a timer every ten minutes turns
+  the task itself into a metronome. If something must repeat, vary the interval.
+- **Space out repeat visits.** The rhythm tell compounds with the volume tell, and
+  the volume half is [a page of its own](agent-retry-loops-rate-limits.md).
+- **Do not re-run a blocked task immediately.** A challenge answered by the identical
+  session ten seconds later confirms the verdict.
+
+If you are building your own harness above an agent loop - executing its actions
+yourself, or wrapping `aihawk do` in a script - you own the timing, and then the rule
+is: vary it, and make it depend on the step. A uniform delay is its own tell. A
+`sleep(1.0)` between every action just moves the cluster from "instant" to "exactly
+one second", and a tight cluster at one second is as machine-regular as a tight
+cluster at zero. Long pauses before decisions, short ones inside a form, no number
+twice:
+
+```python
+import random, time
+
+def dwell(low=0.6, high=2.4):
+    """A varied pause, the kind reading and deciding actually produces."""
+    time.sleep(random.uniform(low, high))
+```
+
+## Seeing your own rhythm before a site does
+
+You can read this signal off your own sessions the way a site would. AIHawk's
+interface narrates every step as it takes it, so the cadence is on screen while the
+task runs; for anything scripted, log a timestamp at each action and look at the
+spread of the gaps. If the minimum and maximum are close together, or the mean sits
+right on top of your model's typical response time, the loop is emitting the
+clustered distribution described above. A human trace has a wide spread and a long
+tail. Measure the stream; do not assume the shape.
+
+## Conclusion
+
+The fingerprint and the rhythm are two different signals, read by two different parts
+of a detection system, and the engine under AIHawk addresses the first. It makes the
+browser real, gives each click a human-shaped path, and puts real key presses behind
+typed text. The cadence between actions is produced above the browser - by the model
+and by how you run it - so it is yours: fewer and larger tasks, no fixed schedules,
+varied pacing where you control the code, and a look at your own gap distribution
+before a site looks at it for you.
+
+## Short answers to the questions that lead here
+
+**Does a stealth browser hide that I am running an AI agent?** It hides that the
+browser is automated. It does not hide the rhythm of the loop driving it, which is a
+separate signal produced above the browser.
+
+**What is the timing signal, exactly?** The gaps between actions cluster around the
+model's latency instead of spreading like human pauses, the pointer is still during
+the pause, and actions land dead centre with no reading time in front of them.
+
+**Why do I get blocked after a few actions rather than at the first page?** A block
+at first load points at the fingerprint or the address. A block after interactions
+points at behaviour, and the agent rhythm is the usual behaviour verdict.
+
+**Can AIHawk add the pacing for me?** The engine humanizes each click's pointer path
+and presses real keys, and the agent reads before acting. The step-to-step cadence
+is decided by the model's loop, so what you control is how many tasks you run,
+against what, on what schedule.
+
+**Do I just add a fixed sleep between actions?** No. A tight cluster at one second is
+as regular as a tight cluster at zero. Vary the pauses and make them depend on the
+step.
+
+**Will fixing the timing get me past everything?** No. A clean rhythm on a bad exit,
+over quota, or against a rate limit still fails.
+[Why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md) sorts the
+layers.
+
+## Sources
+
+- AIHawk's own source: the system prompt in `src/aihawk/agent.py` instructs the model
+  to inspect pages before acting and to prefer one clear action at a time, and the
+  [README](https://github.com/feder-cr/AIHawk#readme) documents the input behaviour
+  (pointer moves, keys pressed, JavaScript form-fill refused). Both read 2026-09-03.
+- The engine wiki's
+  [testing method](https://github.com/feder-cr/invisible_playwright/wiki/how-to-test-bot-detection),
+  which lists behaviour and the model-latency-shaped pause among the things no
+  in-page suite covers, and its
+  [detected-on-one-site checklist](https://github.com/feder-cr/invisible_playwright/wiki/playwright-detected-as-bot),
+  which reaches pointer motion and cadence only after the browser itself is clean.
+
+**See also:** [why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md)
+for the full layer-by-layer sort, [agent retry loops and rate limits](agent-retry-loops-rate-limits.md)
+for the volume half of the same problem, and
+[Claude computer use detected as a bot](claude-computer-use-detected-as-bot.md) for
+the rhythm of a screenshot-driven agent specifically.
+
+---
+
+*Written while maintaining [AIHawk](https://github.com/feder-cr/AIHawk), an AI agent
+on a Firefox patched at the C++ level. The engine makes the browser real; the rhythm
+comes from the loop, and this page is what I check first when a session of my own
+gets challenged after the third click.*

--- a/docs/ai-browser-agent-open-source.md
+++ b/docs/ai-browser-agent-open-source.md
@@ -1,0 +1,187 @@
+---
+title: "Open-source AI browser agents"
+description: "The open-source agents that drive a real browser - browser-use, Skyvern, Stagehand, Nanobrowser, BrowserOS, AIHawk - compared by license, engine and how each reads a page."
+parent: "Alternatives and Comparisons"
+nav_order: 7
+---
+
+
+# Open-source AI browser agents
+
+An AI browser agent is a language model wired to a real browser: you state a goal in
+plain language, the model looks at the page, decides an action, the browser performs
+it, and the loop repeats until the goal is done or the model gives up. This page maps
+the open-source projects that actually do that today, with one disclosure before
+anything else: AIHawk is one of the entries and this is AIHawk's wiki, so read the
+comparison knowing who wrote it. Every claim about the other projects below was read
+from that project's own repository on 2026-09-03, star counts included. Stars drift
+daily; treat them as order-of-magnitude, not scoreboard.
+
+If you are new to the category itself, start with
+[what an AI web agent is](ai-web-agent-explained.md) and come back. And if what you
+picture is an agent looking at raw pixels and clicking screen coordinates, that is a
+different category with different trade-offs, covered in
+[open-source computer-use agents](computer-use-agent-open-source.md).
+
+## What qualifies for this page
+
+Three tests, applied to every entry:
+
+1. **Open source in the useful sense.** A license and a repository you can run
+   yourself, not a waitlist with a GitHub page in front of it.
+2. **A real browser.** The agent drives an actual browser engine that executes
+   JavaScript and renders pages, not an HTTP client with a model attached.
+3. **The model decides.** An LLM chooses the next action from what is on the page,
+   rather than replaying a recorded script.
+
+Several entries also sell a hosted cloud on top of the open code. That is noted where
+it changes what the open part actually contains.
+
+## The projects
+
+### browser-use
+
+The largest project in the category by a wide margin: 112.1k stars, Python, MIT
+licensed. It drives a browser through Playwright and gives the model both views of a
+page at once, a structured DOM representation plus screenshots. It supports many
+model providers, including its own trained models, the major APIs, and local models
+through Ollama. The company behind it also runs a paid hosted cloud; the library is
+the open part, and it is the default answer to "which one do most people use". If you
+are evaluating it against alternatives, there is a dedicated page for that:
+[browser-use alternatives](browser-use-alternatives.md).
+
+### Stagehand
+
+24.1k stars, TypeScript with Python and Go interfaces, MIT licensed, maintained by
+Browserbase. Stagehand is not a finished agent you hand a task to; it is an SDK for
+building browser agents, with Playwright-style methods and self-healing actions. Its
+own framing is the useful one: "Playwright was built for testing, Stagehand is built
+for agents". Pick it when you are writing the agent yourself and want the
+acting-on-a-page layer solved.
+
+### Skyvern
+
+22.9k stars, Python. It combines Playwright with vision language models to interact
+with pages, aimed at repeatable browser workflows, self-hosted via pip or Docker or
+through its managed cloud. The license detail is worth knowing before you commit:
+AGPL-3.0, and the README states that its anti-bot measures are an exception,
+available in the managed cloud offering rather than in the open code.
+
+### Nanobrowser
+
+13.7k stars, TypeScript, Apache-2.0. Structurally different from everything above:
+it is a Chrome extension, so it drives the browser you already run (Chrome and Edge
+are supported; Firefox and Safari are not). Inside it runs a multi-agent design, a
+planner and a navigator cooperating on a task. It positions itself as a free,
+local-privacy alternative to OpenAI Operator, with your own API keys and a long list
+of supported providers including Ollama for local models.
+
+### BrowserOS
+
+13.5k stars, AGPL-3.0. Here the browser itself is the project: a Chromium fork with
+agent capabilities built in, shipping both a daily-driver browser with an embedded
+agent and a secondary browser that external agents control. Agents connect over the
+Model Context Protocol, and local models are supported through Ollama and LM Studio.
+Choose it when you want the agent living inside the browser as a product, not a
+library in your code.
+
+### AIHawk
+
+30.3k stars, Python, MIT. This one is ours, so the disclosure from the top of the
+page applies to this paragraph most of all. AIHawk started as a job-application bot,
+which is where the star count and the TechCrunch, Business Insider and Wired coverage
+came from, and it is now a general web agent. There are two ways in: add its MCP
+server (`invisible-playwright-mcp`) to an assistant that can run tools, such as
+Claude Code, Claude Desktop or Cursor, where the assistant brings the model, or run
+`uvx aihawk ui` with an OpenRouter key and get a chat interface with a live browser
+view (without a key it runs a placeholder mode that takes literal commands).
+
+The structural difference from every other entry is the browser. Everything above
+drives Chromium, Chrome or a fork of them; AIHawk drives a Firefox patched at the
+C++ level, the invisible_playwright engine, built so that what fingerprinting scripts
+read from it is internally consistent. That matters on pages that push back, and the
+honest boundary matters just as much: the engine addresses the browser fingerprint
+layer, and it does not fix a bad exit IP, a rate limit, or robotic pacing. Those
+layers are yours regardless of the agent you pick; the breakdown is in
+[why agents get blocked](why-does-my-ai-agent-get-blocked.md). Platform limits are
+real too: Python 3.11+, Windows and Linux, no macOS support.
+
+## The differences that decide the choice
+
+| Project | Stars (2026-09-03) | Language | License | Browser it drives | How it reads a page |
+|---|---|---|---|---|---|
+| browser-use | 112.1k | Python | MIT | Playwright-driven browser | DOM plus screenshots |
+| Stagehand | 24.1k | TypeScript, Python, Go | MIT | Playwright-compatible runtime | structured actions, DOM-first |
+| Skyvern | 22.9k | Python | AGPL-3.0 (anti-bot parts cloud-only) | Playwright | vision LLM plus page structure |
+| Nanobrowser | 13.7k | TypeScript | Apache-2.0 | your own Chrome or Edge | in-page, multi-agent |
+| BrowserOS | 13.5k | TypeScript, C++ | AGPL-3.0 | its own Chromium fork | agent embedded, MCP tools |
+| AIHawk | 30.3k | Python | MIT | patched Firefox (invisible_playwright) | structured snapshots plus screenshots over MCP |
+
+A few honest cuts through the table:
+
+- **Most people, most tasks:** browser-use. Largest community, most examples, and
+  model quality usually matters more than framework choice for ordinary tasks.
+- **You are writing your own agent:** Stagehand, and it is the only entry here that
+  is honest about being a building block rather than a product.
+- **Zero infrastructure, your own browser:** Nanobrowser. An extension is also the
+  easiest thing on this page to try and to remove.
+- **The browser as the product:** BrowserOS.
+- **Repeatable workflows with a vision-first reading of the page:** Skyvern, with
+  the AGPL and the cloud-only anti-bot carve-out weighed first.
+- **Pages that resist automation, or plugging a browser into Claude Code:** AIHawk,
+  from the people telling you so, with the layer boundaries stated above.
+
+## Short answers to the questions that lead here
+
+**Which open-source browser agent is the biggest?** browser-use, at 112.1k stars as
+of 2026-09-03, roughly four times the next entry. Stars measure attention, not fit,
+but attention buys examples and answered issues.
+
+**Are these actually free?** The code is. The model tokens are not: every entry needs
+an LLM, and on hosted APIs that is a per-task cost. Several projects also sell hosted
+clouds; the open repositories are what this page compared.
+
+**Which ones run with local models?** browser-use, Nanobrowser and BrowserOS all
+document local-model support through Ollama (BrowserOS also LM Studio). Expect a
+capability drop against frontier hosted models on long multi-step tasks.
+
+**What is the difference from a computer-use agent?** A browser agent reads page
+structure and acts on elements; a computer-use agent looks at screen pixels and
+clicks coordinates, so it can drive anything on screen at a cost in precision and
+tokens. The category comparison is on
+[the computer-use page](computer-use-agent-open-source.md).
+
+**Do open-source agents get blocked more than commercial ones?** Blocking does not
+check your license. It checks the browser fingerprint, the exit IP, the request
+volume and the pacing, and most agents on this page inherit a stock automation
+fingerprint. The layer-by-layer breakdown is in
+[why agents get blocked](why-does-my-ai-agent-get-blocked.md).
+
+**Which one should I use with Claude Code?** AIHawk's MCP server is built for exactly
+that, one `claude mcp add` command, and this is its wiki saying so, which is why the
+sentence carries a disclosure instead of a superlative.
+
+## Sources
+
+All retrieved 2026-09-03. Star counts and claims were read from each project's own
+repository page on that date.
+
+- [browser-use/browser-use](https://github.com/browser-use/browser-use)
+- [browserbase/stagehand](https://github.com/browserbase/stagehand)
+- [Skyvern-AI/skyvern](https://github.com/Skyvern-AI/skyvern)
+- [nanobrowser/nanobrowser](https://github.com/nanobrowser/nanobrowser)
+- [browseros-ai/BrowserOS](https://github.com/browseros-ai/BrowserOS)
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README in this
+  repository.
+
+**See also:** [open-source computer-use agents](computer-use-agent-open-source.md),
+[what is an AI web agent?](ai-web-agent-explained.md),
+[choosing an AI browser agent](best-ai-browser-agent.md), and
+[browser-use alternatives](browser-use-alternatives.md).
+
+---
+
+*This page is part of the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. AIHawk
+is the entry above with the patched Firefox underneath; the other five projects were
+described from their own repositories, and where one of them fits your case better,
+the table says so.*

--- a/docs/ai-browser-agents-vs-traditional-scraping.md
+++ b/docs/ai-browser-agents-vs-traditional-scraping.md
@@ -1,0 +1,206 @@
+---
+title: "AI browser agents vs traditional scraping"
+description: "An agent is expensive per page and adapts; a scraper is nearly free per page and brittle. Where each wins, the real cost math, and the hybrid most teams end up with."
+parent: "Alternatives and Comparisons"
+nav_order: 10
+---
+
+
+# AI browser agents vs traditional scraping
+
+A scripted scraper is nearly free per page and expensive per change. An AI browser
+agent is expensive per page and nearly free per change. Almost every practical
+question about choosing between them unwinds from that one asymmetry, so this page
+starts there and stays concrete: where each cost actually comes from, where each one
+breaks, and the hybrid most teams converge on once they have been burned by both.
+
+One framing note before the details. "Traditional scraping" here means code you
+write and run: an HTTP client with a parser, a crawling framework like Scrapy, or a
+Playwright script clicking through pages deterministically. An "agent" means an LLM
+in a loop with a browser, deciding each action from what is on the page;
+[the explainer](ai-web-agent-explained.md) covers that loop if it is new to you.
+
+## What each one actually is
+
+**The scraper is a program about one site's structure.** You inspect the page,
+find that the data lives in a table or a JSON blob, and write code that requests,
+parses and extracts exactly that. Scrapy, the reference framework on the Python
+side, has carried this model for over fifteen years. The defining properties: the
+marginal cost of the next page is close to zero (bandwidth and compute), output is
+deterministic, throughput is whatever the site tolerates, and the code encodes
+assumptions about structure that were true on the day you wrote it.
+
+**The agent is a program about intent.** You state the goal; the model reads each
+page fresh and decides what to do. The defining properties are the mirror image:
+the marginal cost of the next page is a set of model calls, the output is not
+guaranteed to be identical across runs, throughput is capped by model latency, and
+no assumptions about structure are frozen anywhere, because the structure is read
+at run time.
+
+Neither property list is a flaw. They are the design, and they price the two tools
+for opposite jobs.
+
+## The cost math, with real numbers
+
+Scraper first, because it is short: after development, a page costs a request. Run
+it a million times and the dominant costs are infrastructure and the site's
+patience, not the code. The catch is the development itself, and above all the
+redevelopment: every layout change breaks assumptions, and someone pays engineering
+time to notice, diagnose and fix. A scraper's true cost is maintenance, and it is
+lumpy and unplanned.
+
+Now the agent. Each loop turn sends the page state to a model: on a complex page, an
+observation is thousands to tens of thousands of tokens. A realistic multi-step
+task, navigate, search, open results, extract, takes ten to twenty turns with
+history accumulating in the context. Using the pricing of GLM-4.6, AIHawk's default
+model and one of the cheaper capable options at $0.43 per million input tokens and
+$1.75 per million output on OpenRouter: a task moving 500,000 input tokens and
+10,000 output tokens costs roughly $0.23. As an estimate, call it cents per task on
+a budget model, and ten times that on frontier-priced models. Retries and wandering
+multiply it; agents that misread a page can spend forty turns on a six-step task.
+
+Put the two curves side by side and the crossover is stark. At ten pages a day, the
+agent's cents are noise and the scraper's maintenance is the whole cost. At a
+million pages a day, the agent's cents are $10,000+ and the scraper's maintenance
+amortizes to nothing per page. Volume decides, and it decides early: the crossover
+is usually in the hundreds of pages per day, not the millions.
+
+## The reliability question, which is not one question
+
+"Which is more reliable" has two honest answers, because the two tools fail
+differently.
+
+**The scraper fails by going stale, and often silently.** When the page changes,
+the best case is an exception. The worse and common case is that the selector still
+matches something, and you collect wrong or empty data until someone looks. A
+scraper's reliability is excellent right up until the day it is zero, and you do
+not choose the day.
+
+**The agent fails by being wrong, non-deterministically.** The model misreads a
+page, extracts a plausible-looking wrong value, declares success early, or takes a
+different path on the second run. There is no version of "it worked yesterday so it
+works today" with a stochastic component in the loop. The benchmark history is
+sobering on absolute rates: WebArena's 2023 baseline had the best GPT-4 agent
+completing 14.41% of end-to-end web tasks against a human 78.24%. Agents have
+improved a great deal since, but on long open-ended tasks, per-run failure is still
+an expected event, not an anomaly.
+
+The symmetry that matters operationally: the scraper's failures cluster (everything
+breaks at once when the site ships a redesign, then nothing breaks for months),
+while the agent's failures are spread thin across every run. You defend a scraper
+with monitoring and alerts; you defend an agent with validation of its output and
+caps on its spend. If you have neither defense, you have chosen "unreliable" in
+both cases.
+
+## When the agent wins
+
+- **Low volume, high judgement.** Tens of pages where each needs a decision, not
+  thousands where each needs the same three fields.
+- **One-off and ad-hoc tasks.** A scraper for a single afternoon's question costs
+  more to write than the answer is worth. An agent's setup cost per new task is a
+  sentence.
+- **Heterogeneous sites.** One task across twenty differently-built pages would be
+  twenty scrapers. It is one instruction to an agent.
+- **Fast-changing layouts.** The maintenance cost that dominates a scraper's life
+  is exactly what the agent does not have, because nothing about the structure is
+  hardcoded.
+- **Tasks that are actions, not extraction.** Filling forms, walking wizards,
+  checking a flow end to end ([the forms page](ai-agent-fill-out-forms.md) is the
+  honest account). A scraper extracts; it does not do errands.
+
+## When the scraper wins, absolutely
+
+- **Volume.** Past a few hundred pages a day of the same shape, per-page model
+  cost stops being noise. At true scale the agent is not a worse choice, it is not
+  a choice.
+- **Stable, structured sources.** If the data sits in a table, a feed, or a JSON
+  endpoint that has not changed in a year, an agent adds cost and non-determinism
+  to a solved problem. If there is a public API, use the API and neither of these.
+- **Reproducibility and audit.** A pipeline that must produce the same output from
+  the same input, that must be reviewable line by line, or that feeds numbers
+  someone signs off on, wants deterministic code, not sampled decisions.
+- **Latency and throughput.** A parse takes milliseconds; a loop turn takes
+  seconds. Anything interactive or time-sensitive at volume belongs to code.
+
+## The hybrid, which is where this usually lands
+
+The choice is not actually binary, and the strongest pattern uses each tool at its
+own price point:
+
+- **Agent for discovery, script for volume.** Use an agent once to work out where
+  the data lives and how to reach it, then encode that path as a deterministic
+  script for the repeated runs.
+- **Agent as the repair crew.** Run the cheap scraper until it breaks, then hand
+  the broken page to an agent, or to a model asked to re-derive the selectors, and
+  patch the script. The maintenance lump that dominates scraper cost becomes a
+  bounded, occasional model bill.
+- **Agent as the fallback path.** Route pages that parse cleanly through code and
+  send only the exceptions to the agent. The blended per-page cost stays close to
+  the scraper's while the failure mode stops being silent staleness.
+
+## The part neither tool fixes
+
+Both approaches run into sites that push back, and blocking does not care which
+you chose: it reads the browser (or client) fingerprint, the IP's reputation, the
+request volume and the pacing. A scraper on a datacenter IP and an agent with a
+stock automation browser are both visible, each for different reasons. That whole
+topic has its own cluster, starting at
+[why does my AI agent get blocked](why-does-my-ai-agent-get-blocked.md). For the
+agent side, AIHawk's browser being a patched real Firefox addresses the fingerprint
+part of that list specifically, and, as that page spells out, none of the other
+parts.
+
+## Short answers to the questions that lead here
+
+**Is an AI agent better than a web scraper?** Wrong axis. An agent is better per
+change (nothing structural is hardcoded) and a scraper is better per page (near-zero
+marginal cost). Volume and volatility decide which axis matters for your case.
+
+**How much does an AI agent cost per page or per task?** Order of magnitude: cents
+per multi-step task on a budget model like GLM-4.6 ($0.43 per million input tokens
+on OpenRouter as of 2026-09-03), roughly ten times that on frontier-priced models,
+plus multipliers for retries. A scripted request costs effectively nothing.
+
+**Will agents replace web scraping?** Not at current per-token prices for
+high-volume extraction, where deterministic code wins on cost, speed and
+reproducibility. Agents are replacing the low-volume, high-judgement scraping that
+was never worth engineering time, and they are eating scraper maintenance via the
+hybrid patterns above.
+
+**Are agents more reliable on sites that change often?** Per change, yes: an agent
+re-reads structure at run time, which is exactly the scraper's weak point. Per run,
+no: agents fail non-deterministically, so the win only holds with output validation
+around them.
+
+**Do agents get blocked less than scrapers?** Neither gets a pass. Blocking reads
+fingerprint, IP, volume and pacing, and each tool has different weak points across
+those four; the breakdown lives in
+[why does my AI agent get blocked](why-does-my-ai-agent-get-blocked.md).
+
+**Can I use an agent to write my scraper?** Yes, and it is one of the strongest
+patterns available: agent for discovery and repair, deterministic code for the
+volume. The two failure modes cover for each other.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [Scrapy](https://www.scrapy.org/), for the framework's positioning and its
+  fifteen-plus years of maintained history.
+- [GLM-4.6 on OpenRouter](https://openrouter.ai/z-ai/glm-4.6), for the per-token
+  prices used in the cost arithmetic.
+- [WebArena paper abstract (arXiv:2307.13854)](https://arxiv.org/abs/2307.13854),
+  for the 14.41% versus 78.24% end-to-end success figures.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README in this
+  repository, for AIHawk's default model and engine claims.
+
+**See also:** [what is an AI web agent?](ai-web-agent-explained.md),
+[open-source AI browser agents](ai-browser-agent-open-source.md),
+[getting an agent to fill out forms](ai-agent-fill-out-forms.md), and
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. AIHawk is an agent, so
+note what this page did not claim: that agents beat scrapers. Past a few hundred
+uniform pages a day, write the script.*

--- a/docs/ai-web-agent-explained.md
+++ b/docs/ai-web-agent-explained.md
@@ -1,0 +1,195 @@
+---
+title: "What is an AI web agent?"
+description: "An AI web agent is an LLM in a loop with a browser. How the loop works, what it can do today, what it still fails at, and the architectures behind the demos."
+parent: "Alternatives and Comparisons"
+nav_order: 9
+---
+
+
+# What is an AI web agent?
+
+An AI web agent is a language model in a loop with a browser. You give it a goal in
+plain language. It looks at the current page, decides one action, the browser
+performs that action, and the model looks again. The loop repeats until the goal is
+met, the model concludes it cannot be met, or something runs out: patience, money,
+or the site's tolerance.
+
+That is the whole idea. Everything else on this page, and everything in the products
+built on it, is engineering around three questions: what exactly does the model see,
+what exactly can it do, and what happens when either goes wrong. No hype survives
+contact with those three questions, so this page will not carry any.
+
+## The loop, one turn at a time
+
+A single turn of an agent loop has four parts.
+
+1. **Observe.** The framework produces a representation of the page for the model.
+   This is the biggest design decision in the whole category (more below): a
+   structured text rendering of the DOM or accessibility tree, a screenshot, or
+   both.
+2. **Decide.** The model receives the observation, the goal, and the history of what
+   it has done so far, and emits one action: click that element, type this text
+   there, scroll, go to a URL, or declare the task finished.
+3. **Act.** The framework executes the action in a real browser. The page reacts:
+   navigation, a validation error, a popup, nothing at all.
+4. **Repeat.** The new state becomes the next observation.
+
+Two properties of the loop explain most of what you will experience using one.
+First, every turn costs a model call, so an agent's cost scales with the number of
+steps, not the number of pages, and a task that wanders costs more than a task that
+goes straight. Second, the model only knows what the observation shows it, so
+anything the representation drops, a canvas widget, an image-only button, content
+below the fold that was truncated, is invisible to the agent no matter how good the
+model is.
+
+## What agents can actually do today
+
+Used within their range, current agents are genuinely useful at tasks that need a
+browser and a judgement call on every page: read this page and extract what matters,
+compare what these three pages say, walk this multi-step process and stop when
+something unexpected appears, fill this form from these facts (with a person
+reviewing before submit; [the forms page](ai-agent-fill-out-forms.md) is the honest
+account of that one). The common thread is low volume and high judgement.
+
+The trajectory is real, and worth stating with numbers rather than adjectives. When
+the WebArena benchmark was published in 2023, the best GPT-4-based agent completed
+14.41% of its end-to-end web tasks against a human rate of 78.24%. In 2026, on the
+adjacent OSWorld benchmark for full computer tasks, Agent S3's own README reports
+72.6%, which it states is above the measured human level of roughly 72%. Those two
+numbers are from different benchmarks and the second is self-reported, so do not
+lay them end to end as one curve; the honest reading is narrower: in about three
+years, scoped agent tasks went from mostly failing to mostly succeeding.
+
+## What agents still fail at
+
+This is the section vendors skip, so it gets the detail here.
+
+- **Wrong targets.** The model decides to click something that is not what it thinks
+  it is, or references an element that does not exist in the observation, a
+  hallucinated selector. Structured-view agents fail loudly here (the element is not
+  found); screenshot agents fail silently (the click lands somewhere).
+- **Loops and wandering.** An agent that misreads a page can retry the same failing
+  action, or oscillate between two pages, burning a model call per turn. Watching an
+  agent spend forty steps on a six-step task is a rite of passage. Caps on steps and
+  spend are not optional.
+- **Cost per task.** Every observation of a complex page is thousands of tokens.
+  Multiply by steps and by retries. Concretely: AIHawk's default model, GLM-4.6, is
+  priced on OpenRouter at $0.43 per million input tokens and $1.75 per million
+  output, which is cheap for the class; a multi-step task still routinely moves
+  hundreds of thousands of input tokens. On frontier-priced models the same task
+  costs an order of magnitude more. The full cost argument, against the alternative
+  of writing a scraper, is on
+  [agents vs traditional scraping](ai-browser-agents-vs-traditional-scraping.md).
+- **Sites that push back.** Some pages detect and block automation, and an agent
+  inherits every signal its browser emits plus tells of its own, like the
+  machine-regular rhythm covered in
+  [the timing-signal page](ai-agent-timing-signal.md). What blocking is made of, and
+  which parts an agent framework can and cannot fix, is the subject of
+  [why does my AI agent get blocked](why-does-my-ai-agent-get-blocked.md).
+- **Non-determinism.** The same task on the same site can succeed today and fail
+  tomorrow, because the model sampled a different path or the page changed a detail.
+  Anything you need to run repeatedly and reliably deserves either a fixed script or
+  an agent with tight checks around it.
+
+## The architectures, in two axes
+
+**How the agent sees: structure versus pixels.** A DOM-reading agent receives page
+structure, element roles, labels and text, and acts on elements by reference. It is
+precise and comparatively cheap, and it goes blind where structure is missing. A
+screenshot agent receives the rendered image and acts at coordinates; it sees
+whatever a person sees and pays for it in tokens and grounding errors. The two
+category pages carry the specifics:
+[open-source browser agents](ai-browser-agent-open-source.md) for the structural
+side, [open-source computer-use agents](computer-use-agent-open-source.md) for the
+pixel side. The field is converging on hybrids: structure where it exists, pixels
+where it does not.
+
+**Where it runs: hosted versus local.** A hosted agent runs browser and loop on a
+vendor's infrastructure: nothing to install, and in exchange the vendor sees your
+sessions and their logins, you queue behind their limits, and the product can be
+withdrawn (the fate of one well-known hosted agent is its own page:
+[is OpenAI Operator still available?](is-openai-operator-still-available.md)). A
+local agent runs the browser on your machine with your keys. The model itself is
+usually still a hosted API in both cases; fully local models work through tools
+like Ollama, at a real capability cost on long tasks.
+
+Where this project sits, stated once and with its boundary: AIHawk is a local,
+open-source, structure-reading agent whose browser is a Firefox patched at the C++
+level rather than a stock automation build, which addresses the fingerprint layer
+of blocking and does nothing for the IP, volume or pacing layers. Two ways in, an
+MCP server for assistants like Claude Code, or `uvx aihawk ui` with an OpenRouter
+key. This is AIHawk's wiki, so weigh that paragraph as a maintainer describing his
+own tool.
+
+## Where to go from here
+
+This page is the hub of a cluster; each spoke goes one level deeper.
+
+- Choosing a tool: [open-source AI browser agents](ai-browser-agent-open-source.md),
+  [open-source computer-use agents](computer-use-agent-open-source.md),
+  [choosing an AI browser agent](best-ai-browser-agent.md), and the
+  Operator-shaped questions,
+  [alternatives](openai-operator-alternatives.md) and
+  [open-source equivalents](openai-operator-open-source.md).
+- Deciding whether you need an agent at all:
+  [agents vs traditional scraping](ai-browser-agents-vs-traditional-scraping.md).
+- Running one: [getting an agent to fill out forms](ai-agent-fill-out-forms.md).
+- When it stops working:
+  [why does my AI agent get blocked](why-does-my-ai-agent-get-blocked.md),
+  [the timing signal](ai-agent-timing-signal.md), and
+  [retry loops and rate limits](agent-retry-loops-rate-limits.md).
+
+## Short answers to the questions that lead here
+
+**What is an AI web agent, in one sentence?** A language model in a loop with a real
+browser: it observes the page, chooses one action, the browser executes it, and the
+cycle repeats until the goal is done.
+
+**Is that the same as a chatbot with browsing?** No. Search-and-summarize features
+read pages; a web agent acts on them, clicking, typing and navigating, which is a
+different capability with different failure modes.
+
+**Can an agent do anything I can do in a browser?** In principle it can attempt
+most of it; in practice it is reliable on scoped, judgement-per-page tasks and
+unreliable on long open-ended ones. The 2023 WebArena baseline was 14.41% task
+success against a human 78.24%, and while agents have improved sharply since, "give
+it anything" is still not the honest pitch.
+
+**Why do agents cost real money per task?** Each loop turn sends the page state to
+a model. Complex pages are thousands of tokens per observation, tasks take many
+turns, and retries multiply both.
+
+**DOM-reading or screenshot-based, which is better?** For web-only tasks,
+structure: cheaper, more precise, diagnosable failures. For anything without
+readable structure, pixels are the only option. Hybrids are increasingly the
+default answer.
+
+**Do AI web agents get blocked?** Yes, for four separable reasons: browser
+fingerprint, IP reputation, volume, and behavioral rhythm. An agent framework can
+fix the first, influence the fourth, and cannot fix the middle two;
+[the blocked page](why-does-my-ai-agent-get-blocked.md) walks the order to check.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [WebArena paper abstract (arXiv:2307.13854)](https://arxiv.org/abs/2307.13854),
+  for the 14.41% agent versus 78.24% human end-to-end success rates.
+- [simular-ai/Agent-S](https://github.com/simular-ai/Agent-S), for the self-reported
+  OSWorld figure and its human-level comparison.
+- [browser-use/browser-use](https://github.com/browser-use/browser-use), as the
+  reference example of a DOM-plus-screenshot observation design.
+- [GLM-4.6 on OpenRouter](https://openrouter.ai/z-ai/glm-4.6), for current per-token
+  pricing of AIHawk's default model.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README in this
+  repository, for the claims about AIHawk itself.
+
+**See also:** [open-source AI browser agents](ai-browser-agent-open-source.md),
+[agents vs traditional scraping](ai-browser-agents-vs-traditional-scraping.md), and
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md).
+
+---
+
+*Maintained alongside [AIHawk](https://github.com/feder-cr/AIHawk), an open-source
+web agent with a real patched Firefox underneath. The loop described above is the
+one it runs, which is how its failure modes ended up documented this specifically.*

--- a/docs/automate-job-applications-python.md
+++ b/docs/automate-job-applications-python.md
@@ -1,0 +1,211 @@
+---
+title: "Automating job applications in Python"
+description: "The build-it-yourself route: browser automation plus an LLM API, the four components a real pipeline needs, why naive scripts break on wizards, validation and anti-bot layers, and the honest case for using what already exists."
+parent: "Job Application Automation"
+nav_order: 3
+---
+
+
+# Automating job applications in Python
+
+Building a job-application bot in Python is a genuinely instructive project: it
+touches browser automation, LLM integration, state, and the parts of the web
+that push back. This page lays out what the real components are, shows why the
+obvious eighty-line script breaks, and closes with the honest note that this
+exact project has already been built in the open, because that is literally how
+AIHawk started.
+
+One rule this page keeps, like every page under this parent: no job platform is
+named, and the examples run against generic forms or pages you serve yourself.
+The mechanics are the same everywhere, which is exactly why the generic version
+is worth writing down.
+
+## The naive version, to have something to break
+
+Every attempt starts roughly here: Playwright opens the form, an LLM drafts the
+answers, the script fills and submits.
+
+```python
+from playwright.sync_api import sync_playwright
+
+BACKGROUND = open("background.md").read()   # your real history, as text
+
+def draft(question: str) -> str:
+    # any LLM API; the contract is what matters:
+    # answer from BACKGROUND only, say "ASK" when the answer is not in it
+    ...
+
+with sync_playwright() as p:
+    browser = p.firefox.launch()
+    page = browser.new_page()
+    page.goto("http://127.0.0.1:8000/application-form")  # a page you serve
+    for field in page.locator("form [data-question]").all():
+        answer = draft(field.get_attribute("data-question"))
+        field.fill(answer)
+    page.click("#submit")
+```
+
+On a form you wrote yourself, this works on the first try, which is what makes
+the approach look one weekend wide. The distance between this and a pipeline
+that survives real pages is the rest of this page.
+
+## The four components a real pipeline needs
+
+**Form detection.** Real forms do not label themselves with `data-question`.
+Fields associate with their questions through `<label for>`, `aria-label`,
+`aria-labelledby`, placeholder text, or nothing but visual proximity; required
+markers and error text sit in separate nodes; some forms arrive inside an
+embedded iframe with its own document. Mapping "what is this field asking" to
+"which element do I fill" is a real subproblem, and it is where an LLM earns its
+place: handed the rendered page, a model can read the form the way a person
+does, which is the approach described in
+[getting an AI agent to fill out forms](ai-agent-fill-out-forms.md).
+
+**Answer generation.** The model needs your background as grounding and a
+contract that keeps it honest: every claim from the provided history, an
+explicit escape hatch ("ASK") for questions it cannot answer from it, and no
+improvisation. Tailoring - picking which true things to emphasize for this role
+- is the value. Fabricating qualifications is a bug, and it is one your own
+pipeline will happily ship at scale if the prompt does not forbid it.
+
+**Session persistence.** Applying is logged-in work spread over days. That
+means a persistent browser profile rather than a fresh context per run, so
+cookies and logins survive; it also means the same browser identity each time,
+because a login that hops between fingerprints looks stolen. Plan for a profile
+directory and for state you can resume after a crash mid-wizard.
+
+**Pacing.** The component most builds skip and the first one to matter in
+production. Per-account and per-IP rate limits are real, and a submission every
+few seconds is a signature no fingerprint work can hide. Pacing is jitter
+between actions, minutes between applications, a daily cap, and backoff on
+anything that looks like throttling. It is also the ethical component: the
+volume ceiling is where "my bot" stops being distinguishable from spam, a
+lesson this project's own history documents in detail on
+[the history page](open-source-job-application-bot.md).
+
+## Why naive scripts break
+
+**Multi-step wizards.** Real applications are three to eight steps with state:
+conditional fields that appear based on earlier answers, a review step that
+re-renders everything, a back button that resets more than it should. A script
+that models "the form" as one page loses to the first wizard it meets. You need
+a loop over steps - read, fill, advance, re-read - and idempotent resume,
+because step four is where the timeout happens.
+
+**Client-side validation.** Fields validate on blur and on keystroke; masked
+inputs reformat as you type; selects are custom widgets that only respond to
+real interaction. Setting `element.value` from JavaScript skips the events the
+page listens for, so the value silently fails validation, or arrives empty at
+submit. Fill through real typing and clicking. It is telling that AIHawk's own
+agent, per its README, refuses to set form fields from JavaScript even when it
+would be faster, because a page can tell the difference.
+
+**File uploads.** The resume field is a file input, often behind a styled
+button, sometimes a drag-and-drop zone. Playwright's `set_input_files` covers
+the plain case; the styled cases need the real input located first. And a
+tailored resume means generating a file per application, which is its own
+pipeline stage.
+
+**The anti-bot layer.** This is the wall that surprises builders most, because
+it has nothing to do with your code being correct. Stock automation is
+detectable below your script: driver artifacts, headless tells, a fingerprint
+inconsistent with the claimed platform, a TLS handshake that does not match the
+user agent. No amount of selector work fixes a page that has already decided
+what you are. The mechanism layer - fingerprinting surfaces, detection vendors,
+network tells - is documented in depth on the
+[invisible_playwright wiki](https://github.com/feder-cr/invisible_playwright/wiki),
+and the agent-level symptoms in
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md). If
+you stay on the build-it-yourself road, that engine is usable as a library:
+[invisible_playwright](https://github.com/feder-cr/invisible_playwright) is a
+Firefox patched at the C++ level, driven through the standard Playwright API,
+so the code above ports by changing the launch.
+
+## Or use what exists
+
+Here is the honest close. The pipeline this page describes - form reading,
+grounded answer generation, persistent sessions, pacing, on a browser built to
+look like a real one - is an open-source project you can read instead of
+rediscover. [AIHawk](https://github.com/feder-cr/AIHawk) began in 2024 as
+exactly this Python bot, reached about 30,000 stars and a wave of press
+coverage, and grew into a general web agent on that same hardened engine. It is
+MIT-licensed; run it as an interface with `uvx aihawk ui`, script it headless
+with `uvx aihawk do "..."`, or take just the browser layer as a library and
+keep your own agent logic on top.
+
+Building your own is still a fine choice when the point is learning or when
+your flow is unusual. But go in knowing which parts are the actual work: not
+the form filling, which a weekend gets you, but the wizard state, the
+validation-safe input, the stable identity, and the restraint.
+
+## Conclusion
+
+A real job-application pipeline in Python is four components - form detection,
+grounded answer generation, session persistence, pacing - sitting on a browser
+that can survive being looked at. The naive script fails on multi-step wizards,
+event-driven validation, uploads, and an anti-bot layer that inspects the
+browser underneath your code. All four components, on a hardened engine, exist
+in the open already; whether you build or adopt, the volume ceiling and the
+review-before-submit rule are the parts that keep the pipeline worth running.
+
+## Short answers to the questions that lead here
+
+**Can I automate job applications with Python and Playwright?** Yes, and the
+form-filling part is genuinely easy. The real work is wizard state,
+validation-safe typing, persistent sessions, pacing, and a browser that does
+not advertise itself as automation.
+
+**Which LLM do I need?** Any API model works for answer generation. The prompt
+contract matters more than the model: answers only from your provided
+background, with an explicit "ask the human" escape for anything else.
+
+**Why does my script's input disappear at submit?** You are probably setting
+values from JavaScript, which skips the input events client-side validation
+listens for. Type and click like a user; the value then exists the way the page
+expects.
+
+**Why does my bot get blocked even though the code works?** Detection operates
+below your script: driver artifacts, headless tells, fingerprint and TLS
+inconsistencies. See the
+[invisible_playwright wiki](https://github.com/feder-cr/invisible_playwright/wiki)
+for the mechanism layer; correctness of your Python is not the question being
+asked.
+
+**How fast can I safely go?** Slower than the code allows. Jitter inside a
+form, minutes between applications, a daily cap you would defend out loud.
+Past that ceiling you are building a spam tool with extra steps, and the
+account it burns is yours.
+
+**Is there an open-source version already?** Yes -
+[AIHawk](https://github.com/feder-cr/AIHawk), which started as exactly this
+bot and is now a general web agent on a hardened Firefox. Reading its layout is
+a shortcut even if you then build your own.
+
+## Sources
+
+- The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), retrieved
+  2026-09-03, for the interface and headless commands, the library and MCP
+  layers, the license, and the agent's refusal to set form fields from
+  JavaScript.
+- [404 Media's October 2024
+  report](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/),
+  retrieved 2026-09-03, for what the original bot generation actually did in
+  the field: biographical fill, generated resumes, customized cover letters,
+  unattended volume.
+- This project's own engine documentation, linked throughout, for the
+  fingerprinting and detection mechanics summarized in the anti-bot section.
+
+**See also:** [getting an AI agent to fill out
+forms](ai-agent-fill-out-forms.md) for the form-reading approach in isolation,
+[automating job applications with
+Claude](automate-job-applications-with-claude.md) for the no-code version of
+this pipeline, [the open-source job application bot, and what it
+became](open-source-job-application-bot.md) for where the build-it-yourself
+road led once, and the
+[job application automation hub](guides-job-application-automation.md).
+
+---
+
+*Written by the maintainer of [AIHawk](https://github.com/feder-cr/AIHawk),
+which exists because someone built this exact Python project and then spent two
+years on the parts this page says are the actual work.*

--- a/docs/automate-job-applications-with-chatgpt.md
+++ b/docs/automate-job-applications-with-chatgpt.md
@@ -1,0 +1,197 @@
+---
+title: "Automating job applications with ChatGPT"
+description: "What OpenAI's agent products can and cannot do for application forms as of September 2026, where copy-paste ChatGPT is honestly the better tool, and where an agent with its own browser fits."
+parent: "Job Application Automation"
+nav_order: 2
+---
+
+
+# Automating job applications with ChatGPT
+
+"Automating job applications with ChatGPT" means two different things, and most
+advice mixes them up. One is copy-paste assistance: ChatGPT drafts your tailored
+resume bullets and answers, you do the clicking. That works today, on any plan,
+and for the writing itself it is excellent. The other is agentic automation: an
+OpenAI product driving a browser through the form for you. That second thing has
+existed in four different shapes in twenty months, three of which have already
+been shut down, so the honest version of this page has to start with a timeline.
+
+## What OpenAI's agent products are, as of September 2026
+
+The short history, because which advice applies depends on which month's product
+you read about:
+
+- **Operator** (announced January 2025) was the original: a research preview
+  for Pro subscribers in the US, running a virtual browser in the cloud that
+  could fill forms, place orders, and schedule appointments. It was deprecated
+  when ChatGPT agent launched and shut down on August 31, 2025.
+- **ChatGPT agent / agent mode** (July 2025) absorbed Operator's
+  browser-control into ChatGPT itself: pick agent mode, state the task, and a
+  hosted browser works through it.
+- **ChatGPT Atlas** (October 2025) was a full desktop browser with the agent
+  built in, launched for macOS. It shut down in August 2026, with OpenAI
+  folding browser-based agentic work back into ChatGPT.
+- **ChatGPT Work** (announced July 2026) is the current shape: an agent for
+  multi-step office tasks - documents, spreadsheets, research - with a built-in
+  browser in the desktop app, its usage metered against your plan. Around the
+  same time, per Wikipedia's Operator entry, the older agent mode was removed
+  from ChatGPT and users were pointed at ChatGPT Work and a cloud browser
+  feature.
+
+Two things follow from this churn. First, any tutorial about applying to jobs
+"with Operator" or "in Atlas" describes a product that no longer exists. Second,
+the through-line across all four shapes is the same: a browser OpenAI hosts,
+metered usage, and confirmation prompts before consequential actions. Those
+properties, not the product names, are what decide whether the flow fits.
+
+## Where a hosted agent fits application flows, and where it strains
+
+An application flow has a specific shape: log in to an account that is yours,
+move through a multi-step form, upload a resume file, answer questions that vary
+per posting, and do it again tomorrow without looking like a different person.
+Measured against that shape, a cloud-hosted agent has real friction:
+
+**The session is not really yours.** The browser runs on OpenAI's
+infrastructure. Logging your accounts into it is possible but means handing a
+hosted browser your credentials, and the session identity - cookies, IP,
+fingerprint - lives wherever the product runs, shared infrastructure that sites
+see a lot of. Application platforms are exactly the kind of logged-in,
+rate-limited surface where that matters; the general mechanics are covered in
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md).
+
+**Persistence is not the product's goal.** Applying is a campaign, not a task:
+the same identity, the same logins, across days. Hosted agent sessions are
+task-shaped, and each product transition above reset what carried over.
+
+**Metered usage meets a many-step flow.** A multi-step wizard is dozens of agent
+steps, and hosted-agent usage draws down plan quota. One application is fine.
+Volume is expensive in exactly the way it is with every agent, which is not a
+loss, because volume is the wrong goal anyway - more on that below.
+
+**File uploads and judgment calls.** A tailored resume has to exist as a file
+the hosted browser can reach, and questions about salary, work authorization, or
+self-identification need to stop the run and come back to you. Confirmation
+prompts help here; they are the product behaving correctly, not friction to
+engineer away.
+
+## Where plain ChatGPT is honestly the better tool
+
+For the writing, copy-paste ChatGPT remains hard to beat, and it has none of the
+problems above. Paste your background once, then per posting: paste the
+description, ask for the three bullets of your history most relevant to it, a
+tailored summary, and honest draft answers to the form's long-text questions.
+You click through the form yourself, in your own browser, with your own logins,
+at your own pace - which also means every answer passes through your hands
+before it is submitted.
+
+Keep the same grounding rule that applies to any model doing this work: answers
+come from your real history, and a question the model has no data for is a
+question for you, not an invitation to improvise. Tailoring which true things to
+emphasize is the legitimate craft here. Fabricated qualifications are not a
+gray area, and they surface at the worst possible time: in an interview.
+
+## Where an agent with its own browser fits
+
+The gap between those two options - full manual clicking versus a hosted agent
+that is not really yours - is where an open-source agent running on your own
+machine sits. [AIHawk](https://github.com/feder-cr/AIHawk) is one: the model
+reads the form and drafts the answers, but the browser is a real, patched
+Firefox running locally, with a persistent profile (`--profile-dir`) so logins
+survive restarts, a stable seeded identity (`--seed`) so you look like the same
+machine every day, and your own network exit. You run it either by adding its
+MCP browser to an assistant you already have, or as its own interface:
+
+```bash
+uvx aihawk ui --openrouter-key sk-or-...
+```
+
+That is chat on the left, the live browser on the right, so the watching-it-work
+property of the hosted agents is kept. The model comes from OpenRouter, and
+`--model` takes any OpenRouter model id, so this route is not an
+anti-OpenAI position - it is a different answer to where the browser lives and
+who holds the session. The Claude-side equivalent of this page is
+[automating job applications with Claude](automate-job-applications-with-claude.md).
+
+## The same honesty about pacing
+
+Whatever drives the browser, the volume math does not change, and this project
+is the case study: its original bulk-application bot got written up by 404 Media
+and TechCrunch in October 2024, with The Verge's headline framing the trend as
+job seekers learning to think like spammers. The details are on
+[the history page](open-source-job-application-bot.md), but the conclusion
+transfers whole: sprayed applications replicate errors at scale, read as
+generic, and put a machine signature on an account you presumably want to keep.
+A handful of applications per session, each reviewed before submission, is both
+the safer pattern and the one that actually gets responses.
+
+## Conclusion
+
+As of September 2026, OpenAI's agentic route runs through ChatGPT Work and its
+built-in browser, after Operator, agent mode, and Atlas were each retired in
+turn. A hosted agent can walk an application form, but the session, identity,
+and persistence living on shared infrastructure fit a campaign of logged-in
+applications poorly. Copy-paste ChatGPT is excellent for the writing and leaves
+every submission in your hands. An open-source agent with its own local browser
+covers the middle: automated form work, your machine, your identity, your pace.
+All three routes share one constraint that no product changes - applications
+are worth automating one at a time, not in bulk.
+
+## Short answers to the questions that lead here
+
+**Can ChatGPT apply to jobs for me?** ChatGPT can draft everything and, through
+OpenAI's current agent products, can drive a hosted browser through a form. The
+hosted session, metered usage, and confirmation stops make it fit one careful
+application at a time, not a pipeline.
+
+**What happened to Operator and Atlas?** Operator shut down August 31, 2025,
+absorbed into ChatGPT agent mode; the Atlas browser shut down in August 2026.
+Browser-based agentic work now lives in ChatGPT Work, announced July 2026.
+
+**Is copy-paste ChatGPT enough?** For the writing, usually yes, and it is the
+cheapest and least risky option: tailored bullets and drafted answers, with you
+doing the clicking in your own browser.
+
+**Why would I use an open-source agent instead?** The browser runs on your
+machine: persistent logins, a stable identity across days, your network exit,
+and no per-step draw on a hosted plan. The model still does the reading and
+drafting.
+
+**Can I use OpenAI models with AIHawk?** AIHawk's interface takes any OpenRouter
+model id via `--model`, so you choose the model independently of the browser.
+
+**Will any of this get my account flagged?** Volume and robotic pacing are the
+main self-inflicted risks on a logged-in account, whichever tool you use. Keep
+human pace and review each submission; for the detection layers underneath, see
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md).
+
+## Sources
+
+- [Wikipedia, "OpenAI Operator"](https://en.wikipedia.org/wiki/OpenAI_Operator),
+  retrieved 2026-09-03, for the January 2025 launch, the August 31, 2025
+  shutdown, the absorption into ChatGPT agent, and the 2026 removal of agent
+  mode.
+- [Wikipedia, "ChatGPT Atlas"](https://en.wikipedia.org/wiki/ChatGPT_Atlas),
+  retrieved 2026-09-03, for the October 21, 2025 launch and the August 2026
+  shutdown.
+- [PPC Land, "OpenAI kills Atlas browser, folds it into new ChatGPT Work
+  agent"](https://ppc.land/openai-kills-atlas-browser-folds-it-into-new-chatgpt-work-agent/),
+  retrieved 2026-09-03, for ChatGPT Work's July 2026 announcement, its built-in
+  browser, and its metered usage model.
+- The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), retrieved
+  2026-09-03, for the `uvx aihawk ui` interface, `--model`, `--seed`, and
+  `--profile-dir`.
+
+**See also:** [automating job applications with
+Claude](automate-job-applications-with-claude.md) for the MCP-based setup on the
+Claude side, [automating job applications in
+Python](automate-job-applications-python.md) if you would rather build the
+pipeline yourself, [what is an AI web agent?](ai-web-agent-explained.md) for the
+category this all sits in, and the
+[job application automation hub](guides-job-application-automation.md).
+
+---
+
+*Written by the maintainer of [AIHawk](https://github.com/feder-cr/AIHawk), an
+open-source web agent that started as a job-application bot. Three of the four
+OpenAI products this page describes shut down while it was a going concern,
+which is its own argument for tools you can run yourself.*

--- a/docs/automate-job-applications-with-claude.md
+++ b/docs/automate-job-applications-with-claude.md
@@ -1,0 +1,192 @@
+---
+title: "Automating job applications with Claude"
+description: "Claude Code or Claude Desktop plus an MCP browser gives you an agent that works through application forms while you watch - what that setup does well, what it costs, and the pacing that keeps it from hurting you."
+parent: "Job Application Automation"
+nav_order: 1
+---
+
+
+# Automating job applications with Claude
+
+The current, real answer to "can Claude apply to jobs for me" is: Claude plus an
+MCP browser can work through an application form in front of you, reading each
+question, drafting an answer from your background, and filling it in while you
+watch every step. That is genuinely useful. It is not a fire-and-forget pipeline
+that sprays hundreds of applications overnight, and the second half of this page
+is about why you do not want it to be.
+
+## The setup, honestly
+
+Claude brings the model; you add a browser it can drive. If you use Claude Code,
+the whole setup is one command, run once:
+
+```bash
+claude mcp add -s user stealth -- uvx invisible-playwright-mcp
+```
+
+Claude Desktop and Cursor take a JSON config block instead of a command; the
+block, and which file it goes in, are in the
+[server's README](https://github.com/feder-cr/invisible-playwright-mcp). The
+server exposes a patched Firefox over MCP - the same engine behind
+[AIHawk](https://github.com/feder-cr/AIHawk), which is where this wiki lives.
+
+One thing the first run will not warn you about: the browser is about a quarter
+of a gigabyte and is downloaded on the first request that needs a page, so your
+first instruction sits silent for a while. Fetch it ahead of time, in a terminal
+where you can watch the progress:
+
+```bash
+uvx invisible-playwright fetch
+```
+
+After that, you talk to Claude the way you already do. Give it your background
+first - paste your resume text, or point Claude Code at the file - then open a
+listings page or an application form and ask it to work through it. Everything
+it does appears as a visible tool call: navigate, read the page, type into a
+field, click. You are not trusting a black box; you are supervising an intern
+with a very fast reading speed.
+
+## What Claude is actually good at here
+
+**Reading a form nobody wrote a script for.** Application forms differ on every
+site: different field names, different steps, questions hidden behind dropdowns,
+a resume upload here and a text box asking you to retype the same history there.
+A traditional bot needs selectors written for each variant and breaks when the
+markup changes. Claude reads the rendered page like a person does, so an
+unfamiliar form is just another form.
+
+**Tailoring answers from your background to the question asked.** "Describe a
+project where you led a migration" gets a better answer from a model holding
+your actual history than from a paragraph you pasted into twenty forms. This is
+the honest version of tailoring: choosing which true things to emphasize for
+this role. It is not inventing qualifications, and you should say so in your
+instructions - tell Claude explicitly that every claim must come from the
+background you provided, and that missing information means asking you, not
+improvising.
+
+**Noticing what should stop the process.** A good agent run includes moments
+where Claude halts and asks: this form wants a salary expectation, this question
+is about work authorization, this checkbox is a legal attestation. Those are
+yours. A model that answers them for you is not saving you time, it is signing
+things in your name.
+
+## What it does badly
+
+**Cost per application.** A multi-step wizard means reading each step, reasoning
+about each field, and a tool call per interaction - dozens of model round trips
+for one submission, on your plan or API bill. For one thoughtful application
+that is fine. As a bulk strategy it is an expensive way to get a worse outcome
+than five careful applications would have gotten you.
+
+**Judgment calls it should not make alone.** Compensation, notice periods,
+relocation, visa status, disability and veteran self-identification, references.
+None of these belong to an agent. The workable pattern is: Claude fills the
+factual and narrative fields, then stops and lists everything it left blank and
+why, and you finish the pass yourself.
+
+**Anything it was not told.** A model asked a question it has no data for will
+sometimes produce a plausible answer anyway. That failure mode is exactly the
+one a job application cannot afford. Ground it: full background in, explicit
+"ask, never guess" instruction, and your own read of the filled form before
+anything is submitted.
+
+## The part the media coverage was about
+
+This project's own history is the clearest available evidence on volume, and it
+is worth being straight about. AIHawk started life as a bulk job-application
+bot. In October 2024, 404 Media's Jason Koebler
+[used it to apply to 17 jobs in one hour](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/),
+writing up a user who had let it run to 2,843 applications - the bot entered
+biographical details, generated resumes, wrote customized cover letters, and
+filed the paperwork on its own.
+[TechCrunch covered the same story](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/)
+and called the result a bizarre loop: applicants automating applications while,
+by the figure TechCrunch cited, 42 percent of companies were already using AI to
+screen them, humans increasingly absent from both sides. The Verge's same-day
+piece put the criticism in its headline: AI was enabling job seekers to think
+like spammers.
+
+The criticism was not wrong, and the applicant is who it lands on. Sprayed
+applications carry replicated mistakes at scale, answers that read as generic
+because they are, and a volume signature that platforms throttle and recruiters
+learn to discount. An account that submits forty applications an hour does not
+look like an eager candidate; it looks like what it is.
+
+So the etiquette section of this page is short and unambiguous. Keep a human
+pace: a handful of applications in a session, not a stream. Review every filled
+form before it is submitted - the AIHawk README's own rule is "do not submit
+anything a human has not read," and it applies doubly when Claude did the
+writing. Let quality per application be the metric, because it is the only one
+that ever paid the applicant.
+
+## Conclusion
+
+Claude Code or Claude Desktop plus `invisible-playwright-mcp` gives you an agent
+that can genuinely work an application form: read it, tailor honest answers from
+your background, fill it while you watch, and stop where your judgment is
+required. Used at human pace with a human review before every submit, that is a
+real assist. Used as a spray tool, it recreates the exact behavior this
+project's own press coverage documented the costs of. The setup takes one
+command; the discipline is the part you bring.
+
+## Short answers to the questions that lead here
+
+**Can Claude actually fill out a job application?** Yes. With an MCP browser
+attached, Claude reads the rendered form, types into fields, handles multi-step
+wizards, and shows you each action as it happens. You review and submit.
+
+**Does this work with Claude Desktop, or only Claude Code?** Both, and Cursor
+too. Claude Code takes the one-line `claude mcp add` command; the others take a
+JSON config block documented in the MCP server's README.
+
+**Will Claude write my cover letter and answers?** It will draft them from the
+background you give it, tailored to the posting. Keep it grounded: instruct it
+that every claim must come from your provided history and that gaps mean asking
+you, not inventing.
+
+**How many applications can I do this way?** Technically many; practically you
+should not. Each application costs real model usage, and bulk volume is the
+pattern that damaged applicants in this project's own history. A few careful,
+reviewed applications beat a spray.
+
+**Will the browser get blocked?** The engine is a Firefox patched to look and
+behave like a normal desktop browser, which addresses the fingerprint layer.
+Pacing, account behavior, and your network exit are still yours - see
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md).
+
+**Should Claude answer salary, visa, or self-identification questions?** No.
+Have it stop and list them for you. Those answers bind you; a model should not
+be producing them unsupervised.
+
+## Sources
+
+- The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), retrieved
+  2026-09-03, for the `claude mcp add` setup line, the engine download
+  behavior, and the "do not submit anything a human has not read" rule.
+- [404 Media, "I Applied to 2,843 Roles With an AI-Powered Job Application
+  Bot"](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/),
+  Jason Koebler, retrieved 2026-09-03.
+- [TechCrunch, "Someone claims to have used AI to apply to 2,843
+  jobs"](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/),
+  Kyle Wiggers, October 10 2024, retrieved 2026-09-03, including the 42 percent
+  AI-screening figure it cites.
+- The Verge's October 10 2024 piece is linked from the
+  [project README](https://github.com/feder-cr/AIHawk#readme); the site blocks
+  automated retrieval, so the "think like spammers" phrasing is quoted from its
+  headline as linked there.
+
+**See also:** [automating job applications with
+ChatGPT](automate-job-applications-with-chatgpt.md) for the other assistant's
+side of this, [automating job applications in
+Python](automate-job-applications-python.md) for the build-it-yourself route,
+[the open-source job application bot, and what it
+became](open-source-job-application-bot.md) for the full history this page
+compresses, and [getting an AI agent to fill out
+forms](ai-agent-fill-out-forms.md) for the form mechanics on their own.
+
+---
+
+*Written by the maintainer of [AIHawk](https://github.com/feder-cr/AIHawk),
+which began as the job-application bot in those 2024 headlines and grew into a
+general web agent. The browser and the agent are the easy part now; applying
+like a person is still the part that works.*

--- a/docs/best-ai-browser-agent.md
+++ b/docs/best-ai-browser-agent.md
@@ -1,0 +1,174 @@
+---
+title: "Choosing an AI browser agent"
+description: "The four axes that actually separate AI browser agents - who brings the model, what browser is driven, where it runs, and what happens when a site pushes back - with a short decision path and a declared conflict of interest."
+parent: "Alternatives and Comparisons"
+nav_order: 6
+---
+
+# Choosing an AI browser agent
+
+There is no best AI browser agent, and a page that names one without asking
+about your task is selling something. What exists is a small set of axes on
+which the real tools genuinely differ, and once you place your task on those
+axes the field usually narrows itself to one or two candidates. This page is
+the axes, a short decision path, and the cluster of detailed comparisons
+around it.
+
+The conflict of interest, up front: this is the wiki of
+[AIHawk](https://github.com/feder-cr/AIHawk), an open-source agent that
+appears below as one of the candidates. Every claim about another tool on this
+page and its siblings traces to that tool's own site, repository or
+documentation, retrieved 2026-09-03, and the pages say so where a competitor
+covers more than we do. If you first want the category itself explained,
+start at [what an AI web agent is](ai-web-agent-explained.md).
+
+## Axis 1: who brings the model
+
+Three answers exist, and they sort the field cleanly.
+
+**The vendor brings it.** ChatGPT's agentic browsing and Claude in Chrome run
+on their vendor's models under your subscription. Least setup, least control,
+and the capability lives at the vendor's pleasure - the Operator-to-agent-to-
+removal churn of 2025-2026 is the cautionary tale, told with dates on
+[Is OpenAI Operator still available?](is-openai-operator-still-available.md).
+
+**You bring a key.** browser-use, Skyvern, Agent S3 and AIHawk take an API
+key and let you choose the model. You pay per token, you can switch providers,
+and the agent keeps working when a vendor reorganizes a product line.
+
+**You build the loop.** Claude computer use and OpenAI's
+`computer-use-preview` are API tools: the vendor supplies the model's ability
+to click and type, you supply everything else. Maximum control, real
+engineering cost - the architecture is dissected on
+[OpenAI Operator vs Claude computer use](openai-operator-vs-claude-computer-use.md).
+
+## Axis 2: what browser it drives, and how
+
+This is the axis buyers skip and then rediscover the hard way, because it
+decides what a website sees when it looks back.
+
+- **An extension in your real browser** (ChatGPT's Chrome extension, Claude
+  in Chrome): the browser is genuinely yours, history and all; the agent is
+  bounded by the vendor's safety envelope.
+- **A stock automation build, driven over an automation protocol**
+  (browser-use, Skyvern): the standard stack, with
+  [its own observable characteristics](https://github.com/feder-cr/invisible_playwright/wiki/bidi-vs-cdp-detection)
+  and [a build that is not the retail browser](https://github.com/feder-cr/invisible_playwright/wiki/chromium-is-not-chrome).
+- **A screenshot loop over a whole desktop** (Agent S3, Claude computer use):
+  most general, heaviest per action -
+  [DOM reading versus pixel reading is a real fork](https://github.com/feder-cr/invisible_playwright/wiki/dom-reading-vs-screenshot-agents).
+- **A browser modified at the source level** (AIHawk's engine): a Firefox
+  patched in C++ to present a normal desktop fingerprint, with identity
+  derived from a seed so runs replay. This is our approach, and the axis where
+  we have something the others do not; the mechanics live on the
+  [engine wiki](https://github.com/feder-cr/invisible_playwright/wiki/do-websites-know-you-are-using-a-script)
+  rather than in adjectives here.
+
+## Axis 3: where it runs
+
+On your machine, in the tool's cloud, or in the vendor's product. Local runs
+keep data and credentials with you and cost only tokens; clouds (Browser Use
+Cloud, Skyvern Cloud) sell scale and management; vendor products keep both
+the model and the environment. One non-obvious note for local runs: the
+machine itself answers some of a website's questions, and
+[a bare server answers them badly](https://github.com/feder-cr/invisible_playwright/wiki/headless-browser-agent-on-a-server).
+
+## Axis 4: what happens when a site pushes back
+
+The axis nobody's landing page volunteers. Some sites challenge automated
+visitors, and how a tool degrades matters more than how it demos.
+
+Be clear about what is whose: the browser's fingerprint and build are the
+tool's responsibility; the IP's reputation, the account's standing, and the
+pacing of requests are yours, whatever tool you run. No agent on this page,
+ours included, guarantees passage anywhere, and a tool that promises you will
+never be blocked is describing a world with no defenders in it. AIHawk's
+position on this axis is a hardened, real-fingerprint browser plus documented
+limits, not a guarantee. The sorting of blame - and what to actually do -
+is [why an agent gets blocked](why-does-my-ai-agent-get-blocked.md), and
+[the timing signal specific to agents](https://github.com/feder-cr/invisible_playwright/wiki/ai-agent-timing-signal)
+is worth reading before blaming any browser.
+
+Also on this axis: whether you should be automating the site at all. Terms of
+service, rate limits, and a human reviewing anything submitted are your job,
+not the tool's.
+
+## The decision path
+
+1. **Occasional tasks, already paying a vendor?** Use that vendor's browsing
+   agent (ChatGPT's, or Claude in Chrome). Stop here.
+2. **Need the agent as software you control?** Open source, your key. Go on.
+3. **Does the task leave the browser for the desktop?** Agent S3. See
+   [open-source computer-use agents](computer-use-agent-open-source.md).
+4. **Is it browser-only and the default stack works on your target?**
+   browser-use - biggest ecosystem, reasonable default. Its trade-offs:
+   [browser-use alternatives](browser-use-alternatives.md).
+5. **Layouts churn and break flows?** Skyvern's vision-first approach.
+6. **The browser itself is being recognized, you need runs to replay, or you
+   want the agent inside Claude Code / Claude Desktop / Cursor via MCP?**
+   AIHawk - noting we are the ones saying it, and that it is Windows/Linux
+   only.
+7. **Still tied?** Run the finalists on your real task for an afternoon each.
+   Every open tool here installs in one command; the trial costs less than
+   choosing wrong.
+
+## The cluster around this page
+
+The detailed comparisons this hub summarizes:
+
+- [OpenAI Operator alternatives](openai-operator-alternatives.md) - the full
+  field, hosted and open, after Operator's shutdown.
+- [Open-source Operator-style agents](openai-operator-open-source.md) - repo
+  by repo, with stars, licenses and the "open operator" name collisions.
+- [Is OpenAI Operator still available?](is-openai-operator-still-available.md) -
+  the verified 2025-2026 timeline: Operator, agent mode, Atlas.
+- [OpenAI Operator vs Claude computer use](openai-operator-vs-claude-computer-use.md) -
+  the two big-vendor architectures, one of which no longer exists.
+- [browser-use alternatives](browser-use-alternatives.md) - the category
+  leader's real trade-offs, without invented grievances.
+- And around the cluster:
+  [open-source AI browser agents](ai-browser-agent-open-source.md),
+  [agents versus traditional scraping](ai-browser-agents-vs-traditional-scraping.md),
+  and [what an AI web agent is](ai-web-agent-explained.md).
+
+## Short answers to the questions that lead here
+
+**What is the best AI browser agent in 2026?** For most people starting cold:
+browser-use, on ecosystem size. The word "best" stops meaning anything the
+moment your task hits one of the four axes above, which is what the decision
+path is for.
+
+**Are the vendor agents (ChatGPT, Claude) better than open source?** They are
+more convenient and more bounded. Open agents are yours: your key, your
+machine, your code, and no product-line reorg can remove them - which 2026
+demonstrated is not hypothetical.
+
+**Which agent is undetectable?** None, and the claim itself is a red flag.
+Tools differ in what the browser presents; the IP, account and pacing remain
+yours. See [why an agent gets blocked](why-does-my-ai-agent-get-blocked.md).
+
+**Do I need an AI agent at all, or just a scraper?** If the task needs
+judgment about what is on the page, an agent. If it is the same extraction
+repeated, [a script is cheaper and faster](ai-browser-agents-vs-traditional-scraping.md).
+
+**What does an open-source agent cost to run?** The software is free; model
+tokens are the cost. Screenshot-heavy approaches spend more tokens per action
+than DOM-reading ones - that is an architecture property, not a pricing table.
+
+**Why should I trust a buyer's guide written by a vendor?** You should not,
+on faith. Trust the links: every factual claim traces to the named tool's own
+material, and the disclosure is at the top instead of the bottom.
+
+## Sources
+
+- The [browser-use](https://github.com/browser-use/browser-use), [Skyvern](https://github.com/Skyvern-AI/skyvern), [Agent-S](https://github.com/simular-ai/Agent-S) and [AIHawk](https://github.com/feder-cr/AIHawk) repositories, retrieved 2026-09-03.
+- [Anthropic: computer use tool documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool), retrieved 2026-09-03, and coverage of Claude in Chrome's general availability surfaced via search the same day.
+- [Wikipedia: OpenAI Operator](https://en.wikipedia.org/wiki/OpenAI_Operator), retrieved 2026-09-03, and [OpenAI help: Evolving Atlas into ChatGPT](https://help.openai.com/en/articles/20001371-evolving-atlas-into-chatgpt-for-browser-based-agentic-work), surfaced via search 2026-09-03, for the vendor-churn timeline the first axis leans on.
+- [OpenAI computer use guide](https://platform.openai.com/docs/guides/tools-computer-use), surfaced via search 2026-09-03.
+
+---
+
+*Written while maintaining [AIHawk](https://github.com/feder-cr/AIHawk), an
+open-source AI web agent with an obvious stake in step 6 of the decision path.
+The guide above is the one we would want handed to us, which is why steps 1
+through 5 point somewhere else.*

--- a/docs/browser-use-alternatives.md
+++ b/docs/browser-use-alternatives.md
@@ -1,0 +1,169 @@
+---
+title: "browser-use alternatives"
+description: "browser-use is the category leader and deserves it. The verified reasons people still look past it - Chromium-only scope, the CDP detection surface, a cloud-shaped roadmap - and what actually sits next to it."
+parent: "Alternatives and Comparisons"
+nav_order: 5
+---
+
+# browser-use alternatives
+
+Start with the part a page like this usually buries: browser-use is good. It
+is the most adopted open-source browser agent by a wide margin - roughly 112k
+GitHub stars when read on 2026-09-03, MIT licensed, actively developed, backed
+by a $17M seed round in March 2025, with support for multiple model providers
+under your own keys. If you have no specific reason to look elsewhere, it is
+the reasonable default, and nothing below changes that.
+
+This page is for people who do have a specific reason. It goes through the
+reasons that are real and verifiable, then the alternatives, one of which is
+ours: this wiki belongs to [AIHawk](https://github.com/feder-cr/AIHawk), so
+read the comparison knowing who wrote it. No claim here about browser-use goes
+beyond what its own repository and configuration surface show.
+
+## The verified reasons people look for an alternative
+
+### It is Chromium-family only
+
+browser-use drives a Chromium-family browser, and its configuration surface
+says so structurally: the browser-profile code is Chrome logic - locating a
+Chrome executable, deriving Chrome user-data directories, Chromium channel
+types. There is no Firefox path. That is a coherent engineering choice, not a
+flaw, but it means every browser-use session inherits the Chromium automation
+stack whole: the same build type, the same driving protocol, the same
+well-studied tells. If your problem is specifically that this stack is being
+recognized, no browser-use setting reaches it. The mechanics are documented on
+the engine wiki:
+[what browser-use configuration can and cannot change](https://github.com/feder-cr/invisible_playwright/wiki/browser-use-detection)
+and [why a bundled Chromium is not Chrome](https://github.com/feder-cr/invisible_playwright/wiki/chromium-is-not-chrome).
+
+### The detection surface, and where it actually lives
+
+The most common shape of the complaint is "works on my laptop, challenged on
+the server". That is usually not browser-use's fault: a server has no GPU, a
+container font set, no audio device, and an IP with a datacenter reputation,
+and no agent framework fixes machine-level facts. But the parts that are the
+stack's own - a stock automation build, driven over CDP, with
+[the protocol itself observable in ways a page can probe](https://github.com/feder-cr/invisible_playwright/wiki/bidi-vs-cdp-detection) -
+travel with browser-use wherever it runs. Before switching tools over this,
+read [why an agent gets blocked](why-does-my-ai-agent-get-blocked.md) and
+attribute your failure correctly; switching agents does not change your IP.
+
+### The center of gravity is moving cloudward
+
+The project's README today gives most of its space to Browser Use Cloud: a
+hosted agent with rotating egress, integrations, persistence, and a unified
+API key that also unlocks the company's own optimized models. Reasonable
+business, genuinely useful for teams that want managed scale. But if you came
+to open source to keep the agent local, keyed to providers you chose, some of
+the ecosystem's energy is now pointed somewhere you do not want to go. The
+open MIT core still works standalone; you should just know which direction
+the wind blows.
+
+### What is not on this list
+
+No invented grievances: we found no verified problem with browser-use's agent
+quality, its maintenance tempo, or its community, and its issue tracker is the
+normal noise of a project its size. If someone tells you browser-use is
+"broken" or "always detected", ask for the same specificity this page tries
+to practice.
+
+## The first alternative is configuring browser-use better
+
+Boundary honesty: if you are on browser-use and mostly happy, try its own
+levers before switching. Point `executable_path` at a real installed Chrome
+rather than the bundled build, and give `user_data_dir` a profile with real
+history - the second one addresses the thing hardest for any fresh browser to
+fake, which is having existed yesterday.
+[What a persistent profile fixes and breaks](https://github.com/feder-cr/invisible_playwright/wiki/persistent-profiles)
+covers the trade. If that clears your problem, keep the ecosystem you already
+know and close this tab.
+
+## The alternatives, honestly labeled
+
+**Skyvern** ([repo](https://github.com/Skyvern-AI/skyvern), ~23k stars,
+AGPL-3.0). Vision-LLM driven workflows on Playwright: it reads the rendered
+page rather than depending on selectors, which trades token cost for
+resilience to layout changes. Still Chromium underneath, so it is an
+alternative agent, not an alternative detection surface. Mind the AGPL if you
+embed it.
+
+**Agent S3** ([repo](https://github.com/simular-ai/Agent-S), ~12k stars,
+Apache-2.0). A different scope entirely: an open computer-use framework that
+operates the whole desktop, reporting 72.6% on OSWorld. If your automation
+keeps leaving the browser for spreadsheets and dialogs, this is the switch
+that actually addresses it.
+
+**AIHawk** ([repo](https://github.com/feder-cr/AIHawk), ~30k stars, MIT) -
+ours. The differentiator against browser-use is the browser, not the agent
+loop: AIHawk drives a Firefox patched at the C++ level (the
+invisible_playwright engine), a real browser presenting a normal desktop
+fingerprint, rather than a stock automation build driven over CDP. Identity is
+derived from a seed, so a failing run replays exactly. It plugs into an MCP
+assistant you already run (Claude Code, Claude Desktop, Cursor) or runs its
+own local UI with an OpenRouter key.
+
+Where browser-use covers more, plainly: it has several times our community
+and integrations, it supports macOS and we do not (Windows and Linux only),
+its cloud exists if you want managed scale and we have none, and its
+documentation surface for the agent loop is larger. And the hardened browser
+is an advantage only where the browser was your problem: it does not repair
+an IP's reputation, robotic pacing, or a site's rate limits, and we make no
+promise of non-detection anywhere - the engine wiki documents
+[how to test the difference yourself](https://github.com/feder-cr/invisible_playwright/wiki/how-to-test-bot-detection)
+rather than asking you to believe a claim.
+
+## How to decide in one pass
+
+- **Happy with browser-use, occasional challenge pages:** real Chrome binary,
+  used profile, better egress. Stay.
+- **Layouts keep breaking your flows:** Skyvern.
+- **The task leaves the browser:** Agent S3.
+- **The browser itself is what gets recognized, or you want the agent inside
+  your MCP assistant, or you need runs to replay deterministically:** AIHawk,
+  conflict of interest noted.
+- **You want a hosted service:** Browser Use Cloud or Skyvern's cloud - both
+  vendors' own material describes them; we did not test either.
+
+## Short answers to the questions that lead here
+
+**What is the best alternative to browser-use?** Wrong axis. Skyvern changes
+the perception approach, Agent S3 changes the scope, AIHawk changes the
+browser. Pick by which of those three is your actual problem.
+
+**Does browser-use work with Firefox?** Its configuration expects a
+Chromium-family browser; the profile and channel machinery is Chrome logic.
+If you need Firefox, you need a different stack.
+
+**Is browser-use detectable?** Any automation stack is a set of observable
+choices, and a stock Chromium over CDP is the most-studied set there is. But
+most "detected" reports are machine and IP facts no framework fixes.
+Attribute first, switch second.
+
+**Is browser-use free?** The MIT core is. Model tokens cost whatever your
+provider charges, and the cloud is a paid product.
+
+**Is AIHawk better than browser-use?** Not in general, and this is our own
+wiki saying so. It is better specifically where a real-fingerprint Firefox
+and reproducible identity matter, and worse on ecosystem size, macOS, and
+managed hosting.
+
+**See also:** [Choosing an AI browser agent](best-ai-browser-agent.md) for
+the full decision framework,
+[OpenAI Operator alternatives](openai-operator-alternatives.md) for the
+hosted end of the field, and
+[AI browser agents vs traditional scraping](ai-browser-agents-vs-traditional-scraping.md)
+for whether you need an agent at all.
+
+## Sources
+
+- The [browser-use repository](https://github.com/browser-use/browser-use), retrieved 2026-09-03: stars, license, description, model support and the cloud material.
+- [SiliconANGLE: Browser Use raises $17M](https://siliconangle.com/2025/03/23/browser-use-raises-17m-help-steer-ai-agents-internet/), surfaced via search 2026-09-03.
+- The [invisible_playwright wiki's browser-use configuration analysis](https://github.com/feder-cr/invisible_playwright/wiki/browser-use-detection), which reads `BrowserProfile`'s fields from browser-use's own source; our sibling project, maintained by us.
+- The [Skyvern](https://github.com/Skyvern-AI/skyvern), [Agent-S](https://github.com/simular-ai/Agent-S) and [AIHawk](https://github.com/feder-cr/AIHawk) repositories, retrieved 2026-09-03.
+
+---
+
+*Written while maintaining [AIHawk](https://github.com/feder-cr/AIHawk), a
+direct competitor to the tool this page is about. That is why the first
+section praises browser-use, the second tells you how to stay on it, and every
+critical claim points at its own repository.*

--- a/docs/browser-use-getting-blocked.md
+++ b/docs/browser-use-getting-blocked.md
@@ -1,0 +1,191 @@
+---
+title: "browser-use getting blocked: what you can and cannot change"
+description: "What browser-use's BrowserProfile can actually change when the agent gets blocked, what no configuration reaches, the agent-rhythm tell, and the MCP route to a different engine."
+parent: "When the Agent Gets Blocked"
+nav_order: 5
+---
+
+
+# browser-use getting blocked: what you can and cannot change
+
+If your browser-use agent works on your laptop and gets challenge pages on a server,
+the problem is usually not the agent and not the prompt. It is the browser it drives
+and the machine that browser runs on - and only some of that is reachable from
+configuration.
+
+This page is the sorted version: what `BrowserProfile` actually exposes, which of
+those settings are worth using, what no setting can reach, the tell that is specific
+to agent-driven sessions, and the honest answer about swapping in a different
+engine. All of the browser-use specifics below were re-checked against
+`browser_use/browser/profile.py` on 2026-09-03.
+
+## What browser-use gives you to change
+
+`BrowserProfile` is browser-use's configuration surface: a template of launch and
+context arguments handed to the browser session. The fields that matter for blocks:
+
+| Field | What it does |
+|---|---|
+| `executable_path` | which browser binary to launch - documented as a Chromium-based executable |
+| `channel` | a Chromium channel: `chromium`, `chrome`, the beta/dev/canary variants, the Edge variants |
+| `user_data_dir` | a persistent profile directory |
+| `proxy` | proxy settings (server, bypass, username, password) |
+| `headless` | headless or headed |
+| `args` | extra command-line arguments |
+| `cdp_url` | attach to an already-running browser over CDP instead of launching one |
+
+That is a real set of levers, and two of them are worth more than people use them
+for.
+
+### Point `executable_path` at your real Chrome
+
+The field expects a Chromium-family browser - every value in the `channel` enum is
+Chromium, Chrome or Edge, and there is no Firefox among them. Its practical use is
+pointing at your installed Chrome rather than the bundled test Chromium.
+[Those are not the same browser](https://github.com/feder-cr/invisible_playwright/wiki/chromium-is-not-chrome):
+the codec set differs, the branding differs, and a real Chrome install is a far more
+common thing to be than a bundled build.
+
+### Give `user_data_dir` a past
+
+Pointing this at a profile that has genuinely been used is the single
+highest-value change available in the configuration, because it is the only one
+that addresses history rather than hardware. An agent starting from an empty
+profile is a browser that has never been anywhere, which is
+[most of why a fresh browser scores badly](https://github.com/feder-cr/invisible_playwright/wiki/recaptcha-v3-score).
+The traps - profile lock-in, pairing the profile with a consistent identity - are
+covered in
+[what a persistent profile fixes and breaks](https://github.com/feder-cr/invisible_playwright/wiki/persistent-profiles).
+
+One thing not to over-credit: browser-use's default launch arguments already include
+automation masking (`--disable-blink-features=AutomationControlled` and related
+flags). That hides the crudest driver marker; it is surface-level, and it does
+nothing for anything in the next section.
+
+## What no configuration reaches
+
+Everything about the machine. None of the fields above changes any of these, and on
+a server all of them are true at once:
+
+- **No GPU**, so WebGL reports
+  [a software renderer](https://github.com/feder-cr/invisible_playwright/wiki/webgl-renderer-strings).
+- **A container font set** that
+  [does not match the claimed platform](https://github.com/feder-cr/invisible_playwright/wiki/headless-fonts-differ).
+- **No audio device**, so
+  [the audio values fall back to defaults](https://github.com/feder-cr/invisible_playwright/wiki/audiocontext-fingerprinting).
+- **A screen with no taskbar** and
+  [a default resolution](https://github.com/feder-cr/invisible_playwright/wiki/screen-size-headless-tells).
+- **Codec support** that
+  [describes a slim build rather than a desktop install](https://github.com/feder-cr/invisible_playwright/wiki/codec-fingerprinting).
+- **A TLS handshake**
+  [decided by the network stack before any page-level setting exists](https://github.com/feder-cr/invisible_playwright/wiki/ja3-ja4-tls-fingerprint).
+
+This is why "works on my laptop, blocked in Docker" is the most common shape of the
+problem: the agent is identical in both places, and the machine is not.
+[The container version of the list](https://github.com/feder-cr/invisible_playwright/wiki/playwright-docker-detection)
+goes through it in order.
+
+## The tell that is specific to agent-driven sessions
+
+browser-use sessions carry one signal ordinary scraping does not: the rhythm of the
+think-act loop. The agent reads the page, calls a model, waits, then acts - so its
+pauses cluster around model latency rather than reading speed, its pointer is still
+during the pause, its actions land dead centre because coordinates come from page
+structure rather than a hand, and it wastes no actions. No stealth setting in any
+framework fixes this, because it is produced above the browser.
+[The timing signal has its own page](ai-agent-timing-signal.md).
+
+It also gives you the cheapest diagnostic there is: note *when* the block arrives. A
+block at the first page load points at the machine or the address - the lists above.
+A block that arrives after a few interactions points at behaviour or volume, and
+[an agent's retry loop is usually the volume half](agent-retry-loops-rate-limits.md).
+
+## Can I use a stealth Firefox with browser-use?
+
+No, and it is better to say so plainly than to hand you a workaround that does not
+work. browser-use drives its browser over the Chrome DevTools Protocol - the
+configuration even exposes `cdp_url` for attaching to a running one - and its
+executable and channel handling is Chromium-only. A Firefox binary in
+`executable_path` is not a drop-in: the driver would be speaking a protocol the
+browser does not implement.
+
+The route that does accept a different engine is MCP, where the browser is a set of
+tools rather than a CDP endpoint. Microsoft's
+[Playwright MCP server](https://playwright.dev/docs/getting-started-mcp) takes
+`--browser=firefox` (checked 2026-09-03), and
+[invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp)
+goes further: it ships a Firefox patched at the C++ level as the engine behind its
+tools, so an MCP-speaking assistant - Claude Code, Claude Desktop, Cursor - drives a
+browser whose fingerprint is set in its own source. Disclosure: that server and
+this wiki have the same maintainer, and it is the route
+[AIHawk](https://github.com/feder-cr/AIHawk) is built on.
+
+State the trade fairly, because it is a real one: going to MCP means leaving
+browser-use's agent loop and using an MCP-capable agent instead. Which side of the
+trade matters depends on where your blocks come from - the first-load-versus-
+after-interactions test above tells you. If your blocks are machine-shaped, the
+engine matters and MCP is the door to a different engine. If they are
+rhythm-shaped or volume-shaped, no engine swap will save you, in browser-use or
+anywhere else.
+
+## Conclusion
+
+browser-use exposes enough configuration to fix the two things configuration can
+fix: which browser binary runs, and whether the profile has a past. Point it at a
+real Chrome and a used profile and you have taken the available wins. Everything
+else divides into two piles. The machine-level tells are shared with every
+automation tool and are fixed by changing the machine or the engine - neither of
+which is a browser-use setting, and the engine route runs through MCP, not through
+`executable_path`. The agent-rhythm and volume tells are specific to agents and are
+not fixed by any fingerprint work at all. One observation - when does the block
+arrive? - tells you which pile you are in.
+
+## Short answers to the questions that lead here
+
+**Why is my browser-use agent blocked on a server but not locally?** Because the
+server has no GPU, few fonts, no audio device and a default screen, and the agent
+is identical in both places. The machine changed, not the code.
+
+**Can I set a custom browser in browser-use?** Yes: `executable_path` in
+`BrowserProfile`, and it expects a Chromium-family binary. Pointing it at your real
+installed Chrome rather than the bundled Chromium is worth doing.
+
+**Can I use a stealth Firefox with browser-use?** No. It drives over CDP and its
+browser handling is Chromium-only. The route that accepts a different engine is
+MCP, with a different agent on top.
+
+**Does a persistent profile help?** Yes, more than most settings, because it is the
+only one that gives the browser a history. Read the traps first.
+
+**Why do blocks arrive after a few actions rather than immediately?** That points
+at behaviour or volume rather than fingerprint: the agent's rhythm and its retry
+traffic are both visible only once it starts acting.
+
+**Does adding a proxy fix it?** It changes where you come from, and that is all. If
+the browser is announcing a server through its GPU, fonts and screen, the address
+was not the problem.
+
+## Sources
+
+- `browser_use/browser/profile.py` on the browser-use main branch, retrieved
+  2026-09-03: the `BrowserProfile` fields in the table above, the Chromium-only
+  `channel` values, `executable_path` documented as a Chromium-based executable,
+  `cdp_url`, and the automation-masking default launch arguments.
+- [Playwright's MCP documentation](https://playwright.dev/docs/getting-started-mcp),
+  retrieved 2026-09-03, which lists `firefox` among the supported `--browser`
+  values - confirming the MCP route, unlike browser-use, is not Chromium-only.
+- The machine-level surfaces are each documented on their own engine-wiki page,
+  linked inline above.
+
+**See also:** [the timing signal AI agents give off](ai-agent-timing-signal.md) and
+[agent retry loops and rate limits](agent-retry-loops-rate-limits.md) for the two
+agent-specific tells, [why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md)
+for the order to check things in, and [browser-use alternatives](browser-use-alternatives.md)
+for the wider landscape.
+
+---
+
+*Written while maintaining [AIHawk](https://github.com/feder-cr/AIHawk), which runs
+on the patched-Firefox engine described above. This page says that engine does not
+fit browser-use, because it does not, and a guide claiming otherwise would waste
+your afternoon.*

--- a/docs/claude-computer-use-detected-as-bot.md
+++ b/docs/claude-computer-use-detected-as-bot.md
@@ -1,0 +1,186 @@
+---
+title: "Claude computer use detected as a bot"
+description: "Claude computer use skips the usual automation flags because it clicks by pixel. What still gets it caught - the machine's fingerprint, the IP, the screenshot-click rhythm - and what helps, in order."
+parent: "When the Agent Gets Blocked"
+nav_order: 4
+---
+
+
+# Claude computer use detected as a bot
+
+If Claude computer use is getting challenge pages or blocks, the cause is almost
+certainly not the thing most bot-detection advice tells you to check. A
+coordinate-clicking agent never sets off the classic automation flags, because it
+never does the things those flags detect. What catches it is underneath and around
+it: the fingerprint of the machine it runs on, the address it comes from, and the
+rhythm of its screenshot-click loop.
+
+This page goes through those in order - what the tool actually does on a page, why
+the usual flags stay silent, what still gives it away, and what helps, ranked by how
+much it moves.
+
+## How computer use acts on a page
+
+Claude's computer use tool works on screenshots and coordinates, and on nothing
+else. The loop, per Anthropic's own documentation (retrieved 2026-09-03): your
+application sends Claude a screenshot, Claude returns coordinate-based actions -
+`left_click` at `[x, y]`, `type`, `key`, `scroll`, `wait` - your application
+executes them on the actual desktop, and the loop repeats. Coordinates are in the
+pixel space of the screenshot. The current toolset is `computer_toolset_20260801`.
+
+Two details in that design matter for detection. First, the tool does not read the
+DOM, parse HTML, or use an accessibility tree - it is purely visual. Second, *your
+application executes the actions*: Anthropic's side returns intentions, and the code
+that turns them into real mouse and keyboard events is yours, which will matter
+later when we get to pacing.
+
+## The tells it skips
+
+Most advice about detected automation targets the DOM-automation layer:
+[`navigator.webdriver`](https://github.com/feder-cr/invisible_playwright/wiki/navigator-webdriver-explained),
+leftover automation globals, untrusted events dispatched from script, form fields
+set from JavaScript. Those signals exist because a selector-driven script reaches
+into the page and touches elements directly.
+
+A computer-use agent does none of that. It never calls `querySelector`, never sets a
+value from script, never dispatches a synthetic event at a node it located in the
+DOM. Its click is a coordinate delivered through the input pipeline the way a real
+click is. So that whole family of flags is not what catches it - not because
+anything is hidden, but because the agent never generates them in the first place.
+
+That is where people go wrong. They read that coordinate agents dodge the automation
+flags and conclude detection is solved. It is not solved; it is bypassed at one
+layer, and two other layers are completely untouched by that fact.
+
+## What still gives it away
+
+### 1. The machine it runs on
+
+The agent clicks by pixel, but the click still lands in a browser, and that browser
+answers JavaScript. The site's own scripts still ask the engine what it is: the
+WebGL renderer string, the canvas hash, the fonts, the screen geometry, the audio
+stack. None of that goes through the DOM the agent avoids.
+
+And look at where computer use typically runs. Anthropic's docs recommend a
+dedicated virtual machine or container with minimal privileges, and the reference
+implementation is containerized (both retrieved 2026-09-03). Sensible for safety -
+and a container answers the machine questions like a container:
+[a software WebGL renderer](https://github.com/feder-cr/invisible_playwright/wiki/webgl-renderer-strings),
+[a slim font set that does not match the claimed platform](https://github.com/feder-cr/invisible_playwright/wiki/headless-fonts-differ),
+a virtual display with
+[a screen geometry no desktop has](https://github.com/feder-cr/invisible_playwright/wiki/screen-size-headless-tells).
+The whole list is on the engine wiki's
+[container detection page](https://github.com/feder-cr/invisible_playwright/wiki/playwright-docker-detection).
+The vision model driving the session is state of the art; the browser it is clicking
+in reports a server.
+
+### 2. The address
+
+A datacenter IP is distrusted before the first byte of JavaScript runs, and no
+property of the agent or the browser changes that. If the container from the
+previous section is in a cloud, both tells arrive together.
+
+### 3. The screenshot-click rhythm
+
+The loop has a shape: screenshot, a pause while the model reads the image and
+decides, then the action, then another screenshot. The pause is inference latency,
+not human hesitation, so it repeats with a regularity no person produces. And when
+the model returns several actions in one reply - the API supports batches, executed
+sequentially in order - they land as a rapid chain with no reading time between
+them. This is the general agent-timing problem, and it has
+[a page of its own here](ai-agent-timing-signal.md).
+
+## What actually helps, in order
+
+1. **Put a real-looking machine under the agent.** This is the biggest lever,
+   because the machine fingerprint is checked on every page and cannot be configured
+   away from inside a stock build on a server. Either run the desktop on hardware
+   that genuinely looks like a desktop, or give the model a browser whose identity
+   is set in its own source. The second route exists today over MCP: instead of
+   screenshotting a whole desktop, Claude Code, Claude Desktop or Cursor can drive a
+   Firefox patched at the C++ level as a set of tools, via
+   [invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp) -
+   one line for Claude Code: `claude mcp add -s user stealth -- uvx
+   invisible-playwright-mcp`. Disclosure: that server and this wiki have the same
+   maintainer, and it is the route [AIHawk](https://github.com/feder-cr/AIHawk)
+   itself uses. For staying with the screenshot loop instead, the engine wiki shows
+   [how to back a computer-use agent with a real browser engine](https://github.com/feder-cr/invisible_playwright/wiki/back-computer-use-agent-real-browser).
+2. **Fix the exit.** A clean, residential-quality address, with the browser's
+   timezone and locale agreeing with it. A perfect machine on a distrusted address
+   still loses.
+3. **Pace the executor.** Remember that your code executes the actions. That is
+   where jitter lives: vary the delay before each action, do not fire a batch of
+   actions back to back, and use the tool's own `wait` action between steps of a
+   long task. This narrows the rhythm tell; it does not remove it, because the
+   think-pause is still model latency.
+4. **Do not let it retry into a wall.** A blocked step retried immediately, at
+   machine speed, converts a behaviour flag into a volume flag.
+   [Retry loops are their own failure mode](agent-retry-loops-rate-limits.md).
+5. **Test like a site does.** Open a fingerprinting page in the agent's browser and
+   in a normal browser on a normal machine, and compare field by field - and run it
+   ten times, not once, because verdicts in this domain are not deterministic.
+
+## Conclusion
+
+Claude computer use moves the detection problem; it does not remove it. The
+DOM-automation flags that dominate bot-detection advice are silent for it, because a
+pixel click never produces them. What remains is the machine it runs on - usually a
+container that answers like one - the address in front of it, and the machine-regular
+rhythm of the screenshot-click loop. Fix them in that order: a real engine under the
+agent, a clean exit, pacing in the executor, and a hard look at your retry
+behaviour. Handle all of them and the agent looks like a person at a real computer.
+Handle none and you have a brilliant model piloting an obvious server.
+
+## Short answers to the questions that lead here
+
+**Why is Claude computer use detected as a bot?** Usually the machine and the
+address, not the automation. A container or server answers WebGL, font and screen
+checks like a server, and a datacenter IP is distrusted on sight. The
+screenshot-click rhythm adds a behaviour tell on top.
+
+**Does Claude computer use set `navigator.webdriver`?** The tool itself does not
+touch the page's JavaScript at all - it sends screenshots and coordinates. Whether
+that flag is set depends on the browser you point it at; a stock automated build
+sets its own flags regardless of who clicks.
+
+**Can a site tell clicks come from Claude?** Not from the click mechanism, which
+goes through the real input pipeline. What is visible is the rhythm: pauses centred
+on model latency, batches of actions landing with no reading time between them.
+
+**Does a better model fix detection?** No. The model chooses actions; detection
+reads the machine, the address and the timing. Those do not improve with model
+quality.
+
+**What is the single highest-value fix?** The machine. Give the agent a browser that
+reports a real desktop - via MCP with a patched engine, or by running on hardware
+that is what it claims to be - before spending anything on the rest.
+
+**Will that make it undetectable?** No, and distrust anyone who promises that. It
+removes the machine fingerprint from the list of tells; the address, the volume and
+the rhythm remain yours to manage.
+
+## Sources
+
+- Anthropic's [computer use tool documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool),
+  retrieved 2026-09-03: the screenshot-to-coordinate loop, the
+  `computer_toolset_20260801` action set, coordinates in screenshot pixel space,
+  batch actions executed sequentially, the recommendation to run in a dedicated VM
+  or container, and the fact that the caller's application executes the actions. The
+  containerized reference implementation is
+  [anthropic-quickstarts/computer-use-demo](https://github.com/anthropics/anthropic-quickstarts/tree/main/computer-use-demo).
+- The engine wiki's machine-fingerprint pages linked above, which document each
+  surface a container exposes and how it is read.
+
+**See also:** [the timing signal AI agents give off](ai-agent-timing-signal.md) for
+the rhythm tell in depth,
+[browser-use getting blocked](browser-use-getting-blocked.md) for the contrasting
+case of a DOM-driven agent, and
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md) for the
+full sort.
+
+---
+
+*Written while maintaining [AIHawk](https://github.com/feder-cr/AIHawk), an AI agent
+on a Firefox patched at the C++ level. The pattern in this page - clean automation
+layer, guilty machine - is the single most common thing behind "my agent got
+detected", whoever's agent it is.*

--- a/docs/computer-use-agent-open-source.md
+++ b/docs/computer-use-agent-open-source.md
@@ -1,0 +1,185 @@
+---
+title: "Open-source computer-use agents"
+description: "The open-source agents that see pixels and click coordinates - UI-TARS, Cua, Agent S, self-operating computer - and how the category differs from browser agents."
+parent: "Alternatives and Comparisons"
+nav_order: 8
+---
+
+
+# Open-source computer-use agents
+
+A computer-use agent looks at a screenshot and clicks coordinates. That single design
+choice separates it from the browser agents on
+[the sibling page](ai-browser-agent-open-source.md): a browser agent reads page
+structure and acts on named elements, a computer-use agent sees exactly what a person
+sees, pixels, and acts exactly where a person acts, at a point on the screen. This
+page maps the open-source projects in the screenshot-and-click category, verified
+against their own repositories on 2026-09-03, and is honest about when the category
+is the right one, which is less often than the demos suggest.
+
+Disclosure, as on every comparison page here: this is AIHawk's wiki, and AIHawk is a
+browser agent, not a computer-use agent. The category difference below is real and
+cuts both ways.
+
+## The category difference, honestly
+
+A browser agent gets a privileged view: the DOM, the accessibility tree, element
+roles and labels. When it clicks "Submit", it clicks the element called Submit, at
+whatever pixel that element happens to occupy. A computer-use agent gets an image.
+It must find the button in the image, decide the button's coordinates, and issue a
+click at those coordinates, a step the field calls grounding, and grounding is where
+these agents fail: the model knows it wants the search box and clicks forty pixels
+left of it.
+
+What the pixel view buys is generality. A computer-use agent can drive a desktop
+application, a settings dialog, a virtual machine console, a canvas-rendered app
+with no DOM to read, or three applications in one task. A browser agent can drive
+none of those. What the pixel view costs:
+
+- **Tokens.** Screenshots are large model inputs, and every loop step sends a new
+  one. The same task costs more, per step and in step count.
+- **Precision.** Grounding errors have no equivalent in a browser agent; a DOM click
+  either finds the element or fails loudly. A coordinate click on the wrong pixel
+  succeeds silently on the wrong thing.
+- **Blast radius.** An agent with mouse and keyboard on your actual desktop can act
+  outside the task. Most serious projects in the category run in a sandbox or a VM
+  for exactly this reason.
+
+If the task lives entirely inside web pages, the structural view usually wins. If it
+touches anything outside a browser, only this category can do it at all.
+
+## The projects
+
+### UI-TARS Desktop / Agent TARS (ByteDance)
+
+38.8k stars, TypeScript, Apache-2.0. Two things in one repository: UI-TARS Desktop,
+a native GUI-agent application for your own computer, and Agent TARS, a multimodal
+agent stack with a CLI and web UI. The distinctive part is the model: the stack is
+driven by ByteDance's own UI-TARS vision-language models, built for GUI grounding,
+with the research paper published (arXiv:2501.12326). Agent TARS also documents a
+hybrid browser mode that mixes the GUI (pixel) approach with DOM reading, which is
+the clearest sign in the whole category that pure pixels are not always enough.
+
+### Cua (trycua)
+
+22.1k stars, Python, MIT. Cua is the infrastructure answer: sandboxed computer-use
+environments across macOS, Windows, Linux and Android, built on VMs rather than
+containers, with agents perceiving through screenshots and acting through mouse,
+keyboard and touch at pixel coordinates. It aims at running fleets of sandboxes for
+training, evaluation and data generation as much as at single-agent use. Pick it
+when the question is "where do I safely run a computer-use agent" rather than
+"which agent".
+
+### Agent S (Simular)
+
+12.2k stars, Python, Apache-2.0. A research-driven framework that takes screenshots
+and acts through pyautogui on Linux, macOS and Windows, using grounding models
+(UI-TARS among them) for locating elements. Its README reports Agent S3 at 72.6% on
+the OSWorld benchmark, which it states surpasses the roughly 72% human level, plus
+56.6% on WindowsAgentArena and 71.6% on AndroidWorld. Benchmark numbers from a
+project's own README deserve the usual discount, but OSWorld is a real benchmark
+and the trajectory of these numbers over two years is the honest signal: the
+category has moved from demo to competent on scoped desktop tasks.
+
+### self-operating-computer (OthersideAI)
+
+10.3k stars, Python, MIT. The early, minimal take on the idea and still a good way
+to understand it: screenshot in, mouse and keyboard out, with the same interface a
+person has. It supports multiple vision models including local ones through Ollama,
+and adds OCR and Set-of-Mark prompting modes to help the grounding problem. Simpler
+and less capable than the entries above, and the code is small enough to read in a
+sitting, which is worth something.
+
+### OpenHands, and why it is only adjacent
+
+86.1k stars, MIT, the largest project anywhere near this page, listed here because
+people search for it in this category. Its repository positions it as a self-hosted
+control center for coding agents and automations, running agents like its own,
+Claude Code or Codex against development tasks. Its agents work in sandboxed
+environments, but the product is code-and-terminal shaped, not
+screenshot-and-click shaped. If your task is "operate this GUI", it is the wrong
+shelf; if your task is "build and fix software", it is a strong one.
+
+## The table
+
+| Project | Stars (2026-09-03) | Language | License | Sees | Acts |
+|---|---|---|---|---|---|
+| UI-TARS Desktop / Agent TARS | 38.8k | TypeScript | Apache-2.0 | screenshots (hybrid DOM mode in Agent TARS) | mouse and keyboard, own VLM |
+| Cua | 22.1k | Python | MIT | screenshots in sandboxed VMs | pixel-coordinate input, cross-OS |
+| Agent S | 12.2k | Python | Apache-2.0 | screenshots plus grounding models | pyautogui |
+| self-operating-computer | 10.3k | Python | MIT | screenshots, optional OCR / Set-of-Mark | mouse and keyboard |
+| OpenHands (adjacent) | 86.1k | TypeScript, Python | MIT | code, terminals, sandboxes | developer tooling, not GUI clicks |
+
+## Choosing between the two categories
+
+The decision is about the task surface, not the project quality.
+
+- **Everything happens in web pages:** use a browser agent. The structured view is
+  more precise, cheaper per step, and its failures are diagnosable. The options are
+  on [the browser-agent page](ai-browser-agent-open-source.md); AIHawk is one of
+  them, and that sentence carries this wiki's standing disclosure.
+- **The task touches desktop applications, or a UI with no readable structure:**
+  computer-use is the only category that reaches it. Take the sandbox seriously.
+- **Mixed:** the field's own direction is instructive. Agent TARS ships a hybrid
+  GUI-plus-DOM browser mode, and browser agents like browser-use attach screenshots
+  next to the DOM. Both categories are converging on "structure where it exists,
+  pixels where it does not".
+
+One thing the pixel view does not buy, because the question comes up: it does not
+make an agent look human to a website. Detection systems read the browser
+fingerprint, the network, the volume and the pacing, and a computer-use agent
+driving a stock browser through a VM usually looks less normal on the first two, not
+more. That reasoning is laid out in
+[why agents get blocked](why-does-my-ai-agent-get-blocked.md) and, for the specific
+case people search for, in
+[Claude computer use detected as a bot](claude-computer-use-detected-as-bot.md).
+
+## Short answers to the questions that lead here
+
+**What is a computer-use agent?** An agent that perceives the screen as an image and
+acts by moving the mouse and typing at coordinates, the way a person does, rather
+than reading page structure the way a browser agent does.
+
+**Which open-source computer-use agent is the most capable right now?** By its own
+published benchmarks, Agent S3 leads on OSWorld at 72.6%; ByteDance's UI-TARS stack
+is the largest by stars and ships its own grounding models. Both readings are from
+the projects' repositories on 2026-09-03, not independent evaluation.
+
+**Can a computer-use agent browse the web?** Yes, by driving a browser as pixels,
+and for web-only tasks that is usually the worse tool: more tokens, weaker
+targeting, silent misclicks. Use it for the web only when the page offers no usable
+structure.
+
+**Do these run locally?** Agent S, self-operating-computer and the TARS desktop app
+run on your machine; Cua exists precisely to give the agent a VM instead of your
+machine. Local model support varies; self-operating-computer documents Ollama.
+
+**Is OpenAI Operator part of this category?** Operator-style products are hosted
+computer-use agents. This page covers open-source ones; for the hosted comparison
+see [OpenAI Operator vs Claude computer use](openai-operator-vs-claude-computer-use.md)
+and [open-source Operator-style agents](openai-operator-open-source.md).
+
+**Is AIHawk a computer-use agent?** No. It is a browser agent: it reads page
+structure through MCP tools and drives a patched Firefox. If your task leaves the
+browser, use one of the projects on this page instead.
+
+## Sources
+
+All retrieved 2026-09-03, from each project's own repository.
+
+- [bytedance/UI-TARS-desktop](https://github.com/bytedance/UI-TARS-desktop)
+- [trycua/cua](https://github.com/trycua/cua)
+- [simular-ai/Agent-S](https://github.com/simular-ai/Agent-S), including its
+  self-reported OSWorld, WindowsAgentArena and AndroidWorld figures.
+- [OthersideAI/self-operating-computer](https://github.com/OthersideAI/self-operating-computer)
+- [All-Hands-AI/OpenHands](https://github.com/All-Hands-AI/OpenHands)
+
+**See also:** [open-source AI browser agents](ai-browser-agent-open-source.md),
+[what is an AI web agent?](ai-web-agent-explained.md), and
+[OpenAI Operator vs Claude computer use](openai-operator-vs-claude-computer-use.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. AIHawk sits in the
+other category, the browser agents, which is exactly why this page spends its words
+on when pixels beat structure and not the reverse.*

--- a/docs/guides-alternatives-and-comparisons.md
+++ b/docs/guides-alternatives-and-comparisons.md
@@ -1,0 +1,25 @@
+---
+title: "Alternatives and Comparisons"
+has_children: true
+nav_order: 2
+---
+
+# Alternatives and Comparisons
+
+The AI browser-agent space moves fast and most comparison content in it is
+written by a vendor ranking itself first. These pages try to be the exception,
+with one honest disclosure up front: AIHawk is a project in this space, so read
+every comparison here knowing who wrote it. Where a claim is made about another
+tool, it is checked against that tool's own documentation or source, and where
+another tool covers more, the page says so.
+
+- [OpenAI Operator alternatives](openai-operator-alternatives.md)
+- [Open-source Operator-style agents](openai-operator-open-source.md)
+- [Is OpenAI Operator still available?](is-openai-operator-still-available.md)
+- [OpenAI Operator vs Claude computer use](openai-operator-vs-claude-computer-use.md)
+- [browser-use alternatives](browser-use-alternatives.md)
+- [Choosing an AI browser agent](best-ai-browser-agent.md)
+- [Open-source AI browser agents](ai-browser-agent-open-source.md)
+- [Open-source computer-use agents](computer-use-agent-open-source.md)
+- [What is an AI web agent?](ai-web-agent-explained.md)
+- [AI browser agents vs traditional scraping](ai-browser-agents-vs-traditional-scraping.md)

--- a/docs/guides-job-application-automation.md
+++ b/docs/guides-job-application-automation.md
@@ -1,0 +1,21 @@
+---
+title: "Job Application Automation"
+has_children: true
+nav_order: 4
+---
+
+# Job Application Automation
+
+AIHawk was born here: an AI agent that applied to jobs in bulk, covered by
+TechCrunch, Business Insider, Wired and The Verge along the way. The project
+has since become a general web agent, but the job-application use case is
+still real, still asked about, and still where much of this community started.
+
+One rule these pages keep, everywhere: no job board or company site is named.
+Naming who is being automated against turns a guide into a target list, so
+examples use generic forms and pages you serve yourself.
+
+- [Automating job applications with Claude](automate-job-applications-with-claude.md)
+- [Automating job applications with ChatGPT](automate-job-applications-with-chatgpt.md)
+- [Automating job applications in Python](automate-job-applications-python.md)
+- [The open-source job application bot, and what it became](open-source-job-application-bot.md)

--- a/docs/guides-using-the-agent.md
+++ b/docs/guides-using-the-agent.md
@@ -1,0 +1,15 @@
+---
+title: "Using the Agent"
+has_children: true
+nav_order: 5
+---
+
+# Using the Agent
+
+Task-shaped guides: a concrete thing you want done, and how an AI agent with a
+real browser actually does it. Worked examples with recordings live in the
+repository's [articles/](https://github.com/feder-cr/AIHawk/tree/main/articles)
+folder; the pages here are the reading companion - what works, what breaks,
+and what to expect before you spend model tokens finding out.
+
+- [Getting an AI agent to fill out forms](ai-agent-fill-out-forms.md)

--- a/docs/guides-when-the-agent-gets-blocked.md
+++ b/docs/guides-when-the-agent-gets-blocked.md
@@ -1,0 +1,25 @@
+---
+title: "When the Agent Gets Blocked"
+has_children: true
+nav_order: 3
+---
+
+# When the Agent Gets Blocked
+
+An AI agent that browses the web inherits every way a browser can be detected,
+plus a few tells of its own: the rhythm of a think-act loop, the volume of a
+retry storm, the fingerprint of the machine it runs on. These pages sort out
+which is which, because the fix is different for each - and some of them are
+not fixable from the agent at all.
+
+The mechanism layer lives on the
+[invisible_playwright wiki](https://github.com/feder-cr/invisible_playwright/wiki),
+which documents the fingerprinting surfaces and the detection vendors in
+depth. The pages here stay at the level of the agent: what happened, what to
+check, in what order.
+
+- [Why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md)
+- [The timing signal AI agents give off](ai-agent-timing-signal.md)
+- [Agent retry loops trip rate limits, not fingerprints](agent-retry-loops-rate-limits.md)
+- [Claude computer use detected as a bot](claude-computer-use-detected-as-bot.md)
+- [browser-use getting blocked: what you can and cannot change](browser-use-getting-blocked.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,41 @@
+---
+title: "Home"
+nav_order: 1
+---
+
+# AIHawk Wiki
+
+AIHawk is an AI agent with a real browser: you say what you want in plain
+language, it goes and does it on the actual web. This wiki is the reading
+room around it - what an AI web agent is, how the tools in this space compare,
+what to do when an agent gets blocked, and the job-application automation this
+project grew out of.
+
+The [README](https://github.com/feder-cr/AIHawk#readme) is the fastest way to
+run AIHawk. The pages here are for the questions that come before and after:
+which tool fits, why something failed, and what is actually happening
+underneath.
+
+## The guides
+
+- **[Alternatives and Comparisons](guides-alternatives-and-comparisons.md)** -
+  the AI browser-agent landscape: OpenAI Operator and what replaced it,
+  browser-use, computer-use agents, and how the open-source options differ.
+- **[When the Agent Gets Blocked](guides-when-the-agent-gets-blocked.md)** -
+  challenge pages, rate limits, timing tells, and which of those the browser
+  can fix versus which are yours.
+- **[Job Application Automation](guides-job-application-automation.md)** -
+  where this project started: automating application flows with Claude,
+  ChatGPT, or plain Python, and what is realistic today.
+- **[Using the Agent](guides-using-the-agent.md)** - task-shaped guides for
+  putting an agent to work.
+
+## The layer underneath
+
+AIHawk drives a Firefox patched at the C++ level so the browser itself looks
+and behaves like a normal desktop browser. That engine has its own
+documentation, maintained with the same care as this wiki: the
+[invisible_playwright wiki](https://github.com/feder-cr/invisible_playwright/wiki)
+covers browser fingerprinting, bot-detection vendors, network and proxy
+mechanics, and the automation layer in depth. Pages here link into it wherever
+the mechanism matters.

--- a/docs/is-openai-operator-still-available.md
+++ b/docs/is-openai-operator-still-available.md
@@ -1,0 +1,158 @@
+---
+title: "Is OpenAI Operator still available?"
+description: "No. Operator shut down on 31 August 2025, its successor agent mode was removed in August 2026, and Atlas closed the same month. The verified timeline and what to use instead."
+parent: "Alternatives and Comparisons"
+nav_order: 3
+---
+
+# Is OpenAI Operator still available?
+
+No. Operator was shut down on 31 August 2025, about seven months after it
+launched. The capability moved into ChatGPT agent, which was itself removed in
+early August 2026. Atlas, OpenAI's standalone AI browser, shut down on
+9 August 2026. As of this page's writing (September 2026), nothing OpenAI
+offers carries the Operator name, and the closest living equivalents are
+agentic browsing inside the ChatGPT desktop app and Chrome extension, the
+ChatGPT Work agent, and a developer-only computer-use API.
+
+That is the short answer. The rest of this page is the verified timeline,
+because the churn confused a lot of people, and then the practical part: what
+someone who wants that capability today can actually use.
+
+A note on who is telling you this: this page lives on the wiki of
+[AIHawk](https://github.com/feder-cr/AIHawk), an open-source agent in the same
+space, which appears once in the alternatives section below with that conflict
+declared.
+
+## The timeline, date by date
+
+Every row was checked against OpenAI's own pages or mainstream reporting on
+2026-09-03.
+
+| Date | Event |
+|---|---|
+| 23 January 2025 | Operator announced as a research preview. |
+| 1 February 2025 | Available to ChatGPT Pro subscribers in the US. |
+| July 2025 | ChatGPT agent launches, merging Operator's "visual, GUI-based actions" with Deep Research; Operator's deprecation is announced. |
+| 31 August 2025 | Standalone Operator shuts down. |
+| October 2025 | Atlas launches: a Chromium-based AI browser, macOS first. |
+| 9 July 2026 | ChatGPT Work launches: an agent for multi-step work across apps and files. |
+| Early August 2026 | ChatGPT agent mode removed; OpenAI's help pages direct users to ChatGPT Work. Users on the OpenAI forum note it arrived without an advance deprecation notice. |
+| 9 August 2026 | Atlas shuts down; its agentic browsing folds into the ChatGPT desktop app, the ChatGPT Chrome extension, and Codex. |
+
+Three product generations in nineteen months, each replacing the last. If you
+built a workflow on any of them, you have already migrated twice.
+
+## What OpenAI offers today instead
+
+**Agentic browsing in ChatGPT.** The Atlas shutdown notice says its
+browser-based agentic work moved into the ChatGPT desktop app and the ChatGPT
+Chrome extension. This is the nearest thing to Operator's original shape that
+OpenAI still ships: the assistant can browse and act inside a browser context,
+under your subscription.
+
+**ChatGPT Work.** Launched 9 July 2026, described by OpenAI and press coverage
+as an agent that gathers context across your apps and files and returns
+finished documents, spreadsheets and reports, staying with a project for
+hours. It is aimed at deliverables, not at interactively clicking through an
+arbitrary website. The most-viewed forum thread about the agent mode removal
+makes exactly that complaint: Work does not replicate "spawned a virtual
+computer, opened a real browser, visually interpret rendered websites, clicked
+through interfaces".
+
+**The computer-use API.** For developers, the `computer-use-preview` model in
+the Responses API drives a click-type-scroll loop over screenshots. It is a
+research preview, gated to higher usage tiers, priced per token. It is a
+building block, not a product: you supply the browser or VM it acts on.
+
+Whether any of these is "Operator, still available" depends on which half of
+Operator you wanted: the hosted convenience survives in ChatGPT's browsing
+mode; the watch-it-click-through-any-site agent, per OpenAI's own users, does
+not have a direct heir inside ChatGPT today.
+
+## If you want what Operator did, today
+
+The capability did not die with the product; it moved out into the rest of
+the field.
+
+**Another vendor's browser agent.** Claude in Chrome became generally
+available for paid Claude plans on 26 August 2026 and drives the Chrome you
+already have. The architectural comparison with Operator's approach is on
+[OpenAI Operator vs Claude computer use](openai-operator-vs-claude-computer-use.md).
+
+**The open-source route.** Several maintained open projects do the
+describe-a-task, watch-the-browser-work loop on your own machine with your own
+model key: browser-use (~112k stars), Skyvern (~23k), Agent S3 (~12k) for
+whole-desktop tasks, and AIHawk (~30k), our own, whose particular bet is
+driving a Firefox patched at the source level so the browser reads as a normal
+desktop machine rather than an automation build. The repo-by-repo survey with
+licenses and trade-offs is
+[Open-source Operator-style agents](openai-operator-open-source.md), and the
+full hosted-plus-open landscape is
+[OpenAI Operator alternatives](openai-operator-alternatives.md).
+
+One thing to carry over from the Operator era regardless of route: no agent,
+hosted or open, is guaranteed passage on every site. Operator itself had
+sites it would not touch, and every alternative inherits some version of the
+same boundary - [why an agent gets blocked](why-does-my-ai-agent-get-blocked.md)
+is about which parts of that are the browser's fault and which are yours.
+
+## Why this keeps happening, briefly
+
+Reading the announcements together, a pattern is visible and worth naming
+without editorializing: OpenAI has treated the browser agent as a feature in
+search of its right container - standalone product, ChatGPT mode, standalone
+browser, then back into ChatGPT and an extension. Coverage of the Atlas
+shutdown quotes the conclusion that the browser is "a feature, not the
+destination". For users, the practical lesson is less about OpenAI than about
+hosted agents generally: a capability you rent can be reorganized out from
+under you without a deprecation window, which the August 2026 agent-mode
+removal demonstrated. It is the strongest argument the open-source column of
+this wiki has, and it was written by events, not by us.
+
+## Short answers to the questions that lead here
+
+**Is OpenAI Operator still available?** No. It shut down 31 August 2025.
+
+**Did ChatGPT agent replace it, and is that still there?** It did, in July
+2025, and no: agent mode was removed in early August 2026. OpenAI's help
+pages now point to ChatGPT Work.
+
+**What happened to ChatGPT Atlas?** Shut down 9 August 2026, with agentic
+browsing folded into the ChatGPT desktop app, the Chrome extension, and
+Codex. It never left macOS while it lived, per coverage of the shutdown.
+
+**Can I still access Operator if I pay for Pro?** No tier restores it. The
+subscription route today is ChatGPT's built-in browsing agent and ChatGPT
+Work.
+
+**Is there an API version?** The `computer-use-preview` model in the
+Responses API, a tier-gated research preview where you provide the
+environment it controls.
+
+**What is the closest replacement I can run myself?** An open-source browser
+agent with your own model key - see
+[Open-source Operator-style agents](openai-operator-open-source.md).
+
+**See also:** [OpenAI Operator alternatives](openai-operator-alternatives.md)
+for the full option landscape,
+[OpenAI Operator vs Claude computer use](openai-operator-vs-claude-computer-use.md)
+for the two vendor architectures, and
+[Choosing an AI browser agent](best-ai-browser-agent.md) for how to pick a
+replacement that will not need replacing.
+
+## Sources
+
+- [Wikipedia: OpenAI Operator](https://en.wikipedia.org/wiki/OpenAI_Operator), retrieved 2026-09-03, for the January/February 2025 and 31 August 2025 dates and the August 2026 agent removal note.
+- [OpenAI help: ChatGPT agent](https://help.openai.com/en/articles/11752874-chatgpt-agent) and [OpenAI help: Evolving Atlas into ChatGPT for browser-based agentic work](https://help.openai.com/en/articles/20001371-evolving-atlas-into-chatgpt-for-browser-based-agentic-work), surfaced via search 2026-09-03.
+- [OpenAI community: "Agent Mode was removed with no real replacement"](https://community.openai.com/t/agent-mode-was-removed-with-no-real-replacement/1389601), retrieved 2026-09-03, for the removal, the "use Work" guidance, and the quoted capability description.
+- [TechCrunch: OpenAI is shutting down Atlas](https://techcrunch.com/2026/07/09/openai-is-shutting-down-atlas-but-its-ai-browser-ambitions-are-still-growing/) and [Search Engine Land: OpenAI sets Aug. 9 end date for ChatGPT Atlas](https://searchengineland.com/openai-chatgpt-atlas-deprecation-482003), surfaced via search 2026-09-03.
+- [Bloomberg: OpenAI launches ChatGPT Work](https://www.bloomberg.com/news/articles/2026-07-09/openai-unveils-chatgpt-work-agent-to-field-tasks-for-hours) and [The Next Web on the same launch](https://thenextweb.com/news/openai-chatgpt-work-agent-launch), surfaced via search 2026-09-03.
+- [OpenAI computer use guide](https://platform.openai.com/docs/guides/tools-computer-use) and [computer-use-preview model page](https://developers.openai.com/api/docs/models/computer-use-preview), surfaced via search 2026-09-03.
+
+---
+
+*Kept current by the maintainers of [AIHawk](https://github.com/feder-cr/AIHawk),
+an open-source AI web agent. We have an interest in the answer being "no", so
+every date above traces to OpenAI's own pages or mainstream reporting rather
+than to us.*

--- a/docs/open-source-job-application-bot.md
+++ b/docs/open-source-job-application-bot.md
@@ -1,0 +1,186 @@
+---
+title: "The open-source job application bot, and what it became"
+description: "AIHawk's own history, told straight: the 2024 bulk-application bot, the 30,000 stars and the media wave, the spammers criticism and the fair answer to it, and why the project became a general web agent."
+parent: "Job Application Automation"
+nav_order: 4
+---
+
+
+# The open-source job application bot, and what it became
+
+If you searched for an open-source job application bot, this repository is
+probably one of the results, and it earned that placement the loud way: in 2024
+it was the bot in the headlines. This page is the project telling its own
+story, including the part where the criticism was substantially right - because
+what the project became only makes sense once you see what the original hit,
+and what it hit first was its own ceiling.
+
+## What the original bot was
+
+The project began as a Python bot that automated job applications end to end.
+Point it at listings, give it your history, and it did the rest: entered
+biographical details into forms, generated resumes, wrote customized cover
+letters per posting, checked the required boxes, and submitted - unattended, in
+volume. That description is not marketing memory; it is how
+[404 Media](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/)
+described what it watched the bot do.
+
+It spread fast because it sat on a real nerve. Application forms had grown long
+and repetitive, applicants were being screened by software, and here was
+software that screened back. The repository climbed to about 30,000 stars, and
+in October 2024 the press arrived.
+
+## The media wave, and what it actually said
+
+404 Media's Jason Koebler ran the bot himself and
+[applied to 17 jobs in one hour](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/),
+building the piece around a user who had let it run to 2,843 applications.
+[TechCrunch picked the story up the same day](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/)
+and named the uncomfortable context: by the figure it cited, 42 percent of
+companies were already using AI to screen applicants, so automated applications
+meeting automated screening formed what it called a bizarre loop, with humans
+increasingly absent from both ends of hiring. The Verge published its take the
+same day with the criticism in the headline: AI was enabling job seekers to
+think like spammers. The
+[project README's featured strip](https://github.com/feder-cr/AIHawk#readme)
+carries the full set - Business Insider, Semafor, Wired's Italian edition, and
+Vanity Fair Italy alongside those three.
+
+Thirty thousand stars and international coverage is the part a project brags
+about. The next section is the part that matters more.
+
+## The criticism deserved a straight answer
+
+The spammers framing was not a cheap shot. A bot whose value proposition is
+volume converges on spam mechanics no matter how it is built: the same answers
+fanned out everywhere, any error in your data replicated 2,843 times, cover
+letters that read generic because they are generated at a rate no one reviews.
+And the damage lands on the applicant first. Recruiters learn to discount what
+looks mass-produced; platforms throttle and flag accounts with machine-like
+volume; an interview earned by an application you never read is an interview
+you walk into unprepared. The loop TechCrunch described makes it worse at the
+system level - every escalation in application volume buys more automated
+screening, which everyone then has to out-volume.
+
+There was a second, quieter problem: the original bot was welded to the markup
+of the pages it automated. Selectors written for a specific flow break when the
+page changes, and pages change constantly - some of that is ordinary
+redesign, some of it is aimed. A tool built as a collection of site-specific
+scripts is in a maintenance race it cannot win, which is why this wiki's pages
+name no job platforms at all: the durable knowledge is the mechanics that are
+the same everywhere, not any one site's layout.
+
+So the project's answer to the criticism is not a defense of spray. It is
+agreement, followed by a change of direction: the metric that pays the
+applicant is quality per application, and the honest way to build for that is
+an agent that does one application well, with a human reviewing it, rather
+than a cannon that does thousands unread. The project's own README now states
+the rule in one line: do not submit anything a human has not read.
+
+## What it became, and why
+
+Strip the volume out of the original bot and ask what was actually valuable in
+it, and two parts survive. First, a model that can read any form: the LLM never
+cared that the form was a job application, and reading an unfamiliar page is
+precisely what site-specific scripts could not do. Second, a browser that holds
+up under inspection, because the anti-bot layer meets automation everywhere,
+not just on application flows.
+
+Those two parts are simply a general web agent, and that is what AIHawk is
+now: you say what you want in plain language, and it does it in a real browser
+- the pointer moves, keys are pressed, and it declines shortcuts a page could
+detect, like setting form fields from JavaScript. The browser is the part that
+went deepest: a Firefox patched at the C++ level so the browser itself, not a
+wrapper of overrides, looks and behaves like a normal desktop Firefox. That
+engine and its documentation live at
+[invisible_playwright](https://github.com/feder-cr/invisible_playwright), and
+what an agent in this category is at all is covered in
+[what is an AI web agent?](ai-web-agent-explained.md).
+
+There are two ways in, both current. If you already use an assistant that runs
+tools - Claude Code, Claude Desktop, Cursor - you add the browser to it as an
+MCP server, and your assistant brings the model. Otherwise `uvx aihawk ui`
+runs the project's own interface, chat beside a live browser view, with the
+model coming from an OpenRouter key you supply. The code is MIT-licensed as of
+September 2026; everything distributed earlier was and remains AGPL-3.0.
+
+Job applications did not disappear from the picture - this page's siblings
+cover doing them [with Claude](automate-job-applications-with-claude.md),
+[with ChatGPT](automate-job-applications-with-chatgpt.md), and
+[in Python](automate-job-applications-python.md). What disappeared is the
+unattended volume. The agent works through an application in front of you,
+drafts from your real history, and stops where your judgment is required.
+
+## Conclusion
+
+The open-source job application bot was real, enormous, and covered by half
+the tech press in a week, and the sharpest criticism it drew was right:
+volume-first automation hurts the people it claims to help, applicants
+included. What survived the criticism was not the bulk pipeline but the two
+hard parts inside it - a model that reads any form, and a browser built to
+withstand inspection - and those two parts, generalized, are AIHawk today: an
+open-source web agent that treats a job application as one task done well
+rather than thousands done blind.
+
+## Short answers to the questions that lead here
+
+**What was the original AIHawk?** A 2024 open-source Python bot that applied
+to jobs automatically: form filling, generated resumes, customized cover
+letters, unattended submission. It reached about 30,000 stars and was covered
+by 404 Media, TechCrunch, The Verge, Business Insider, Semafor, Wired's
+Italian edition, and Vanity Fair Italy.
+
+**Is the bulk-application bot still what this repository is?** No. The project
+is now a general web agent on a hardened browser. The job-application use case
+remains supported as supervised, one-at-a-time work, not unattended volume.
+
+**Was the "spammers" criticism fair?** Substantially, yes. Spray-and-pray
+replicates errors at scale, reads as generic, and triggers the throttling and
+discounting that hurt the applicant first. The project's answer is quality per
+application, not more spray.
+
+**Why did it stop being job-board-specific?** Site-specific scripts lose the
+maintenance race against changing pages, and a general agent that reads any
+form does not need them. That is also why no page on this wiki names a job
+platform.
+
+**Can I still use it to apply to jobs?** Yes - through an assistant you
+already have via MCP, or through its own interface. See
+[automating job applications with Claude](automate-job-applications-with-claude.md)
+for the concrete setup and the pacing rules that keep it useful.
+
+**What license is it under?** MIT for everything distributed from
+September 2, 2026; earlier distributions were AGPL-3.0 and stay under it.
+
+## Sources
+
+- [404 Media, "I Applied to 2,843 Roles With an AI-Powered Job Application
+  Bot"](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/),
+  Jason Koebler, retrieved 2026-09-03, for the first-hand account of the
+  original bot's behavior and volume.
+- [TechCrunch, "Someone claims to have used AI to apply to 2,843
+  jobs"](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/),
+  Kyle Wiggers, October 10 2024, retrieved 2026-09-03, for the 42 percent
+  AI-screening figure and the automation-loop framing.
+- The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), retrieved
+  2026-09-03, for the featured-coverage list, the current two ways to run the
+  agent, the human-review rule, and the licensing dates.
+- The Verge's October 10 2024 piece is linked from that README; the site
+  blocks automated retrieval, so its framing is cited from the headline as
+  linked there.
+
+**See also:** the
+[job application automation hub](guides-job-application-automation.md) for the
+practical guides this history sits behind,
+[automating job applications in Python](automate-job-applications-python.md)
+for the road the original bot walked,
+[what is an AI web agent?](ai-web-agent-explained.md) for the category it
+moved into, and
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md) for
+the layer that made the browser the hard part.
+
+---
+
+*Written by the maintainer of [AIHawk](https://github.com/feder-cr/AIHawk).
+The 2,843 applications in those headlines were sent by the old bot; the point
+of the new agent is that nobody should ever send that many again.*

--- a/docs/openai-operator-alternatives.md
+++ b/docs/openai-operator-alternatives.md
@@ -1,0 +1,189 @@
+---
+title: "OpenAI Operator alternatives"
+description: "Operator shut down in August 2025 and its successor inside ChatGPT was removed a year later. The real alternative landscape in September 2026, hosted and open source, compared by the axes that matter."
+parent: "Alternatives and Comparisons"
+nav_order: 1
+---
+
+# OpenAI Operator alternatives
+
+If you are looking for an Operator alternative in September 2026, you are really
+looking for the capability Operator demonstrated: you describe a task in plain
+language and an AI drives a real browser until the task is done. Operator itself
+shut down on 31 August 2025. The ChatGPT agent mode that absorbed it was removed
+in early August 2026, and Atlas, OpenAI's standalone AI browser, shut down on
+9 August 2026. So "alternative" no longer means "a substitute for a living
+product". It means the whole category, and the category has real options.
+
+One disclosure before the list: this page lives on the wiki of
+[AIHawk](https://github.com/feder-cr/AIHawk), which appears below as one of
+those options. Every claim about another tool here traces to that tool's own
+site, repository, or documentation, retrieved on 2026-09-03, and where another
+tool covers more than ours does, the page says so.
+
+## What Operator was, briefly
+
+Operator launched as a research preview for ChatGPT Pro subscribers in the US
+on 1 February 2025. It drove a web browser to fill forms, place orders, and
+click through pages on the user's behalf. In July 2025 OpenAI folded its
+"visual, GUI-based actions" into ChatGPT agent, and the standalone preview was
+shut down on 31 August 2025. The successor churned again in 2026. The full
+timeline, with what OpenAI offers today, is on
+[Is OpenAI Operator still available?](is-openai-operator-still-available.md) -
+this page will not repeat it.
+
+## The axes that separate the alternatives
+
+Every tool below answers the same three questions differently, and the answers
+matter more than any feature list:
+
+- **Open source or hosted.** Can you read the code and run it yourself, or is
+  it a service that can change or disappear under you? Operator's own history
+  is the argument for caring about this.
+- **Who brings the model.** Some tools are inseparable from one vendor's
+  model. Others take your API key and let you pick.
+- **What browser it drives, and how.** A hosted browser in a vendor's cloud, a
+  screenshot-and-coordinates loop over a VM, a stock automation build of
+  Chromium driven over an automation protocol, or a browser patched at the
+  source level to present a normal desktop fingerprint. When a site inspects
+  its visitor, this axis is the one that decides what the site sees.
+
+## The landscape at a glance
+
+Star counts and statuses were read from each project's repository or vendor
+pages on 2026-09-03 and will drift.
+
+| Tool | Open source | Model | What it drives | Where it runs |
+|---|---|---|---|---|
+| ChatGPT agentic browsing (desktop app + Chrome extension) | No | OpenAI's, via subscription | Your Chrome, or browsing inside the ChatGPT app | Your machine + OpenAI |
+| Claude in Chrome | No | Anthropic's, via subscription | Your installed Chrome | Your machine |
+| Claude computer use (API tool) | Tool spec is public; you build the rest | Anthropic models, your API key | Whatever environment you provide | Your infrastructure |
+| [browser-use](https://github.com/browser-use/browser-use) | Yes, MIT (~112k stars) | Your key, or their cloud and models | Chromium-family browser via automation protocol | Your machine or their cloud |
+| [Skyvern](https://github.com/Skyvern-AI/skyvern) | Yes, AGPL-3.0 (~23k stars) | Your key, or their cloud | Playwright-driven browser, vision-LLM based | Your machine or their cloud |
+| [Agent S3](https://github.com/simular-ai/Agent-S) | Yes, Apache-2.0 (~12k stars) | Your key | The whole desktop GUI, not only a browser | Your machine |
+| [AIHawk](https://github.com/feder-cr/AIHawk) | Yes, MIT (~30k stars) | Your OpenRouter key, or your MCP assistant's model | Its own Firefox, patched at the C++ level | Your machine |
+
+## The vendor routes that remain
+
+**OpenAI's own answer** to "I want what Operator did" is no longer a product
+named anything like Operator. Agentic browsing now lives inside the ChatGPT
+desktop app and the ChatGPT Chrome extension, where Atlas's capabilities were
+folded when it shut down, and ChatGPT Work (launched 9 July 2026) handles
+longer multi-step tasks across apps and files. Users on OpenAI's own forum have
+pointed out that none of these reproduces the old agent mode's interactive
+website navigation exactly. Developers can build with the `computer-use-preview`
+model in the Responses API, a research preview limited to higher usage tiers.
+
+**Anthropic's answer** comes in two shapes. Claude in Chrome, the browser
+extension, became generally available for paid Claude plans on 26 August 2026
+and drives the Chrome you already have. For builders, the computer use tool in
+the Claude API is a screenshot-and-coordinates loop where you supply the whole
+environment. [OpenAI Operator vs Claude computer use](openai-operator-vs-claude-computer-use.md)
+compares those two architectures properly.
+
+Both routes are good if you are already paying that vendor and your tasks fit
+inside their safety envelope. Neither is open source, and both tie the agent to
+one vendor's models.
+
+## The open-source field
+
+**browser-use** is the category leader by adoption: roughly 112k stars, MIT
+licensed, a $17M seed round in March 2025, and a hosted cloud. It drives a
+Chromium-family browser and supports multiple model providers with your own
+keys. If you want the largest community and the most examples, start there.
+[browser-use alternatives](browser-use-alternatives.md) covers where its
+trade-offs bite and what sits next to it.
+
+**Skyvern** (~23k stars, AGPL-3.0) takes a vision-first approach: LLMs and
+computer vision map what is on screen to actions instead of relying on brittle
+selectors, on top of Playwright. It also runs a managed cloud with features the
+self-hosted version does not include.
+
+**Agent S3** from Simular (~12k stars, Apache-2.0) is a computer-use framework
+rather than a browser agent: it operates the whole desktop GUI and reports
+72.6% on the OSWorld benchmark, which its paper describes as above the human
+baseline on that suite. If your task spans desktop applications and not just
+the web, it is the strongest open option we found.
+
+The deeper survey of open repositories, including two unrelated projects that
+both answer to the name "open operator", is on
+[Open-source Operator-style agents](openai-operator-open-source.md).
+
+## Where AIHawk fits, stated by its maintainer
+
+AIHawk is open source (MIT), takes your OpenRouter key or plugs into an MCP
+assistant you already run (Claude Code, Claude Desktop, Cursor), and its
+differentiator is the browser itself: it drives a Firefox patched at the C++
+level so that what a page inspects looks like a normal desktop browser, not a
+stock automation build. The engine's mechanics are documented on the
+[invisible_playwright wiki](https://github.com/feder-cr/invisible_playwright/wiki/do-websites-know-you-are-using-a-script).
+
+The honest limits: it is Windows and Linux only, no macOS. You bring the model
+and pay for tokens. A hardened browser does not repair a bad egress IP, robotic
+pacing, or a per-account limit, and nothing here promises you will not be
+detected - [that boundary has its own page](why-does-my-ai-agent-get-blocked.md).
+And it has a fraction of browser-use's community.
+
+## How to choose
+
+- **Already paying for ChatGPT or Claude, task is occasional?** Use that
+  vendor's browsing agent and stop reading.
+- **Need code you can read, run, and keep?** The open-source field above.
+- **Largest ecosystem and Chromium is fine?** browser-use.
+- **Tasks that leave the browser for the desktop?** Agent S3.
+- **Sites inspect your browser and a stock automation build gets challenged?**
+  That is the case AIHawk's engine was built for, with the caveat paragraph
+  above in full force.
+- **Undecided?** Run two of them against your actual task for an afternoon.
+  A live trial beats this table, and we wrote the table.
+
+The broader decision framework, beyond replacing Operator specifically, is on
+[Choosing an AI browser agent](best-ai-browser-agent.md).
+
+## Short answers to the questions that lead here
+
+**What replaced OpenAI Operator?** Inside OpenAI: ChatGPT agent (July 2025),
+then agentic browsing in the ChatGPT desktop app and Chrome extension plus
+ChatGPT Work (2026). Outside OpenAI: the tools in the table above.
+
+**Is there a free Operator alternative?** The open-source agents are free
+software; you still pay for model tokens unless you run a local model where a
+tool supports one. AIHawk's UI runs keyless in a placeholder mode that takes
+literal commands, which is for testing the browser rather than doing real work.
+
+**Which alternative is most like Operator?** browser-use's cloud or Skyvern's
+cloud are closest in shape, a hosted browser doing your task. On your own
+machine, any of the open agents above.
+
+**Do any of these guarantee they will not be blocked?** No, and distrust any
+page that says otherwise. The browser's fingerprint is one factor; the IP,
+the account, and the pacing are yours either way.
+
+**Can I use Claude or GPT models with the open-source agents?** browser-use
+and Skyvern take multiple providers' keys. AIHawk takes any OpenRouter model
+id, or inherits whatever model your MCP assistant runs.
+
+**See also:** [Is OpenAI Operator still available?](is-openai-operator-still-available.md)
+for the full shutdown timeline,
+[Open-source Operator-style agents](openai-operator-open-source.md) for the
+repo-by-repo survey, and
+[OpenAI Operator vs Claude computer use](openai-operator-vs-claude-computer-use.md)
+for the two big-vendor architectures side by side.
+
+## Sources
+
+- [Wikipedia: OpenAI Operator](https://en.wikipedia.org/wiki/OpenAI_Operator), for the launch, deprecation and shutdown dates, retrieved 2026-09-03.
+- [OpenAI help: ChatGPT agent](https://help.openai.com/en/articles/11752874-chatgpt-agent) and [OpenAI help: Evolving Atlas into ChatGPT](https://help.openai.com/en/articles/20001371-evolving-atlas-into-chatgpt-for-browser-based-agentic-work), surfaced via search 2026-09-03.
+- [OpenAI community: "Agent Mode was removed with no real replacement"](https://community.openai.com/t/agent-mode-was-removed-with-no-real-replacement/1389601), retrieved 2026-09-03.
+- [TechCrunch on the Atlas shutdown](https://techcrunch.com/2026/07/09/openai-is-shutting-down-atlas-but-its-ai-browser-ambitions-are-still-growing/) and [Bloomberg on the ChatGPT Work launch](https://www.bloomberg.com/news/articles/2026-07-09/openai-unveils-chatgpt-work-agent-to-field-tasks-for-hours), surfaced via search 2026-09-03.
+- [OpenAI computer use guide](https://platform.openai.com/docs/guides/tools-computer-use), surfaced via search 2026-09-03.
+- [Anthropic: computer use tool documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool), retrieved 2026-09-03; Claude in Chrome general availability per coverage surfaced via search the same day.
+- The [browser-use](https://github.com/browser-use/browser-use), [Skyvern](https://github.com/Skyvern-AI/skyvern), [Agent-S](https://github.com/simular-ai/Agent-S) and [AIHawk](https://github.com/feder-cr/AIHawk) repositories, retrieved 2026-09-03.
+- [SiliconANGLE on browser-use's $17M seed](https://siliconangle.com/2025/03/23/browser-use-raises-17m-help-steer-ai-agents-internet/), surfaced via search 2026-09-03.
+
+---
+
+*Written while maintaining [AIHawk](https://github.com/feder-cr/AIHawk), an
+open-source AI web agent in exactly this space. The comparison above is the one
+we would want to read ourselves, which is why the disclosure sits at the top
+and every claim about another tool traces to that tool's own material.*

--- a/docs/openai-operator-open-source.md
+++ b/docs/openai-operator-open-source.md
@@ -1,0 +1,190 @@
+---
+title: "Open-source Operator-style agents"
+description: "The open-source agents that do what Operator did, repo by repo: browser-use, Skyvern, Agent S3, AIHawk, and the two unrelated projects both called open-operator, with stars and activity as found."
+parent: "Alternatives and Comparisons"
+nav_order: 2
+---
+
+# Open-source Operator-style agents
+
+Operator is gone, but the thing it demonstrated - tell an AI what you want,
+watch it drive a browser until it is done - is now better represented in open
+source than it ever was as a hosted preview. This page goes through the open
+repositories one by one: what each actually is, its license, and its scale as
+read from GitHub on 2026-09-03. The hosted-versus-open landscape, and what
+happened to Operator itself, are on
+[OpenAI Operator alternatives](openai-operator-alternatives.md) and
+[Is OpenAI Operator still available?](is-openai-operator-still-available.md);
+this page does not repeat them.
+
+Disclosure first: this wiki belongs to AIHawk, one of the projects below. Star
+counts and descriptions were read from each repository this session, and the
+projects that are bigger, older, or broader than ours are described as exactly
+that.
+
+## What "Operator-style" means here
+
+An Operator-style agent takes a goal in natural language, drives a real
+browser or desktop, looks at what came back, and decides the next action
+itself. That excludes plain automation frameworks (you write the steps) and
+excludes chat assistants that only summarize pages. Every entry below clears
+that bar or is included to clear up a naming collision.
+
+## The repositories
+
+### browser-use - the biggest, by far
+
+[github.com/browser-use/browser-use](https://github.com/browser-use/browser-use).
+Roughly 112k stars, MIT license, and the description reads "Make websites
+accessible for AI agents. Automate tasks online with ease." It drives a
+Chromium-family browser, supports OpenAI, Google and Anthropic models with
+your own keys plus its own optimized models through a unified key, and has an
+active commit history in the five figures. There is also a hosted cloud, which
+is out of scope for this page.
+
+If you are new to the category, start here: the community, the examples, and
+the integrations are the largest in the field. The reasons someone eventually
+looks past it are real but narrower than its size, and they get their own page
+in [browser-use alternatives](browser-use-alternatives.md).
+
+### Skyvern - vision-first browser workflows
+
+[github.com/Skyvern-AI/skyvern](https://github.com/Skyvern-AI/skyvern).
+About 23k stars, AGPL-3.0. Description: "Automate browser based workflows with
+AI". Its distinctive bet is using vision LLMs and computer vision to understand
+the page and map elements to actions, instead of depending on selectors that
+break when a layout changes. It runs on Playwright underneath and is actively
+developed. Note the license: AGPL-3.0 carries obligations MIT does not, which
+matters if you embed it in a product. A managed cloud exists with capabilities
+the open repository does not include.
+
+### Agent S3 - the whole desktop, not just the browser
+
+[github.com/simular-ai/Agent-S](https://github.com/simular-ai/Agent-S).
+About 12k stars, Apache-2.0, from Simular. Description: "Agent S: an open
+agentic framework that uses computers like a human". This is a computer-use
+agent: it operates the GUI of the machine, browser included but not only. The
+Agent S3 release (October 2025, with a TMLR 2026 paper) reports 72.6% on
+OSWorld, which the project describes as above the human baseline on that
+benchmark. If Operator appealed to you because it could do things, not only
+web things, this is the most capable open framework we verified.
+
+The trade-off is the mirror of its breadth: a screenshot-driven desktop agent
+is heavier per action than a browser-native one, and
+[reading the DOM versus reading pixels](https://github.com/feder-cr/invisible_playwright/wiki/dom-reading-vs-screenshot-agents)
+is a real architectural fork, not a detail.
+
+### AIHawk - ours, with the browser as the differentiator
+
+[github.com/feder-cr/AIHawk](https://github.com/feder-cr/AIHawk). About 30k
+stars, MIT (distributions before 2 September 2026 remain AGPL-3.0). The stars
+predate the current shape: the project began as a job-application bot and is
+becoming a general web agent, which its own description says plainly.
+
+What makes it different in this list is not the agent loop, it is what the
+loop drives: a Firefox patched at the C++ level so the browser presents a
+normal desktop fingerprint rather than announcing itself as an automation
+build. It runs two ways: as an MCP server added to an assistant you already
+have (Claude Code, Claude Desktop, Cursor), or as its own local UI with an
+OpenRouter key, chat on the left and the live browser on the right. Python
+3.11+, Windows and Linux only - no macOS, and that is a real gap next to every
+other entry here. A hardened browser is also not a promise of passage:
+[what it cannot fix](why-does-my-ai-agent-get-blocked.md) is documented as
+carefully as what it can.
+
+### The two projects both called "open operator"
+
+The name collision costs people time, so here it is untangled.
+
+**[browserbase/open-operator](https://github.com/browserbase/open-operator)**
+(~2k stars, MIT) was a template for building web agents with Stagehand on
+Browserbase, and its README called itself a proof of concept rather than a
+product. It was archived on 20 May 2026 and is read-only; the code moved into
+a demos repository. Do not adopt it expecting maintenance - its value today is
+as a worked example of the Stagehand/Browserbase stack.
+
+**[All-Hands-AI/open-operator](https://github.com/All-Hands-AI/open-operator)**
+(~428 stars, MIT), from the OpenHands organization, is not an agent at all: its
+description is "Open-source resources on agents for computer use", a curated
+reference covering benchmarks and implementations. Useful reading, wrong shelf
+if you wanted software to run.
+
+## Reading the table honestly
+
+| Repo | Stars (2026-09-03) | License | Scope | Status |
+|---|---|---|---|---|
+| browser-use | ~112k | MIT | Browser agent | Active |
+| AIHawk | ~30k | MIT | Browser agent | Active |
+| Skyvern | ~23k | AGPL-3.0 | Browser workflows | Active |
+| Agent-S | ~12k | Apache-2.0 | Desktop computer use | Active |
+| browserbase/open-operator | ~2k | MIT | Template | Archived 2026-05-20 |
+| All-Hands-AI/open-operator | ~428 | MIT | Resource list | Maintained |
+
+Two cautions about this table, because a table flattens things. Stars measure
+attention, not fitness for your task, and part of AIHawk's count is heritage
+from its job-bot era. And "active" was judged from commit and issue activity
+visible on the repo pages this session, which is a snapshot, not a guarantee.
+
+## How to pick from the open field
+
+- **Most examples, largest community, Chromium acceptable:** browser-use.
+- **Layout-fragile workflows you want vision to absorb:** Skyvern, minding
+  the AGPL.
+- **Tasks that span desktop apps:** Agent S3.
+- **Sites that inspect the browser, or you want the agent inside your
+  existing MCP assistant:** AIHawk, with our conflict of interest noted and
+  the macOS gap admitted.
+- **You want to survey the space first:** the All-Hands resource list, then
+  come back.
+
+Whatever you pick, run it against your real task before committing. Every
+project above is a `pip install` or a `uvx` away, which is the whole point of
+this list existing.
+
+## Short answers to the questions that lead here
+
+**Is there an open-source version of OpenAI Operator?** Not a clone of the
+product, but several open agents do what it did: browser-use, Skyvern, Agent
+S3, and AIHawk are the ones this page verified.
+
+**Which open-source browser agent has the most stars?** browser-use, at
+roughly 112k when read on 2026-09-03.
+
+**Is "open operator" a real project?** Two are: an archived Browserbase
+template and an OpenHands resource list. Neither is a maintained agent
+product.
+
+**Do these need an OpenAI or Anthropic subscription?** No. They take API keys
+(or, for AIHawk's MCP route, ride the assistant you already run). Model usage
+is pay-per-token to whichever provider you choose.
+
+**Are open agents as good as the hosted ones were?** On desktop benchmarks
+the open field now leads: Agent S3 reports 72.6% on OSWorld where OpenAI's
+computer-use model reported 38.1%. Benchmarks are not your workload, but the
+direction is clear.
+
+**See also:** [OpenAI Operator alternatives](openai-operator-alternatives.md)
+for the hosted options next to these,
+[browser-use alternatives](browser-use-alternatives.md) for the leader's
+trade-offs in detail, and
+[Choosing an AI browser agent](best-ai-browser-agent.md) for the decision
+framework above the level of any one repo.
+
+## Sources
+
+- The [browser-use](https://github.com/browser-use/browser-use),
+  [Skyvern](https://github.com/Skyvern-AI/skyvern),
+  [Agent-S](https://github.com/simular-ai/Agent-S),
+  [browserbase/open-operator](https://github.com/browserbase/open-operator),
+  [All-Hands-AI/open-operator](https://github.com/All-Hands-AI/open-operator)
+  and [AIHawk](https://github.com/feder-cr/AIHawk) repositories, all retrieved
+  2026-09-03; stars, licenses, descriptions and archive status as shown there
+  that day.
+- [OpenAI computer use guide](https://platform.openai.com/docs/guides/tools-computer-use),
+  surfaced via search 2026-09-03, for the 38.1% OSWorld figure quoted in the FAQ.
+
+---
+
+*Maintained alongside [AIHawk](https://github.com/feder-cr/AIHawk), one of the
+repositories on this list. The star counts that beat ours are printed anyway,
+because a survey that hides the bigger projects is an ad, not a survey.*

--- a/docs/openai-operator-vs-claude-computer-use.md
+++ b/docs/openai-operator-vs-claude-computer-use.md
@@ -1,0 +1,181 @@
+---
+title: "OpenAI Operator vs Claude computer use"
+description: "A hosted browser product that no longer exists versus an API building block that does: the two big-vendor approaches to browser agents compared on architecture, availability and cost."
+parent: "Alternatives and Comparisons"
+nav_order: 4
+---
+
+# OpenAI Operator vs Claude computer use
+
+This comparison is lopsided in a way most pages about it do not admit: one
+side no longer exists. OpenAI Operator shut down on 31 August 2025, and the
+agent mode that absorbed it was removed from ChatGPT in August 2026. Claude
+computer use is alive, documented, and available on the Claude API today. So
+the honest version of this page is not a feature race - it is an explanation
+of the two architectures, because the architectural fork they represent is
+still the fork every current tool sits on.
+
+Disclosure: this page is on the wiki of
+[AIHawk](https://github.com/feder-cr/AIHawk), an open-source agent that
+appears in the closing section. Claims about OpenAI trace to their pages and
+mainstream reporting; claims about Anthropic trace to their live
+documentation, all retrieved 2026-09-03.
+
+## Two architectures, not two versions of one thing
+
+**Operator was a hosted product.** You subscribed to ChatGPT Pro, described a
+task, and OpenAI's model drove a browser session for you, doing what its
+successor's users later described as "visual, GUI-based actions": look at the
+rendered page, click, type, hand control back for logins. The environment,
+the browser, and the model all belonged to OpenAI. You brought a task and a
+subscription.
+
+**Claude computer use is an API tool, not a product.** Anthropic's
+documentation is explicit about the division of labor: "When you use computer
+use, Claude doesn't directly connect to this environment. Instead, your
+application: receives Claude's tool use requests, translates them into actions
+in your computing environment, captures the results... and returns these
+results to Claude." Claude sends actions like `screenshot`, `left_click`, and
+`type` with pixel coordinates; your code executes them against a display you
+own, typically a container running a virtual display and a browser; the loop
+repeats until the task is done.
+
+The consequence of the fork is everything else on this page. A hosted product
+is convenient and disposable - Operator's own history proved the second part.
+An API building block is work up front and yours afterwards: the environment,
+the browser choice, the guardrails, and the operating costs are all decisions
+you get to make and have to make.
+
+## Availability, verified this session
+
+**Operator: unavailable.** No tier of ChatGPT restores it or its agent-mode
+successor; OpenAI's help pages point long multi-step tasks at ChatGPT Work,
+and browser-based agentic work at the ChatGPT desktop app and Chrome
+extension. The full churn timeline is on
+[Is OpenAI Operator still available?](is-openai-operator-still-available.md).
+For developers, OpenAI's own entry in this architecture is the
+`computer-use-preview` model in the Responses API - a research preview, gated
+to usage tiers 3-5, and notably the same shape as Anthropic's approach: a
+screenshot loop over an environment you provide.
+
+**Claude computer use: generally available on the API.** The current toolset
+version (`computer_toolset_20260801`) needs no beta header and is supported by
+the current model families on the Claude API and the major cloud platforms,
+some marked beta. Anthropic publishes a reference environment (a container
+with a virtual display and browser) as a starting point.
+
+**The consumer-side counterpart.** If what you actually wanted was
+Operator-as-a-user rather than computer-use-as-a-developer, Anthropic's
+equivalent is Claude in Chrome, generally available to paid plans since
+26 August 2026, which drives the Chrome you already run rather than a hosted
+browser.
+
+## What each costs
+
+Operator's cost model was a subscription: it launched inside ChatGPT Pro. Its
+API descendant, `computer-use-preview`, is priced per token ($3 per million
+input, $12 per million output, per OpenAI's model page).
+
+Claude computer use is standard API token pricing with no special rate, and
+the practical cost driver is screenshots: Anthropic's docs put each one at
+roughly 1,000 to 1,800 tokens and recommend keeping no more than about twenty
+in context. A long browsing session is mostly paying to re-look at the screen.
+That is not a criticism of Anthropic; it is the tax the
+screenshot-and-coordinates architecture itself levies, and OpenAI's version
+pays it too.
+
+## What each can and cannot do
+
+**The screenshot loop is general.** Anything visible on a display is in
+scope: browsers, desktop applications, dialogs. Agent benchmarks reflect the
+generality: OpenAI reported 38.1% on OSWorld for its computer-use model, and
+Anthropic's docs devote most of their length to environment setup and safety
+because the tool will do whatever the pixels afford.
+
+**Both vendors bound their agents deliberately.** Anthropic's docs recommend
+sandboxed VMs, allowlisted domains, avoiding handing over credentials, and
+human confirmation for consequential actions, and state that classifiers
+screen for prompt injection and can steer the model to ask for confirmation.
+Operator similarly declined categories of task while it existed. If your use
+case sits near those edges, a vendor agent will keep declining, and that is
+by design rather than a defect.
+
+**Neither controls what the website sees very well.** A hosted browser or a
+reference container is a recognizable environment:
+[a headless server machine answers a page's questions differently from a
+desktop](https://github.com/feder-cr/invisible_playwright/wiki/headless-browser-agent-on-a-server),
+and [an agent's pacing is its own signal](https://github.com/feder-cr/invisible_playwright/wiki/ai-agent-timing-signal).
+With computer use you at least own the environment and can improve it; with a
+hosted product you could not.
+
+## The scorecard
+
+| Axis | Operator (historical) | Claude computer use (current) |
+|---|---|---|
+| Status on 2026-09-03 | Shut down 2025-08-31; successor mode removed 2026-08 | Available on the Claude API, current toolset GA |
+| Shape | Consumer product | API tool inside your agent loop |
+| Environment | OpenAI-hosted browser | Yours: VM/container, display, browser |
+| Model | OpenAI's, fixed | Claude models, your API key |
+| Cost | Subscription tier | Per token; screenshots dominate |
+| Who fixes it when it breaks | Nobody, now | You, which cuts both ways |
+
+## The third option
+
+There is a paragraph missing from most Operator-versus-Claude pages, and it is
+the one that changes the decision: you do not have to choose between a vendor
+product and building a computer-use loop from scratch. Open-source agents ship
+the loop already built, run on your machine, and take your model key -
+browser-use and Skyvern drive Chromium-family browsers, Agent S3 does the
+whole desktop, and our own AIHawk pairs the agent with a Firefox patched at
+the C++ level so the browser itself presents a normal desktop fingerprint
+instead of a reference container's. None of them, ours included, guarantees a
+site will not push back - [that boundary is documented, not waved
+away](why-does-my-ai-agent-get-blocked.md) - but all of them survive a vendor
+reorg, which is more than one side of this page's title can say. The survey is
+at [Open-source Operator-style agents](openai-operator-open-source.md).
+
+## Short answers to the questions that lead here
+
+**Which is better, Operator or Claude computer use?** The question expired:
+Operator no longer exists. Its architectural heirs at OpenAI are ChatGPT's
+built-in agentic browsing and the tier-gated `computer-use-preview` API.
+
+**Is Claude computer use a product I can just use?** Not by itself: it is an
+API tool, and you supply the environment and the agent loop. The
+consumer-shaped version is Claude in Chrome, on paid plans.
+
+**Can Claude computer use control a real browser?** Yes: whatever browser you
+put in the environment it controls, via screenshots and coordinates.
+
+**Which is cheaper?** Not comparable in kind: Operator was a subscription;
+computer use is per-token, with screenshots as the dominant cost. For steady
+workloads, measure a real session before assuming either direction.
+
+**Do either of them solve captchas or guarantee access to sites?** No, and
+both vendors' materials point the other way: bounded action, confirmation for
+consequential steps, and sites remain free to challenge any visitor.
+
+**What if I want this without a big-vendor dependency?** The open-source
+route in the previous section; start with
+[Choosing an AI browser agent](best-ai-browser-agent.md).
+
+**See also:** [Is OpenAI Operator still available?](is-openai-operator-still-available.md)
+for the shutdown timeline this page leans on,
+[OpenAI Operator alternatives](openai-operator-alternatives.md) for the whole
+field, and [Open-source computer-use agents](computer-use-agent-open-source.md)
+for the screenshot-loop architecture in open source.
+
+## Sources
+
+- [Anthropic: computer use tool documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool), retrieved 2026-09-03; quotes, toolset version, model support, screenshot token figures and safety guidance are from this page.
+- [Wikipedia: OpenAI Operator](https://en.wikipedia.org/wiki/OpenAI_Operator), retrieved 2026-09-03, for launch and shutdown dates and the OSWorld figure.
+- [OpenAI help: ChatGPT agent](https://help.openai.com/en/articles/11752874-chatgpt-agent), [OpenAI computer use guide](https://platform.openai.com/docs/guides/tools-computer-use) and [computer-use-preview model page](https://developers.openai.com/api/docs/models/computer-use-preview), surfaced via search 2026-09-03.
+- [OpenAI community: "Agent Mode was removed with no real replacement"](https://community.openai.com/t/agent-mode-was-removed-with-no-real-replacement/1389601), retrieved 2026-09-03.
+- Coverage of Claude in Chrome's general availability, surfaced via search 2026-09-03, including [Engadget on Cowork in the Chrome sidebar](https://www.engadget.com/2235919/claude-cowork-can-now-run-in-a-chrome-sidebar/).
+
+---
+
+*Written while maintaining [AIHawk](https://github.com/feder-cr/AIHawk), an
+open-source agent that competes with both approaches described here. That is
+exactly why the quotes come from the vendors' own pages: grade our homework
+against their material, not our summary of it.*

--- a/docs/why-does-my-ai-agent-get-blocked.md
+++ b/docs/why-does-my-ai-agent-get-blocked.md
@@ -1,0 +1,205 @@
+---
+title: "Why does my AI agent get blocked?"
+description: "Four independent layers block agents - browser fingerprint, IP reputation, volume, behavioral rhythm. Which your framework can fix, and the order to check them in."
+parent: "When the Agent Gets Blocked"
+nav_order: 1
+---
+
+
+# Why does my AI agent get blocked?
+
+Because of one of four things, and they are genuinely independent: the browser's
+fingerprint, the IP's reputation, the volume of requests, or the rhythm of the
+actions. A site can flag any one of them on its own, fixing one buys you nothing on
+the other three, and most wasted debugging time in this area comes from fixing the
+wrong layer, usually by swapping tools when the problem was the network, or swapping
+networks when the problem was the tool.
+
+This page is the map: what each layer is, which ones an agent framework can fix for
+you, which ones nothing can fix for you, and the order to check them in. It stays at
+the level of an agent user; the mechanism deep-dives live on the
+invisible_playwright wiki and are linked where they belong, starting with the
+overview of the whole model,
+[how do websites detect bots](https://github.com/feder-cr/invisible_playwright/wiki/how-do-websites-detect-bots).
+
+## Layer 1: the browser fingerprint
+
+Before your agent takes a single action, the page has already read the browser. Two
+kinds of reading happen. On the network, the TLS handshake itself has a shape, the
+order of ciphers and extensions offered, and that shape identifies the software
+sending it before any page content loads; automation stacks that are not real
+browsers, or modified ones, produce shapes no retail browser produces. The
+mechanics are on the wiki:
+[JA3 and JA4, why a TLS fingerprint cannot be patched](https://github.com/feder-cr/invisible_playwright/wiki/ja3-ja4-tls-fingerprint).
+In the page, JavaScript reads dozens of properties, canvas rendering, GPU strings,
+fonts, screen values, timezone, and joins them. It is not looking for any single
+rare value; it is looking for values that disagree with each other, a browser that
+claims one operating system while rendering like another, or the known defaults of
+an automation build.
+
+**Can the framework fix it? Yes.** This is the one layer that is entirely the
+tooling's job, because the fingerprint is a property of the browser the agent
+ships. It is also where agent frameworks differ most: an agent driving a stock
+automation browser inherits that browser's tells. AIHawk's browser is a real
+Firefox patched at the C++ level (the invisible_playwright engine), built so that
+what both kinds of reading see is a consistent, ordinary Firefox, and that is its
+honest advantage on exactly this layer. Stated just as plainly: it does nothing for
+the three layers below. A clean fingerprint on a flagged IP, over a rate limit, or
+acting with machine rhythm still gets blocked, and any tool telling you otherwise
+is describing one layer as if it were all four.
+
+## Layer 2: IP and network reputation
+
+Every request carries the address it came from, and the address carries history and
+context you cannot see: what network announces it (a datacenter range or a
+residential one), what else has been done from it, and how many other clients are
+using it right now. Sites score this before your browser is even considered, and a
+bad score blocks a perfect browser. The full mechanism, including why the network
+operator matters more than the individual address, is on the wiki:
+[ASN and IP reputation in bot detection](https://github.com/feder-cr/invisible_playwright/wiki/asn-and-ip-reputation-in-bot-detection).
+
+**Can the framework fix it? No, and be suspicious of anything claiming to.** The
+exit address is supplied by you: your machine's connection, or a proxy you
+configure. What a good framework does is honor the choice cleanly; AIHawk's
+`--proxy` option, for instance, routes egress through the proxy you give it and
+aligns timezone and locale to the exit so the browser does not contradict its own
+address. Choosing an exit worth using, an address that is not a datacenter range
+and not shared with a crowd, is a purchasing decision, not a software feature.
+
+## Layer 3: volume and rate
+
+Sites count. Requests per minute from one address, pages per session, sessions per
+account, and they act on thresholds long before anything sophisticated runs. Agents
+trip this layer in a specific, self-inflicted way: retries. An agent that fails a
+step tends to try again immediately, and a loop of failures becomes a burst of
+identical requests, which reads as exactly what it is. One blocked response can
+become a hard block purely through the agent's own persistence; that failure mode
+has its own page,
+[agent retry loops and rate limits](agent-retry-loops-rate-limits.md).
+
+**Can the framework fix it? Only partly.** A framework can cap retries and space
+its own requests, and an assistant driving a browser over MCP can be told to slow
+down. But volume is mostly decided by what you ask for: "check these 400 pages" is
+a volume decision made in the prompt, and no tooling downstream of the prompt can
+unmake it. Rate limits are also legitimate; the responsible reading of a 429
+response is to honor it, not to engineer around it.
+
+## Layer 4: behavioral rhythm
+
+Even with a clean browser, a clean address and modest volume, the way an agent acts
+is measurable. An LLM loop emits actions with machine-regular gaps clustered around
+the model's latency, pointers that arrive without travel, forms filled with no
+reading time. Humans are ragged; loops are not. This signal needs no fingerprint
+and no reputation database, just timestamps. The full anatomy is on
+[the timing-signal page](ai-agent-timing-signal.md).
+
+**Can the framework fix it? Partly, and honestly only partly.** The browser layer
+can make individual actions human-shaped; AIHawk's engine, for example, moves the
+pointer along curved paths rather than teleporting it, and the agent acts through
+real input events rather than setting values from JavaScript, because pages can
+tell the difference. What no browser can supply is the cadence between actions,
+the pauses, the reading time, the irregularity, because that rhythm is produced by
+the loop above the browser. With an agent you drive through prompts, pacing is
+partly promptable: asking for one thing at a time, at human speed, is not a joke
+instruction, it changes the emitted rhythm.
+
+## The order to check them in
+
+When an agent starts getting blocked, check cheapest and most-likely first, and
+change one thing at a time or you will not know which change mattered.
+
+1. **Same task by hand, same machine, same network.** Open the site yourself in a
+   normal browser. Blocked too? The problem is layer 2 (or the site blocks your
+   whole region or network); no agent-side change will help until the exit
+   changes.
+2. **Blocked on the very first page load, before the agent did anything?** Then
+   volume and behavior are innocent, they have not happened yet. It is fingerprint
+   or IP. If the same exit works by hand in a normal browser, suspect the agent's
+   browser: this is the layer where
+   [the tooling comparison](ai-browser-agent-open-source.md) genuinely differs.
+3. **Blocked after many pages, or on retries?** Count your own requests, and read
+   what the agent did when the first failure appeared. A retry storm in the
+   transcript is layer 3, and the fix is caps and honoring limits, not stealth.
+4. **Blocked mid-session, after actions on the page?** With the first three layers
+   ruled out, look at rhythm: instant fills, zero think time, identical pacing
+   between actions. That is layer 4, and it lives in how the agent is driven.
+
+Two cluster pages apply this checklist to specific stacks people arrive from:
+[Claude computer use detected as a bot](claude-computer-use-detected-as-bot.md) and
+[browser-use getting blocked](browser-use-getting-blocked.md).
+
+## What this means before you swap anything
+
+The four layers assign responsibility cleanly, and it is worth saying who owns
+what with no comfort in it:
+
+- **Fingerprint: the framework's job.** If this layer is your problem, changing
+  the agent's browser changes the outcome.
+- **IP: your job.** Bought, not configured.
+- **Volume: mostly your job.** The prompt decides the ask; the framework can only
+  keep the ask from becoming a storm.
+- **Rhythm: shared.** The browser shapes each action; the loop, and the way you
+  drive it, shapes the cadence.
+
+And one boundary that belongs on the funnel page of a cluster like this: none of
+the above is a way around a site that has told you no. Sites signal their terms
+through rate limits, robots policies and account rules; the four layers explain
+why an agent doing legitimate work gets misread as hostile, and the fixes here are
+about not being misread, not about defeating a refusal.
+
+## Short answers to the questions that lead here
+
+**Why is my agent blocked when the same site works in my normal browser?** Then
+layer 2 is partly ruled out and the leading suspect is layer 1, the agent's
+browser fingerprint, with the agent's own volume and rhythm next. Work through the
+order above before swapping anything.
+
+**Does a stealth browser make my agent unblockable?** No, and distrust the word.
+It addresses one layer of four. A patched real Firefox like AIHawk's fixes what
+the site reads from the browser; the IP, the volume and the pacing are untouched
+by it, and any of the three can block you alone.
+
+**Do I need a proxy for my agent?** If your own address is the problem, or the
+task needs a different region, yes, and quality decides everything; a widely
+shared or datacenter exit can be worse than none. See the wiki's
+[IP-reputation page](https://github.com/feder-cr/invisible_playwright/wiki/asn-and-ip-reputation-in-bot-detection)
+for what actually gets scored.
+
+**Why did the agent work for ten pages and then get blocked?** That shape points
+at layer 3. Look for a retry loop in the transcript first; agents amplify one
+failure into a burst, which is the layer-3 signature.
+
+**Can the site tell it is specifically an AI agent?** It can read signals that
+correlate strongly with one: automation fingerprints and machine-regular action
+timing. The rhythm signal is the agent-specific tell, covered on
+[the timing-signal page](ai-agent-timing-signal.md).
+
+**Which layer does AIHawk actually fix?** The fingerprint layer, because its
+browser is a real Firefox patched at the C++ level rather than a stock automation
+build, plus human-shaped individual actions. It does not fix IP reputation, volume
+or the loop's cadence, and this wiki says so on every page that touches the
+subject.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [How do websites detect bots](https://github.com/feder-cr/invisible_playwright/wiki/how-do-websites-detect-bots),
+  the mechanism-level overview of the same four-layer model.
+- [JA3 and JA4: why a TLS fingerprint cannot be patched](https://github.com/feder-cr/invisible_playwright/wiki/ja3-ja4-tls-fingerprint),
+  for the network side of layer 1.
+- [ASN and IP reputation in bot detection](https://github.com/feder-cr/invisible_playwright/wiki/asn-and-ip-reputation-in-bot-detection),
+  for layer 2.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README in this
+  repository, for the engine, proxy and input-event claims about AIHawk.
+
+**See also:** [the timing signal AI agents give off](ai-agent-timing-signal.md),
+[agent retry loops and rate limits](agent-retry-loops-rate-limits.md),
+[Claude computer use detected as a bot](claude-computer-use-detected-as-bot.md), and
+[browser-use getting blocked](browser-use-getting-blocked.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. AIHawk's engine exists
+for layer 1, which is why this page could afford to be blunt about the other three:
+they are yours, whatever agent you run.*

--- a/scripts/build_wiki.py
+++ b/scripts/build_wiki.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Render the Jekyll docs/ tree into a GitHub wiki checkout.
+
+Usage: build_wiki.py <docs_dir> <out_dir>
+
+A GitHub wiki is a flat set of <Page>.md files with no Jekyll front matter and a
+_Sidebar.md for navigation. This converter, for every docs/*.md:
+  - strips the YAML front matter (the body already starts with the H1),
+  - rewrites internal links [x](slug.md[#a]) -> [x](slug[#a]) (wiki has no .md),
+  - names the page by its slug (stable URLs matching the docs site), except
+    index.md -> Home.md (the wiki landing page),
+and then generates _Sidebar.md mirroring the parent/has_children/nav_order tree.
+"""
+import os, re, sys
+
+DOCS = sys.argv[1]
+OUT = sys.argv[2]
+
+def parse(path):
+    t = open(path, encoding="utf-8").read()
+    fm, body = {}, t
+    m = re.match(r'^---\n(.*?)\n---\n?(.*)$', t, re.S)
+    if m:
+        for line in m.group(1).splitlines():
+            mm = re.match(r'([A-Za-z_]+):\s*(.*?)\s*$', line)
+            if mm:
+                v = mm.group(2)
+                if len(v) >= 2 and v[0] == '"' and v[-1] == '"':
+                    v = v[1:-1]
+                fm[mm.group(1)] = v
+        body = m.group(2)
+    return fm, body.lstrip("\n")
+
+# Subdirectories are walked, not skipped. `docs/` grew `integrations/` with nine
+# pages, and a converter reading only the flat level dropped all nine AND left
+# every link into them pointing at a wiki page that does not exist - nine dead
+# links across eight pages, invisible because the pages themselves rendered.
+# A wiki is flat, so a subdirectory page is named by its own slug, except an
+# `index`/`README` inside a directory, which takes the DIRECTORY's name so that
+# a `](integrations/)` link has somewhere to land.
+pages = {}
+sources = {}
+for dirpath, _dirnames, filenames in os.walk(DOCS):
+    rel = os.path.relpath(dirpath, DOCS).replace(os.sep, "/")
+    for f in sorted(filenames):
+        if not f.endswith(".md"):
+            continue
+        stem = f[:-3]
+        if rel == ".":
+            slug = stem
+            src = stem
+        elif stem in ("index", "README"):
+            slug = rel.split("/")[-1]
+            src = rel
+        else:
+            slug = stem
+            src = rel + "/" + stem
+        if slug in pages:
+            raise SystemExit(
+                "two docs pages want the same flat wiki name %r: %s and %s. "
+                "A wiki has no directories, so this has to be resolved in "
+                "docs/ rather than silently letting one overwrite the other."
+                % (slug, sources[slug], src))
+        pages[slug] = parse(os.path.join(dirpath, f))
+        sources[slug] = src
+
+valid = set(pages.keys())
+#: Every way a doc page can be addressed from another one, mapped to its flat
+#: wiki name: bare slug, `dir/slug`, either with `.md`, and `dir/` on its own.
+addressable = {src: slug for slug, src in sources.items()}
+for slug, src in sources.items():
+    if "/" in src:
+        addressable.setdefault(src.split("/")[-1], slug)
+# `dir/` on its own is how a page links to a directory index, and it needs the
+# trailing form for EVERY source, not only the ones that already carry a slash:
+# `integrations/README.md` has the source `integrations`, so the first cut of
+# this left `](integrations/)` as the single dead link out of 325 pages.
+for src in list(addressable):
+    addressable.setdefault(src + "/", addressable[src])
+
+def rewrite(body):
+    def repl(m):
+        target, anchor = m.group(1), (m.group(2) or "")
+        hit = addressable.get(target) or (target if target in valid else None)
+        if hit:
+            return "](" + ("Home" if hit == "index" else hit) + anchor + ")"
+        return m.group(0)
+    # `[a-z0-9/-]` and an optional `.md`: a link into a subdirectory carries the
+    # slash and may or may not carry the extension, and the first version of
+    # this pattern matched neither.
+    return re.sub(r'\]\(([a-z0-9/\-]+)(?:\.md)?(#[A-Za-z0-9\-]+)?\)', repl, body)
+
+os.makedirs(OUT, exist_ok=True)
+written = 0
+for slug, (fm, body) in pages.items():
+    name = "Home" if slug == "index" else slug
+    open(os.path.join(OUT, name + ".md"), "w", encoding="utf-8", newline="\n").write(rewrite(body) + "\n")
+    written += 1
+
+def title_of(slug):
+    return pages[slug][0].get("title", slug)
+
+def link(slug):
+    return "[%s](%s)" % (title_of(slug), "Home" if slug == "index" else slug)
+
+def children_of(group_title):
+    kids = [(s, fm) for s, (fm, b) in pages.items() if fm.get("parent") == group_title]
+    kids.sort(key=lambda x: int(x[1].get("nav_order", "999")))
+    return kids
+
+toplevel = [(s, fm) for s, (fm, b) in pages.items() if not fm.get("parent") and s != "index"]
+toplevel.sort(key=lambda x: int(x[1].get("nav_order", "999")))
+
+lines = ["### " + link("index"), ""]
+for slug, fm in toplevel:
+    t = title_of(slug)
+    lines.append("**%s**" % t)
+    for cs, cfm in children_of(t):
+        if cfm.get("has_children") == "true":
+            lines.append("- %s" % link(cs))
+            for gs, gfm in children_of(cfm.get("title", cs)):
+                lines.append("  - %s" % link(gs))
+        else:
+            lines.append("- %s" % link(cs))
+    lines.append("")
+open(os.path.join(OUT, "_Sidebar.md"), "w", encoding="utf-8", newline="\n").write("\n".join(lines) + "\n")
+
+print("wrote %d pages + _Sidebar.md to %s" % (written, OUT))


### PR DESCRIPTION
## Summary

Opens AIHawk's wiki with the infrastructure already proven on invisible_playwright (a `docs/` tree, `scripts/build_wiki.py`, and a `publish-wiki` workflow that renders it into the GitHub wiki on release or manual dispatch) and its first twenty pages, chosen from measured search data rather than guesses: 53 live SERPs were read before writing anything.

**Alternatives and Comparisons** (10 pages): the OpenAI Operator cluster (alternatives, open-source options, current availability, vs Claude computer use - with the full verified 2025-2026 timeline: Operator shut down Aug 2025, agent mode removed Aug 2026, Atlas shut down Aug 2026), browser-use alternatives, choosing an AI browser agent, open-source AI browser agents, open-source computer-use agents, what an AI web agent is, and agents vs traditional scraping. Every page carries the conflict-of-interest disclosure at the top, and every claim about another tool traces to that tool's own site or source, fetched while writing.

**When the Agent Gets Blocked** (5 pages): the funnel cluster - why agents get blocked (four independent layers, which ones no agent framework fixes), plus four pages adapted from the invisible_playwright wiki's AI-agents section (timing signal, retry loops, computer-use detection, browser-use's config surface), retargeted to agent language. Mechanism depth stays on the engine wiki via absolute links; these pages stay at the agent level.

**Job Application Automation** (4 pages): the project's heritage, written honestly - automating applications with Claude (the MCP route this repo already documents), with ChatGPT (against the verified current state of OpenAI's offerings), in Python, and the history page that owns the 30k-star story including the criticism. No job board, company site or ATS vendor is named anywhere, per the same rule `articles/README.md` already declares.

**Using the Agent** (1 page): getting an agent to fill out forms.

Plus a Home page and four hub pages that generate the wiki sidebar.

## Test plan

- [x] `scripts/check_english_only.py` clean (full tree)
- [x] Zero em/en-dashes, pure ASCII across all 25 docs pages
- [x] All internal links resolve; engine-wiki links are absolute URLs
- [x] `scripts/build_wiki.py docs <out>` builds all 25 pages + _Sidebar with no collisions
- [x] No target-site or proxy-provider names (scanned)

After merge: enable the repo wiki and dispatch the `publish-wiki` workflow.

Generated with Claude Code
