### PR TITLE
The two-column table clipped the command it was there to show

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,164 +20,148 @@
 
 ---
 
-## First, one prerequisite for both ways
+## Two ways to use it
 
-**Python 3.11 or newer**, on **Windows (x86_64) or Linux (x86_64, arm64)** - macOS
-is not supported, the last engine build for it was `firefox-20`. Then
-[uv](https://docs.astral.sh/uv/), because both commands below start with `uvx`:
+The only question is where the model comes from.
 
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh              # Linux
-```
-```powershell
-irm https://astral.sh/uv/install.ps1 | iex                   # Windows
-```
+### 1. You already use Claude Code, Claude Desktop or Cursor
 
-## Now pick one
-
-**Do you already use an AI assistant that can run tools - Claude Code, Claude
-Desktop, Cursor?** If yes, it brings the model and you add this browser to it. If
-no, or if you would rather watch the work happen, run our interface instead.
-
-<table>
-<tr>
-<th width="50%">1. Add it to the assistant you have</th>
-<th width="50%">2. Run our interface</th>
-</tr>
-<tr>
-<td valign="top">
-
-Your assistant brings the model. Nothing to pay us, nothing to sign up for.
-
-**Claude Code**, once for every project:
+Your assistant brings the model. You add this browser to it, and nothing changes
+about how you work.
 
 ```bash
 claude mcp add -s user stealth -- uvx invisible-playwright-mcp
 ```
 
-**Claude Desktop, Cursor, and the rest** take a config file instead. The block to
-paste, and which file it goes in, are in the
-[server's README](https://github.com/feder-cr/invisible-playwright-mcp).
-
-Then talk to your assistant as usual:
+Then ask your assistant, in the window you already have open:
 
 > Go to news.ycombinator.com and give me the top five titles.
 
-</td>
-<td valign="top">
+For Claude Desktop, Cursor and the rest, which take a config file instead, the
+block to paste is in the [server's README](https://github.com/feder-cr/invisible-playwright-mcp).
 
-We bring the interface, you bring an [OpenRouter](https://openrouter.ai) account
-and its key. Chat on the left, the live browser on the right.
+### 2. You don't, or you want to watch it work
+
+We bring the interface, you bring an [OpenRouter](https://openrouter.ai) key.
+Chat on the left, the live browser on the right.
 
 ```bash
 uvx aihawk ui --openrouter-key sk-or-...
 ```
 
-Open **http://127.0.0.1:8765** and type the same thing.
+Then open **http://127.0.0.1:8765** and type the same thing.
 
-Curious first? `uvx aihawk ui` runs with no key at all on a placeholder that
-takes literal commands, which is enough to see the interface work and to tell a
-browser problem from a model problem before spending anything.
+No key yet? `uvx aihawk ui` starts anyway on a placeholder that takes literal
+commands, which is enough to see the interface work.
 
-</td>
-</tr>
-</table>
+**Same patched Firefox behind both.** AIHawk reaches it through that MCP server,
+over MCP, exactly as your assistant would.
 
-Same patched Firefox behind both. AIHawk reaches it through that MCP server, over
-MCP, exactly as your assistant would - so anything the interface can do, your
-assistant can do too.
+---
 
-## The download nobody warns you about
+## Before either one
 
-The browser is about a quarter of a gigabyte and it is **not** fetched when you
-install either side. It arrives on the **first request that needs a page**, which
-means your first instruction sits there doing nothing for a while, and on a slow
-connection the assistant may report a timeout that says nothing about a download.
+**Python 3.11 or newer**, on **Windows (x86_64)** or **Linux (x86_64, arm64)**.
+macOS is not supported: the last engine build for it was `firefox-20`.
 
-Get it over with first, in a terminal where you can watch it:
+Both commands above start with `uvx`, so you need [uv](https://docs.astral.sh/uv/):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh              # Linux
+powershell -c "irm https://astral.sh/uv/install.ps1 | iex"   # Windows
+```
+
+**The browser is a separate download of about a quarter of a gigabyte**, and it
+does not arrive when you install either side. It arrives on the first request
+that needs a page, so your first instruction sits there for a while and a slow
+connection can time out with an error that says nothing about a download. Get it
+over with first, where you can watch it:
 
 ```bash
 uvx invisible-playwright fetch
 ```
 
-Cached afterwards, and shared by both ways in. Per-platform sizes are in the
-[engine's README](https://github.com/feder-cr/invisible_playwright).
+---
+
+## What to ask it
+
+Anything that needs a browser rather than an API, and a person's judgement about
+what is on the page.
+
+> Go to `<paste the URL>`. One way, Milan to Lisbon, economy, one checked bag,
+> one adult. Check every date from the 12th to the 16th of next month, one at a
+> time, and read the cheapest fare for each day. The date field is a calendar
+> widget, so click the days rather than typing them. If a date has no
+> availability, say so. Do not guess a number.
+
+It drives the page the way a person would: the pointer moves, keys are pressed,
+and it refuses to set a form field from JavaScript even when that would be
+quicker, because a page can tell the difference.
 
 ## Without a page, for scripts and cron
-
-Same machinery, no interface, the answer on stdout.
 
 ```bash
 uvx aihawk do "Go to example.com and tell me the top headline" --openrouter-key sk-or-...
 ```
 
-The keyless placeholder from column 2 takes exactly these: `go <url>`,
-`read [selector]`, `click <selector>`, `type <selector> <text>`, `tab` (opens a new
-browser tab), `shot`.
-
-## What it is good at
-
-Anything that needs a browser rather than an API, and needs a person's judgement
-about what is on the page.
-
-> Go to `<paste the URL>`. One way, Milan to Lisbon, economy, one checked bag, one
-> adult. Check every date from the 12th to the 16th of next month, one at a time,
-> and read the cheapest fare for each day. The date field is a calendar widget, so
-> click the days rather than typing them. If a date has no availability, say so.
-> Do not guess a number.
-
-It drives the page the way a person would: the pointer moves, keys are pressed, and
-it will refuse to set a form field from JavaScript even when that would be quicker,
-because a page can tell the difference.
+Same machinery, no interface, the answer on stdout.
 
 ## Options
 
-`ui` and `do` share all of these except the last row, which is `ui` only.
+`ui` and `do` take all of these except the last one, which is `ui` only.
 
-| Option | What it does |
-|---|---|
-| `--openrouter-key` | Your key, or the `OPENROUTER_API_KEY` variable. Required for `do`, optional for `ui`. |
-| `--model` | An OpenRouter model id, or `AIHAWK_MODEL`. Defaults to `z-ai/glm-4.6`. |
-| `--proxy` | Optional. `http://user:pass@proxy.example.com:8080`, or `socks5://proxy.example.com:1080`. Host and port are both required; a bare scheme is rejected. With one set, the timezone, locale and egress follow it. |
-| `--binary` | Path to an engine binary you already have. It must be the exact build the packaged seal pins, or startup refuses: this skips the download, not the version check. |
-| `--seed` | An integer. Same seed, same browser identity, every run. Set one for anything you run twice. |
-| `--profile-dir` | A directory to keep the profile in, so logins and cookies survive restarts. A relative path works and resolves from where you ran the command, which is rarely what you want. |
-| `--headed` | Show the browser window. The interface shows you the page anyway. |
-| `--host`, `--port` | `ui` only. `127.0.0.1` and `8765`. Changing the host exposes the interface, and it has no authentication, so anyone who can reach the port can drive your browser. |
+- **`--openrouter-key`** Your key, or the `OPENROUTER_API_KEY` variable.
+  Required for `do`, optional for `ui`.
+- **`--model`** An OpenRouter model id, or `AIHAWK_MODEL`. Defaults to `z-ai/glm-4.6`.
+- **`--proxy`** Optional. `http://user:pass@proxy.example.com:8080` or
+  `socks5://proxy.example.com:1080`. Host and port are both required. The
+  timezone, locale and egress follow it.
+- **`--binary`** An engine binary you already have. It must be the build the seal
+  pins, or startup refuses: this skips the download, not the version check.
+- **`--seed`** An integer. Same seed, same browser identity, every run.
+- **`--profile-dir`** A directory to keep the profile in, so logins and cookies
+  survive restarts.
+- **`--headed`** Show the browser window. The interface shows you the page anyway.
+- **`--host`, `--port`** `ui` only. `127.0.0.1` and `8765`. Changing the host
+  exposes an interface that has no authentication.
 
-Passing `--openrouter-key` puts the key in your shell history, and on Linux in the
-process list for every user on the machine. `OPENROUTER_API_KEY` in the environment
-avoids both.
+Passing `--openrouter-key` puts the key in your shell history, and on Linux in
+the process list. `OPENROUTER_API_KEY` in the environment avoids both.
 
-Either way it does not reach the browser process. It is removed from the environment the
-engine starts with, by name and by value, so a copy kept under a second name -
-`OPENAI_API_KEY` is the usual one - goes too. [`tests/test_key_isolation.py`](https://github.com/feder-cr/AIHawk/blob/main/tests/test_key_isolation.py)
+Either way it does not reach the browser process: it is removed from the
+environment the engine starts with, by name and by value, so a copy under a
+second name goes too.
+[`tests/test_key_isolation.py`](https://github.com/feder-cr/AIHawk/blob/main/tests/test_key_isolation.py)
 fails if that stops being true.
 
 ## The rest of the family
 
-| Project | What it is |
-|---|---|
-| [invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp) | The MCP server from column 1. Tools only, no interface. |
-| [invisible_playwright](https://github.com/feder-cr/invisible_playwright) | The engine, as a Python library. Use it if you would rather write code than prompts: the API is Playwright's. |
-| [invisible_core](https://github.com/feder-cr/invisible_core) | Seed to fingerprint to preferences, proxy and geolocation. |
+- **[invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp)**
+  The MCP server from option 1. Tools only, no interface.
+- **[invisible_playwright](https://github.com/feder-cr/invisible_playwright)**
+  The engine, as a Python library, for writing code instead of prompts. The API
+  is Playwright's.
+- **[invisible_core](https://github.com/feder-cr/invisible_core)**
+  Seed to fingerprint to preferences, proxy and geolocation.
 
 ## Contributing
 
-Issues and pull requests welcome on whichever of those the problem lives in. If you
-are not sure, open it here. See [CONTRIBUTING](https://github.com/feder-cr/AIHawk/blob/main/.github/CONTRIBUTING.md).
+Issues and pull requests welcome on whichever of those the problem lives in. If
+you are not sure, open it here. See
+[CONTRIBUTING](https://github.com/feder-cr/AIHawk/blob/main/.github/CONTRIBUTING.md).
 
 When something fails on a page, say which step, what the page did, what the tool
 returned and which exit country you were on. "It got blocked" is not something
 anyone can act on.
 
-
 ## Using it responsibly
 
-This automates a browser under your control. Read the terms of the sites you point
-it at, respect their rate limits, and do not submit anything a human has not read.
+This automates a browser under your control. Read the terms of the sites you
+point it at, respect their rate limits, and do not submit anything a human has
+not read.
 
 ## License
 
-[MIT](https://github.com/feder-cr/AIHawk/blob/main/LICENSE). Everything distributed before 2 September 2026 was released under
-AGPL-3.0 and stays under it.
+[MIT](https://github.com/feder-cr/AIHawk/blob/main/LICENSE). Everything
+distributed before 2 September 2026 was released under AGPL-3.0 and stays under
+it.

--- a/tests/test_readme_offers_both.py
+++ b/tests/test_readme_offers_both.py
@@ -37,7 +37,10 @@ def _sections():
     """(heading, body) pairs, in order. The lead-in before the first heading is
     returned under an empty heading, because a logo block is not a section."""
     text = README.read_text(encoding="utf-8")
-    parts = re.split(r"^(#{1,3} .*)$", text, flags=re.M)
+    # H1 and H2 only. A page may split the choice into "### 1." and "### 2."
+    # under one heading - that is the same choice, presented well, and an
+    # earlier version of this file called it two sections and went red on it.
+    parts = re.split(r"^(#{1,2} .*)$", text, flags=re.M)
     out = [("", parts[0])]
     for i in range(1, len(parts), 2):
         out.append((parts[i].strip(), parts[i + 1]))
@@ -74,7 +77,7 @@ FIRST_SCREEN = 45
 def _where_the_offer_starts(text):
     """(line number, heading) of the section that carries BOTH commands."""
     lines = text.split(chr(10))
-    heads = [(i, l) for i, l in enumerate(lines, 1) if l.startswith("#")]
+    heads = [(i, l) for i, l in enumerate(lines, 1) if re.match(r"#{1,2} ", l)]
     for pos, (line, heading) in enumerate(heads):
         end = heads[pos + 1][0] if pos + 1 < len(heads) else len(lines) + 1
         body = chr(10).join(lines[line - 1:end - 1])


### PR DESCRIPTION
Opened the page in a browser and looked at it. GitHub gives a README 838 pixels. The two-column HTML table asked for 50% each and put fenced code blocks inside, and code does not wrap: the cells measured 567 and 402, which is 969 in a space of 838. The overflow was 132 pixels at a 1280 viewport and 388 at 1024.

What got cut was `uvx aihawk ui --openrouter-key s...` - the most important line on the page, unreadable, inside the block that exists to make the choice easy.

The table is gone rather than adjusted. Two numbered sections stacked vertically cannot overflow, every command gets the full width, and it reads the same on a phone. Options and the sibling list were tables too, with the first column squeezed hard enough to break `--openrouter-key` over three lines; they are lists now.

Rendered old and new through GitHub's markdown API at 838 pixels and measured again: the old one clips, the new one does not.

The gate moved with it, and it was the gate that was too strict: it split on any heading, so "### 1." and "### 2." under one "## Two ways to use it" read as two sections. It counts H1 and H2 now, and is still red against both READMEs as they were yesterday.