### PR TITLE
Wiki wave two: eight product pages, a fact-check pass, and the README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,17 @@ second name goes too.
 [`tests/test_key_isolation.py`](https://github.com/feder-cr/AIHawk/blob/main/tests/test_key_isolation.py)
 fails if that stops being true.
 
+## The wiki
+
+The reading room around the agent lives in the
+[wiki](https://github.com/feder-cr/AIHawk/wiki): the
+[AI browser-agent landscape and its comparisons](https://github.com/feder-cr/AIHawk/wiki/guides-alternatives-and-comparisons),
+[what to check when an agent gets blocked](https://github.com/feder-cr/AIHawk/wiki/why-does-my-ai-agent-get-blocked),
+[the job-application automation this project grew out of](https://github.com/feder-cr/AIHawk/wiki/guides-job-application-automation),
+and [what happened to OpenAI Operator](https://github.com/feder-cr/AIHawk/wiki/is-openai-operator-still-available),
+among others. Worked examples with recordings live in
+[articles/](https://github.com/feder-cr/AIHawk/tree/main/articles).
+
 ## The rest of the family
 
 - **[invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp)**

--- a/articles/README.md
+++ b/articles/README.md
@@ -30,11 +30,15 @@ theirs or ours.
 
 ## Two rules that are not style
 
-**No target sites.** No job board, retailer, airline or booking site by name,
-in the prose, in a screenshot, or in a recording. Not because the automation is
-secret, but because naming who is being automated against turns a guide into a
-target list. `books.toscrape.com` exists for exactly this and is fair game;
-otherwise use a page you serve yourself.
+**Site names are for subjects, not examples.** A mainstream platform may be
+the declared subject of a guide - a piece about automating a specific site,
+written in the open, honest about what that site's terms say and what the
+reader risks. What stays out is the other thing: naming sites incidentally as
+the targets your demo happens to run against, which turns a guide into a
+target list. For demos and recordings, `books.toscrape.com` exists for exactly
+this and is fair game; otherwise use a page you serve yourself. A guide about
+a named site never includes instructions aimed at defeating that specific
+site's protections.
 
 **No proxy providers, and no credentials.** Not in a config block, not in a URL
 in a screenshot, not in a terminal recording. A recording is the easiest place

--- a/docs/best-ai-browser-agent.md
+++ b/docs/best-ai-browser-agent.md
@@ -36,8 +36,8 @@ removal churn of 2025-2026 is the cautionary tale, told with dates on
 key and let you choose the model. You pay per token, you can switch providers,
 and the agent keeps working when a vendor reorganizes a product line.
 
-**You build the loop.** Claude computer use and OpenAI's
-`computer-use-preview` are API tools: the vendor supplies the model's ability
+**You build the loop.** Claude computer use and OpenAI's computer use tool
+are API offerings: the vendor supplies the model's ability
 to click and type, you supply everything else. Maximum control, real
 engineering cost - the architecture is dissected on
 [OpenAI Operator vs Claude computer use](openai-operator-vs-claude-computer-use.md).

--- a/docs/best-ai-browser-agent.md
+++ b/docs/best-ai-browser-agent.md
@@ -86,7 +86,7 @@ never be blocked is describing a world with no defenders in it. AIHawk's
 position on this axis is a hardened, real-fingerprint browser plus documented
 limits, not a guarantee. The sorting of blame - and what to actually do -
 is [why an agent gets blocked](why-does-my-ai-agent-get-blocked.md), and
-[the timing signal specific to agents](https://github.com/feder-cr/invisible_playwright/wiki/ai-agent-timing-signal)
+[the timing signal specific to agents](ai-agent-timing-signal.md)
 is worth reading before blaming any browser.
 
 Also on this axis: whether you should be automating the site at all. Terms of

--- a/docs/browser-problem-or-model-problem.md
+++ b/docs/browser-problem-or-model-problem.md
@@ -1,0 +1,167 @@
+---
+title: "Browser problem or model problem?"
+description: "When an agent task fails, one of two very different things broke. How to tell them apart with the keyless placeholder and a two-model comparison, before spending on either fix."
+parent: "Using the Agent"
+nav_order: 3
+---
+
+
+# Browser problem or model problem?
+
+When an agent task fails, one of two very different things broke: the browser
+side (the page never arrived, or arrived hostile) or the model side (the page
+was fine and the model mishandled it). The fixes have nothing in common -
+network and identity on one side, model choice and instructions on the other -
+so misdiagnosing sends you shopping in the wrong store. People upgrade to a
+frontier model to fix a blocked page, and swap proxies to fix a model that
+clicks the wrong button, and both spend money to change nothing.
+
+AIHawk gives you an unusually clean way to split the two, and it costs nothing:
+the keyless placeholder. `uvx aihawk ui` with no API key runs the full
+interface and the full stealth browser with no model in the loop at all - your
+typed commands go straight to the browser tools. Whatever happens in that mode
+happened without a model, so it cannot be a model problem. That is the
+instrument this page is built around.
+
+## The instrument: a browser with no model attached
+
+Without a key, the interface swaps the model for a placeholder that understands
+a fixed set of literal commands - `go <url>`, `read [selector]`,
+`click <selector>`, `type <selector> <text>`, `tab`, `shot` - and answers
+anything else with a help line. Each command is one real tool call on the same
+browser, over the same connection, that the real agent would use; the live pane
+on the right shows the page throughout.
+[The keyless-mode page](using-aihawk-without-an-api-key.md) covers it in full;
+here it is a diagnostic probe: you can replay any single step of a failed task
+by hand and see exactly what the browser saw, with zero model behavior mixed
+in.
+
+## Symptoms that point at the browser side
+
+These appear with any model, and with no model:
+
+- **The page never loads.** `go` times out or errors in placeholder mode too.
+  Network, proxy, or the site itself. If a proxy is configured, suspect it
+  first; if this is the first run ever, see the last symptom below.
+- **A challenge page or block message appears instead of the content.** `read
+  body` in placeholder mode shows you verbatim what the site served. If the
+  block is there before any automation logic has acted, no model change can
+  touch it - work through
+  [why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md),
+  which separates fingerprint, IP reputation, volume and rhythm.
+- **It works by hand in your normal browser, but not through AIHawk, on the
+  same network.** That narrows it to the agent's exit or identity rather than
+  the site being down. The blocked page's checklist is the map.
+- **It worked for many pages, then stopped.** Volume or retries, not
+  intelligence. Check the transcript for a retry burst;
+  [retry loops and rate limits](agent-retry-loops-rate-limits.md) is that
+  failure's own page.
+- **The very first instruction ever hangs for minutes.** Probably not a
+  failure at all: the browser engine, roughly a quarter of a gigabyte, downloads
+  on the first request that needs a page. `uvx invisible-playwright fetch` in a
+  terminal gets it over with where you can watch it.
+
+## Symptoms that point at the model side
+
+These appear only with a model in the loop, on pages the placeholder handles
+fine:
+
+- **The right page, the wrong element.** The transcript shows the page loaded
+  and the model clicked or typed somewhere defensible but wrong. Often a
+  field-mapping problem - [the forms page](ai-agent-fill-out-forms.md) covers
+  why look-alike fields invite it.
+- **Loops.** The same action, or the same failing submit, repeated with no
+  change in between. A model that does not register that its last action
+  changed nothing.
+- **Giving up, or declaring victory early.** An answer that does not match
+  what the live pane showed, or a "done" with steps visibly left.
+- **Misreading the task.** It did something coherent, just not what you asked.
+  Usually fixable with a more explicit instruction before it is a reason to
+  change models.
+- **The turn ceiling.** An error saying the task did not finish within
+  `max_turns=25` means the model spent 25 turns without converging. On a
+  genuinely long task, that is the task's problem; on a short one, it is the
+  model wandering.
+- **Unreadable tool arguments.** The transcript notes the model's arguments
+  were not valid JSON and it was told to retry. Occasional is tolerable;
+  frequent is a model quality signal in itself.
+
+## The procedure
+
+1. **Read the failed transcript first.** Both the interface and `aihawk do`
+   ran the same loop; the interface shows each step, what was called, and what
+   came back. Most failures are legible there, and the split is often obvious:
+   a block page in a tool result is browser-side, a wrong click on a healthy
+   page is model-side.
+2. **Replay the failing step in placeholder mode.** Restart the interface with
+   no key, `go` to the same URL, `read` what came back, `click` the same
+   selector. If the failure reproduces with literal commands, it is
+   browser-side, full stop - no model was present. If your hand-driven steps
+   sail through, the page is drivable and the model is the variable.
+3. **Same task, two models.** If step 2 cleared the browser, run the identical
+   instruction with `--model` set to something stronger, and pass the same
+   `--seed` both times so the browser identity is constant and the model is
+   the only thing you moved. One model failing where another succeeds, on the
+   same page and identity, is the clean model-side verdict - and the moment to
+   read [which model to use](which-model-to-use-with-aihawk.md).
+4. **Change one thing at a time.** Swapping model and proxy together tells you
+   nothing whichever way it goes. This is the same discipline as the blocked
+   checklist, because it is the same trap.
+
+## When it is honestly both
+
+The two sides feed each other. A page that starts refusing mid-task makes a
+competent model look lost, because every read comes back strange; and a model
+that reacts to failure by hammering retries turns one soft refusal into a hard
+block, which then greets the next run too. If a transcript shows both, fix the
+browser side first: it is upstream, and model behavior on a hostile page is not
+evidence about the model. Then rerun before judging anything else.
+
+## Short answers to the questions that lead here
+
+**How do I know if my agent failed because of the site or the model?** Replay
+the failing step with literal commands in keyless `aihawk ui`. Reproduces
+without a model: browser side. Works by hand: model side. That single test
+settles most cases.
+
+**The page shows a challenge or block - which side is that?** Browser side,
+always: it was served before any model decision mattered. Work through
+[the blocked page](why-does-my-ai-agent-get-blocked.md); changing models
+changes nothing there.
+
+**The agent clicks the wrong thing - which side?** Model side, if the
+transcript shows the page loaded correctly. Try a sharper instruction first,
+then a stronger model on the same task and seed.
+
+**What does the max_turns error mean?** The model used its 25-turn budget
+without finishing. On a short task, that is a model-side symptom; on a long
+one, split the task into smaller instructions before blaming anything.
+
+**Can I run this diagnosis without spending anything?** The placeholder half,
+yes - keyless mode is free apart from the one-time engine download. The
+two-model comparison spends normal task tokens on each run.
+
+**Do I need the placeholder if I already have a key?** It stays useful with a
+key precisely because it removes the model: any failure it reproduces is
+guaranteed browser-side, which is a certainty no model-driven run gives you.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), this repository's
+  source: `src/aihawk/brain.py` (the placeholder's command set and that each
+  command is a real tool call), `src/aihawk/agent.py` (the shared loop, the
+  turn ceiling, the invalid-arguments retry), and the README (the keyless mode,
+  the engine download and prefetch command).
+
+**See also:** [why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md),
+[using AIHawk without an API key](using-aihawk-without-an-api-key.md),
+[which model to use with AIHawk](which-model-to-use-with-aihawk.md), and
+[agent retry loops and rate limits](agent-retry-loops-rate-limits.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The placeholder
+exists because the maintainer needed this exact split while debugging; it was
+kept as a feature because you will too.*

--- a/docs/browser-use-alternatives.md
+++ b/docs/browser-use-alternatives.md
@@ -33,7 +33,7 @@ stack whole: the same build type, the same driving protocol, the same
 well-studied tells. If your problem is specifically that this stack is being
 recognized, no browser-use setting reaches it. The mechanics are documented on
 the engine wiki:
-[what browser-use configuration can and cannot change](https://github.com/feder-cr/invisible_playwright/wiki/browser-use-detection)
+[what browser-use configuration can and cannot change](browser-use-getting-blocked.md)
 and [why a bundled Chromium is not Chrome](https://github.com/feder-cr/invisible_playwright/wiki/chromium-is-not-chrome).
 
 ### The detection surface, and where it actually lives
@@ -158,7 +158,7 @@ for whether you need an agent at all.
 
 - The [browser-use repository](https://github.com/browser-use/browser-use), retrieved 2026-09-03: stars, license, description, model support and the cloud material.
 - [SiliconANGLE: Browser Use raises $17M](https://siliconangle.com/2025/03/23/browser-use-raises-17m-help-steer-ai-agents-internet/), surfaced via search 2026-09-03.
-- The [invisible_playwright wiki's browser-use configuration analysis](https://github.com/feder-cr/invisible_playwright/wiki/browser-use-detection), which reads `BrowserProfile`'s fields from browser-use's own source; our sibling project, maintained by us.
+- [browser-use getting blocked: what you can and cannot change](browser-use-getting-blocked.md), this wiki's own analysis, which reads `BrowserProfile`'s fields from browser-use's source.
 - The [Skyvern](https://github.com/Skyvern-AI/skyvern), [Agent-S](https://github.com/simular-ai/Agent-S) and [AIHawk](https://github.com/feder-cr/AIHawk) repositories, retrieved 2026-09-03.
 
 ---

--- a/docs/guides-using-the-agent.md
+++ b/docs/guides-using-the-agent.md
@@ -13,3 +13,11 @@ folder; the pages here are the reading companion - what works, what breaks,
 and what to expect before you spend model tokens finding out.
 
 - [Getting an AI agent to fill out forms](ai-agent-fill-out-forms.md)
+- [Which model to use with AIHawk](which-model-to-use-with-aihawk.md)
+- [Browser problem or model problem?](browser-problem-or-model-problem.md)
+- [Running AIHawk's browser from Claude Code](running-aihawk-with-claude-code.md)
+- [Using AIHawk without an API key](using-aihawk-without-an-api-key.md)
+- [Extracting data to a CSV with an AI agent](how-to-extract-data-to-csv-with-an-ai-agent.md)
+- [Monitoring a page for changes with an AI agent](how-to-monitor-a-page-with-an-ai-agent.md)
+- [Running AIHawk's browser from Claude Desktop](running-aihawk-with-claude-desktop.md)
+- [Running AIHawk's browser from Cursor](running-aihawk-with-cursor.md)

--- a/docs/how-to-extract-data-to-csv-with-an-ai-agent.md
+++ b/docs/how-to-extract-data-to-csv-with-an-ai-agent.md
@@ -1,0 +1,201 @@
+---
+title: "Extracting data to a CSV with an AI agent"
+description: "What to say, what the agent actually does underneath, where a scripted scraper wins instead, the failure modes - truncation, drifting columns, cost - and how to verify the output."
+parent: "Using the Agent"
+nav_order: 6
+---
+
+
+# Extracting data to a CSV with an AI agent
+
+The instruction is one sentence: "go to this page, pull every item's name and
+price into a CSV." The agent reads the page's structure, walks the pagination
+if there is any, and hands you the rows. That part genuinely works. The rest of
+this page is what most write-ups skip: what actually happens underneath, why
+cost grows faster than page count, the specific ways extractions go quietly
+wrong, and why you never ship an extraction you have not spot-checked.
+
+The running example is [books.toscrape.com](https://books.toscrape.com/), a
+sandbox built for exactly this practice: 1,000 fictional books, 20 per page
+across 50 pages, each with a title, a price and a stock line. Practice there or
+on a page you serve yourself; the mechanics transfer, the risk does not.
+
+## What you actually say
+
+A working instruction, typed into the AIHawk interface or passed to
+`uvx aihawk do`:
+
+> Go to https://books.toscrape.com/. For each book on the first two pages,
+> extract the title and the price. Reply with CSV only: a header line
+> `title,price`, one line per book, no commentary before or after.
+
+Four choices in there do most of the work:
+
+- **Name the columns.** A model left to choose its own schema chooses a
+  slightly different one next run; a named header line is a contract.
+- **Say "CSV only, no commentary."** Models wrap answers in prose by default,
+  and prose in the middle of a redirected file is a broken file.
+- **Bound the scope.** "The first two pages" is a budget. "Every page" on a
+  50-page catalog is a long, expensive walk that may not finish in one run.
+- **Point at the region when the page is busy.** On a page with sidebars and
+  banners, "the product list in the main column" saves the agent from reading,
+  and you from paying for, everything else.
+
+One mechanical fact, early: the agent has no file-writing
+tool. The browser tools navigate, read, click and type; the CSV materializes as
+the model's final answer, nothing else. From the interface you copy it out of
+the chat; from the command line, `uvx aihawk do "..." > books.csv` works
+because the answer is printed to stdout.
+
+## What happens underneath
+
+The loop is the same one [the explainer](ai-web-agent-explained.md) describes:
+observe, decide one action, repeat. The agent navigates, then reads the page,
+with a text read or a structural snapshot, and the values it extracts live in
+the conversation transcript, not in any database. On a page that fits in one
+read, extraction is a handful of turns. With pagination, each further page is
+another cycle: find the next control, click it, read again, keeping the
+accumulating rows straight in a growing transcript.
+
+That transcript is where the cost curve hides. Every turn resends the entire
+conversation so far to the model, so page ten is priced with pages one through
+nine still in the context. A 20-page walk is not twenty times the cost of one
+page; it is worse, because the pages ride along. The comparison page
+[runs the actual numbers](ai-browser-agents-vs-traditional-scraping.md).
+
+Three hard limits in AIHawk's own loop, taken from its source, bound one run:
+
+- **Tool results are clipped at 8,000 characters** before the model sees them.
+  A 20-item page fits comfortably; a page listing hundreds of items may not.
+- **The loop stops at 25 turns** by default. A navigate-and-read cycle per page
+  plus the reading turns means a full 50-page walk does not fit in one run.
+- **The final reply has a token ceiling** (8,192 tokens). Around a thousand
+  rows, the CSV itself outgrows the answer that is supposed to carry it.
+
+These are budgets, not defects, and the practical consequence is one habit:
+batch. "Pages one to ten, then stop" completes and verifies; "all fifty pages"
+runs long, costs more per row, and can hit a ceiling with the work
+half-carried.
+
+## Where this beats a scraper, and where it loses
+
+The honest comparison has [its own page](ai-browser-agents-vs-traditional-scraping.md);
+the extraction-specific summary: the agent wins when the task is small,
+one-off, or needs judgment a selector cannot express - twenty differently-built
+pages, a "category" column that requires reading the item, a layout that changed
+last week and will change again. You state intent once and pay cents.
+
+The scraper wins on volume and repetition, and it is not close. The 1,000 books
+of the example are a few lines of deterministic code that run in seconds, cost
+nothing per run, and produce the same bytes every time. If you will extract the
+same shape from the same site more than a handful of times, the strongest
+pattern is the hybrid: use the agent once to discover where the data lives,
+then let it help you write the script that does the repeated runs.
+
+## The failure modes, specifically
+
+Extractions rarely fail loudly. These are the quiet versions to expect:
+
+- **Truncation on long lists.** An over-full page arrives clipped at 8,000
+  characters, and the model extracts what it received, confidently: output
+  that looks complete and is short. Defense: keep reads narrow ("read the
+  product list, not the page"), and check counts, below.
+- **Columns drifting between pages.** Page one yields `title,price`; page four,
+  where a title contains a comma or a price is missing, yields quoted fields or
+  an improvised extra column. Each page is a fresh decision, and fresh
+  decisions drift. A named header and "exactly two columns on every line" in
+  the instruction hold it down; a per-line check afterwards catches what
+  slipped.
+- **Declared success, early.** The model finishes page three of five, sees a
+  plausible pile of rows, and answers: partial output, delivered with
+  confidence.
+- **Invented or repaired rows.** Rare on clean pages, real on messy ones: a
+  missing price becomes a guessed one because the model would rather complete
+  the row than break the schema. Say so explicitly: "if a value is missing,
+  write an empty field, do not infer it."
+- **Cost growth.** Not wrong output, just a bill: retries and long walks
+  multiply turns, and turns carry the whole transcript. If a run wanders, stop
+  it and re-scope rather than letting it find its way.
+
+If the page never loads at all, or loads empty, that is not an extraction
+problem; work through [why agents get blocked](why-does-my-ai-agent-get-blocked.md)
+before touching the prompt.
+
+## Verify the output, every time
+
+Never trust an extraction unseen. The checks are cheap and mechanical:
+
+1. **Count.** The site usually tells you the truth to check against: the
+   example catalog says 1,000 results, 20 per page, so two pages should be 40
+   rows plus a header. `wc -l` settles it in a second; a short count is
+   truncation or an early stop, caught cheap.
+2. **Spot-check rows by hand.** Pick a few, including the last one, and compare
+   them against the live page. The last row matters most: truncation and early
+   stops eat the tail, not the head.
+3. **Check the shape.** Every line has the same number of fields; every price
+   parses as a number. A spreadsheet import that flags ragged rows catches
+   column drift.
+4. **Run it twice if it matters.** Two runs that agree do not prove
+   correctness, but two runs that disagree prove one of them is wrong.
+   (AIHawk's `--seed` pins the browser's identity across runs, not the model's
+   choices, so agreement is evidence, not a guarantee.)
+
+The checks are the price of using a stochastic reader for a deterministic job,
+and they are still far cheaper than writing the scraper, right up until the day
+they are not, which is when you write it.
+
+## Short answers to the questions that lead here
+
+**Can an AI agent export scraped data to a CSV?** Yes: describe the columns and
+the scope, and the CSV comes back as the agent's answer, which you copy or
+redirect to a file. There is no file-writing tool; the answer text is the
+deliverable.
+
+**How do I get only CSV, with no explanation around it?** Say exactly that:
+"reply with CSV only, header `title,price`, no commentary before or after."
+Named columns and an explicit no-prose clause are the two highest-value lines
+in the instruction.
+
+**Why is my extracted CSV incomplete?** Three usual causes: a long page
+truncated before the model saw all of it, an early "done" before the last
+pages, or a turn budget exhausted mid-walk. Counting rows against the site's
+own total finds all three; batching into smaller runs prevents them.
+
+**Can it handle pagination?** Yes, by walking it: find next, click, read,
+repeat, with cost per page climbing as the transcript grows. Bound the walk
+("pages one to ten") and concatenate batches.
+
+**Is an agent cheaper than writing a scraper?** For one-off and small jobs,
+usually, because the scraper's real cost is engineering time. For repeated
+volume, no, and it is not close; the crossover math is on
+[the comparison page](ai-browser-agents-vs-traditional-scraping.md).
+
+**How do I know the data is right?** You check: row count against the site's
+stated total, a few hand-compared rows including the last, and a
+same-field-count pass over every line. An unverified extraction is a guess
+with a header row.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [books.toscrape.com](https://books.toscrape.com/), the scraping sandbox used
+  as the running example: 1,000 fictional items, 20 per page, with the site's
+  own disclaimer that prices and ratings are randomly assigned.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README and
+  source in this repository: the loop, the 25-turn default, the 8,000-character
+  tool-result clip and the reply ceiling are in
+  [`src/aihawk/agent.py`](https://github.com/feder-cr/AIHawk/blob/main/src/aihawk/agent.py),
+  and the stdout behavior of `aihawk do` in
+  [`src/aihawk/cli.py`](https://github.com/feder-cr/AIHawk/blob/main/src/aihawk/cli.py).
+
+**See also:** [AI browser agents vs traditional scraping](ai-browser-agents-vs-traditional-scraping.md),
+[monitoring a page for changes](how-to-monitor-a-page-with-an-ai-agent.md),
+[what is an AI web agent?](ai-web-agent-explained.md), and the rest of
+[Using the Agent](guides-using-the-agent.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The verification
+section is not boilerplate: the maintainer counts the rows every time, because
+the unchecked extraction is the one that ships wrong.*

--- a/docs/how-to-monitor-a-page-with-an-ai-agent.md
+++ b/docs/how-to-monitor-a-page-with-an-ai-agent.md
@@ -1,0 +1,216 @@
+---
+title: "Monitoring a page for changes with an AI agent"
+description: "When a plain diff monitor is the right tool, when an agent's judgment earns its cost, how to schedule checks with the aihawk CLI, and what to store between runs."
+parent: "Using the Agent"
+nav_order: 7
+---
+
+
+# Monitoring a page for changes with an AI agent
+
+Start with the uncomfortable half: if the question is "tell me when this page
+changes at all," an AI agent is the wrong tool. A diff-based monitor fetches the
+page, compares it to the last fetch, and notifies on difference, at effectively
+zero cost per check; an agent run is a browser launch plus a chain of model
+calls, cents and tens of seconds per check, to answer the same yes/no. Running
+an LLM on a schedule to do a byte comparison is paying for judgment and not
+using it.
+
+The agent earns its cost when the question actually needs judgment: not "did a
+byte change" but "did the return policy meaningfully change," "is the price now
+below the threshold I care about," "summarize what is different in terms I can
+act on." A diff monitor fires on a rotated banner, a new timestamp in the
+footer, a reshuffled ad slot; it cannot tell you whether the change matters.
+That distinction is a reading-comprehension question, and reading comprehension
+is the one thing the agent brings.
+
+This page covers both halves: the plain tool, scheduling the agent, and the
+two-stage pattern that uses each at its own price.
+
+## When the plain tool is the right answer
+
+For "any change, tell me fast," use a purpose-built monitor. The reference
+open-source option is [changedetection.io](https://github.com/dgtlmoon/changedetection.io):
+self-hostable, diffs pages on a schedule you set, and notifies over the usual
+channels. It does per-check what an agent cannot: run constantly, for free,
+without a model in the loop.
+
+Choose it whenever your condition is mechanical. A number appearing, a string
+disappearing, a section changing at all: these are diff conditions, and paying
+model tokens to evaluate them is waste. It is the same boundary
+[the scraping comparison](ai-browser-agents-vs-traditional-scraping.md) draws
+for extraction: deterministic conditions belong to deterministic tools.
+
+## When the agent earns its cost
+
+Three shapes of monitoring genuinely need the model:
+
+- **Meaningful-change detection.** "Tell me when the terms of service change in
+  a way that affects cancellation." A diff fires on every typo fix; the agent
+  reads both versions and answers the question you actually asked.
+- **Threshold and condition checks that need reading.** "If the top item is
+  marked unavailable, or the stated delivery estimate slips past two weeks,
+  flag it." The facts live in prose and layout, not in one stable element a
+  selector could watch.
+- **Summarized deltas.** "What changed on this page since last week, in three
+  bullets, ignoring cosmetics." The output is an editorial judgment, which is
+  exactly what you cannot script.
+
+Be honest about the price even here: every check is a fresh agent run. On
+AIHawk that means a browser session opened, a handful of model turns, and the
+session closed, cents per check on the default model and roughly a minute of
+wall clock. Daily is comfortable; every five minutes is a bill and, as covered
+below, a signature.
+
+## Scheduling it: the CLI exists, and this is what it does
+
+AIHawk has a headless entrypoint built for exactly this, and its README files
+it under "for scripts and cron":
+
+```bash
+uvx aihawk do "Go to <your page>. Report the current title and price of the
+first listed item, one line, no commentary." --seed 7 --profile-dir ~/.hawk-mon
+```
+
+`do` runs one instruction in the stealth browser, prints the model's answer to
+stdout, and exits; the browser is opened for the run and closed after. That
+shape composes with cron, systemd timers, or Windows Task Scheduler the way any
+command does: redirect stdout to a dated file and you have a log of answers.
+
+Three flags matter for a recurring check:
+
+- **`--seed`** pins the browser identity. Same seed, same fingerprint, every
+  run; without it each check arrives as a new device, which is not what a
+  returning reader looks like.
+- **`--profile-dir`** keeps a persistent profile, so cookies and any login
+  survive between runs. Use an absolute path; a relative one resolves from
+  wherever cron happened to start the command.
+- **The key comes from the environment.** `do` requires an OpenRouter key, and
+  `OPENROUTER_API_KEY` in the environment beats `--openrouter-key` on a
+  schedule twice over: the flag lands in shell history and, on Linux, in the
+  process list for every user on the machine.
+
+A real crontab line, deliberately not on the hour:
+
+```
+17 8 * * *  . $HOME/.hawk-env && uvx aihawk do "..." >> $HOME/hawk-mon/$(date +\%F).txt 2>&1
+```
+
+with the key exported from `~/.hawk-env`, readable only by you. The interface
+(`uvx aihawk ui`) has no scheduler; the recurring path is `do` plus whatever
+scheduler your system already has.
+
+## What to store between runs
+
+Each `do` run is a one-shot conversation: nothing carries over on its own,
+which means the memory of the monitor is yours to keep. Two files do it:
+
+- **The previous answer.** "What changed" only means something against a
+  baseline, and the baseline has to travel in the prompt. The workable pattern
+  feeds the last run's output back in:
+
+  ```bash
+  uvx aihawk do "Here is what this page said on the last check:
+  $(cat ~/hawk-mon/last.txt)
+  Now go to <your page> and report only meaningful differences from that,
+  or the exact word NOCHANGE if nothing that matters changed." \
+    --seed 7 --profile-dir ~/.hawk-mon | tee ~/hawk-mon/last.txt
+  ```
+
+  Asking for a sentinel word like `NOCHANGE` makes the no-op case scriptable:
+  grep for it and only notify when it is absent.
+
+- **The dated archive.** Keep every answer with its timestamp. When the agent
+  claims a change, the archive is how you check whether it is real or a
+  misreading, and misreadings happen: the model is a stochastic reader, and a
+  monitor that alerts falsely gets ignored precisely when it is finally right.
+
+The strongest architecture is the two-stage hybrid: let the cheap diff monitor
+watch constantly, and run the agent only when the diff fires, to judge whether
+the change matters and to write the summary. The plain tool does the always-on
+part; the model is paid only for judgment.
+
+## Pacing, which is also a signal
+
+A monitor is repeated traffic by definition, so the pacing rules are not
+etiquette, they are survival:
+
+- **A fixed clock-minute schedule is itself a signal.** A visitor who arrives
+  at exactly :00 every hour, forever, has announced what it is; sites can read
+  regularity the same way they read
+  [action rhythm](ai-agent-timing-signal.md). Pick odd minutes, and put a
+  random sleep in front of the command.
+- **Check as rarely as the answer allows.** The right frequency comes from the
+  question, not the scheduler's resolution: a policy page that changes yearly
+  does not need an hourly reader.
+- **Do not retry a failed check inside the same slot.** One check that fails
+  should be one log line, not a burst of attempts; agents amplify failures
+  into exactly the pattern described in
+  [retry loops and rate limits](agent-retry-loops-rate-limits.md). Let the next
+  scheduled run be the retry.
+- **Honor the site.** Recurring automated visits are the case where reading
+  the site's terms and rate expectations is least optional. If the site offers
+  a feed or an API for the thing you are watching, use that and retire the
+  browser check entirely.
+
+If checks that used to work start failing, resist tuning the prompt first;
+work through [why agents get blocked](why-does-my-ai-agent-get-blocked.md), and
+remember that with `--seed` unset, every run was a different browser.
+
+## Short answers to the questions that lead here
+
+**Can an AI agent monitor a website for changes?** Yes, mechanically: schedule
+`uvx aihawk do` with a prompt that carries the previous state and asks for
+meaningful differences. Whether it should depends on the question: byte-level
+"did it change" belongs to a diff tool; "does the change matter" is the
+agent's case.
+
+**Is an LLM agent overkill for change detection?** For plain change detection,
+yes, by orders of magnitude on cost and latency. It stops being overkill when
+the check requires reading: meaningful-change questions, prose thresholds,
+summarized deltas.
+
+**How do I schedule AIHawk to check a page every day?** Cron (or any
+scheduler) plus `uvx aihawk do "..."` with `OPENROUTER_API_KEY` in the
+environment, `--seed` for a stable identity, `--profile-dir` for a persistent
+profile, and stdout redirected somewhere dated. There is no built-in scheduler;
+the CLI is the building block on purpose.
+
+**What does each check cost?** A browser session plus a short model
+conversation: cents on the default model, roughly a minute of wall clock. The
+hybrid pattern, diff tool always on, agent only on diff-fire, keeps the model
+bill proportional to actual changes.
+
+**How does the agent know what changed since last time?** It does not, unless
+you tell it. Runs share nothing; store the previous answer and feed it back in
+the next prompt as the baseline to compare against.
+
+**Will a site notice a scheduled agent?** It can: a metronomic schedule is a
+tell independent of the browser, and the browser's own realism does not cover
+it. Jitter the schedule, keep frequency honest, and read
+[the timing-signal page](ai-agent-timing-signal.md) for what regularity gives
+away.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [dgtlmoon/changedetection.io](https://github.com/dgtlmoon/changedetection.io),
+  the self-hosted diff-based monitor referenced as the plain-tool baseline,
+  including its scheduling and notification features.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README and
+  source in this repository: the `do` command, its "scripts and cron" framing,
+  the key-in-environment advice, and the one-shot open-run-close behavior in
+  [`src/aihawk/runner.py`](https://github.com/feder-cr/AIHawk/blob/main/src/aihawk/runner.py).
+
+**See also:** [extracting data to a CSV](how-to-extract-data-to-csv-with-an-ai-agent.md),
+[agent retry loops and rate limits](agent-retry-loops-rate-limits.md),
+[the timing signal AI agents give off](ai-agent-timing-signal.md), and
+[which model to use with AIHawk](which-model-to-use-with-aihawk.md) for keeping
+per-check cost down.
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The maintainer runs
+the two-stage version: a free diff watching always, the agent woken only to
+answer "does this matter", which is the only question worth paying it for.*

--- a/docs/is-openai-operator-still-available.md
+++ b/docs/is-openai-operator-still-available.md
@@ -60,9 +60,11 @@ makes exactly that complaint: Work does not replicate "spawned a virtual
 computer, opened a real browser, visually interpret rendered websites, clicked
 through interfaces".
 
-**The computer-use API.** For developers, the `computer-use-preview` model in
-the Responses API drives a click-type-scroll loop over screenshots. It is a
-research preview, gated to higher usage tiers, priced per token. It is a
+**The computer-use API.** For developers, OpenAI's computer use tool in the
+Responses API drives a click-type-scroll loop over screenshots. It left its
+research-preview phase: the current guide documents it as a generally
+available tool (named `computer`) driven by current models such as `gpt-5.6`,
+with a migration path from the old `computer-use-preview` model. It is a
 building block, not a product: you supply the browser or VM it acts on.
 
 Whether any of these is "Operator, still available" depends on which half of
@@ -126,9 +128,9 @@ Codex. It never left macOS while it lived, per coverage of the shutdown.
 subscription route today is ChatGPT's built-in browsing agent and ChatGPT
 Work.
 
-**Is there an API version?** The `computer-use-preview` model in the
-Responses API, a tier-gated research preview where you provide the
-environment it controls.
+**Is there an API version?** Yes: the computer use tool in the Responses
+API, now generally available and driven by current models, where you provide
+the environment it controls.
 
 **What is the closest replacement I can run myself?** An open-source browser
 agent with your own model key - see
@@ -148,7 +150,7 @@ replacement that will not need replacing.
 - [OpenAI community: "Agent Mode was removed with no real replacement"](https://community.openai.com/t/agent-mode-was-removed-with-no-real-replacement/1389601), retrieved 2026-09-03, for the removal, the "use Work" guidance, and the quoted capability description.
 - [TechCrunch: OpenAI is shutting down Atlas](https://techcrunch.com/2026/07/09/openai-is-shutting-down-atlas-but-its-ai-browser-ambitions-are-still-growing/) and [Search Engine Land: OpenAI sets Aug. 9 end date for ChatGPT Atlas](https://searchengineland.com/openai-chatgpt-atlas-deprecation-482003), surfaced via search 2026-09-03.
 - [Bloomberg: OpenAI launches ChatGPT Work](https://www.bloomberg.com/news/articles/2026-07-09/openai-unveils-chatgpt-work-agent-to-field-tasks-for-hours) and [The Next Web on the same launch](https://thenextweb.com/news/openai-chatgpt-work-agent-launch), surfaced via search 2026-09-03.
-- [OpenAI computer use guide](https://platform.openai.com/docs/guides/tools-computer-use) and [computer-use-preview model page](https://developers.openai.com/api/docs/models/computer-use-preview), surfaced via search 2026-09-03.
+- [OpenAI computer use guide](https://developers.openai.com/api/docs/guides/tools-computer-use), fetched 2026-09-03: the tool is generally available, driven by current models, with a migration section from the old `computer-use-preview`.
 
 ---
 

--- a/docs/openai-operator-alternatives.md
+++ b/docs/openai-operator-alternatives.md
@@ -71,8 +71,9 @@ desktop app and the ChatGPT Chrome extension, where Atlas's capabilities were
 folded when it shut down, and ChatGPT Work (launched 9 July 2026) handles
 longer multi-step tasks across apps and files. Users on OpenAI's own forum have
 pointed out that none of these reproduces the old agent mode's interactive
-website navigation exactly. Developers can build with the `computer-use-preview`
-model in the Responses API, a research preview limited to higher usage tiers.
+website navigation exactly. Developers can build with the computer use tool in
+the Responses API, now generally available and driven by current models (the
+old `computer-use-preview` model has a documented migration path to it).
 
 **Anthropic's answer** comes in two shapes. Claude in Chrome, the browser
 extension, became generally available for paid Claude plans on 26 August 2026

--- a/docs/openai-operator-vs-claude-computer-use.md
+++ b/docs/openai-operator-vs-claude-computer-use.md
@@ -104,7 +104,7 @@ by design rather than a defect.
 reference container is a recognizable environment:
 [a headless server machine answers a page's questions differently from a
 desktop](https://github.com/feder-cr/invisible_playwright/wiki/headless-browser-agent-on-a-server),
-and [an agent's pacing is its own signal](https://github.com/feder-cr/invisible_playwright/wiki/ai-agent-timing-signal).
+and [an agent's pacing is its own signal](ai-agent-timing-signal.md).
 With computer use you at least own the environment and can improve it; with a
 hosted product you could not.
 

--- a/docs/openai-operator-vs-claude-computer-use.md
+++ b/docs/openai-operator-vs-claude-computer-use.md
@@ -53,10 +53,11 @@ successor; OpenAI's help pages point long multi-step tasks at ChatGPT Work,
 and browser-based agentic work at the ChatGPT desktop app and Chrome
 extension. The full churn timeline is on
 [Is OpenAI Operator still available?](is-openai-operator-still-available.md).
-For developers, OpenAI's own entry in this architecture is the
-`computer-use-preview` model in the Responses API - a research preview, gated
-to usage tiers 3-5, and notably the same shape as Anthropic's approach: a
-screenshot loop over an environment you provide.
+For developers, OpenAI's own entry in this architecture is the computer use
+tool in the Responses API - out of its research-preview phase and generally
+available, driven by current models such as `gpt-5.6`, and notably the same
+shape as Anthropic's approach: a screenshot loop over an environment you
+provide.
 
 **Claude computer use: generally available on the API.** The current toolset
 version (`computer_toolset_20260801`) needs no beta header and is supported by
@@ -73,8 +74,9 @@ browser.
 ## What each costs
 
 Operator's cost model was a subscription: it launched inside ChatGPT Pro. Its
-API descendant, `computer-use-preview`, is priced per token ($3 per million
-input, $12 per million output, per OpenAI's model page).
+API descendant, the computer use tool, is priced like any Responses API call:
+standard token pricing for the model that drives it, multiplied by the
+screenshot-heavy context a computer-use loop consumes.
 
 Claude computer use is standard API token pricing with no special rate, and
 the practical cost driver is screenshots: Anthropic's docs put each one at
@@ -138,7 +140,7 @@ at [Open-source Operator-style agents](openai-operator-open-source.md).
 
 **Which is better, Operator or Claude computer use?** The question expired:
 Operator no longer exists. Its architectural heirs at OpenAI are ChatGPT's
-built-in agentic browsing and the tier-gated `computer-use-preview` API.
+built-in agentic browsing and the now generally available computer use API.
 
 **Is Claude computer use a product I can just use?** Not by itself: it is an
 API tool, and you supply the environment and the agent loop. The
@@ -169,7 +171,7 @@ for the screenshot-loop architecture in open source.
 
 - [Anthropic: computer use tool documentation](https://platform.claude.com/docs/en/agents-and-tools/tool-use/computer-use-tool), retrieved 2026-09-03; quotes, toolset version, model support, screenshot token figures and safety guidance are from this page.
 - [Wikipedia: OpenAI Operator](https://en.wikipedia.org/wiki/OpenAI_Operator), retrieved 2026-09-03, for launch and shutdown dates and the OSWorld figure.
-- [OpenAI help: ChatGPT agent](https://help.openai.com/en/articles/11752874-chatgpt-agent), [OpenAI computer use guide](https://platform.openai.com/docs/guides/tools-computer-use) and [computer-use-preview model page](https://developers.openai.com/api/docs/models/computer-use-preview), surfaced via search 2026-09-03.
+- [OpenAI help: ChatGPT agent](https://help.openai.com/en/articles/11752874-chatgpt-agent), surfaced via search 2026-09-03, and the [OpenAI computer use guide](https://developers.openai.com/api/docs/guides/tools-computer-use), fetched 2026-09-03: generally available, driven by current models, migration section from `computer-use-preview`.
 - [OpenAI community: "Agent Mode was removed with no real replacement"](https://community.openai.com/t/agent-mode-was-removed-with-no-real-replacement/1389601), retrieved 2026-09-03.
 - Coverage of Claude in Chrome's general availability, surfaced via search 2026-09-03, including [Engadget on Cowork in the Chrome sidebar](https://www.engadget.com/2235919/claude-cowork-can-now-run-in-a-chrome-sidebar/).
 

--- a/docs/running-aihawk-with-claude-code.md
+++ b/docs/running-aihawk-with-claude-code.md
@@ -1,0 +1,178 @@
+---
+title: "Running AIHawk's browser from Claude Code"
+description: "One command adds the stealth browser to Claude Code as an MCP server. What happens on first run, which tools Claude gains, prompts to try first, and the two things that go wrong."
+parent: "Using the Agent"
+nav_order: 4
+---
+
+
+# Running AIHawk's browser from Claude Code
+
+If you already use Claude Code, you do not need AIHawk's interface, its CLI, or
+an OpenRouter key. Claude Code brings the model; you add the browser to it. The
+browser is the same MCP server AIHawk itself talks to -
+[invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp) -
+so anything AIHawk's own interface can do, your assistant can do too, and that
+is by construction: the interface holds no privileged access, it calls the same
+tools over the same protocol as any other client.
+
+This page is Claude Code specifically. Claude Desktop and Cursor take a config
+file instead of a command, and have their own pages:
+[Claude Desktop](running-aihawk-with-claude-desktop.md) and
+[Cursor](running-aihawk-with-cursor.md). The config blocks themselves live in
+the [server's README](https://github.com/feder-cr/invisible-playwright-mcp),
+which is the one place they are kept current.
+
+## The one line
+
+Two prerequisites, same as everywhere in this project: Python 3.11 or newer on
+Windows (x86_64) or Linux (x86_64, arm64) - macOS is not supported, the last
+engine build for it was `firefox-20` - and [uv](https://docs.astral.sh/uv/),
+because the command runs the server with `uvx`. Then, once:
+
+```bash
+claude mcp add -s user stealth -- uvx invisible-playwright-mcp
+```
+
+Reading it left to right: `-s user` registers the server at user scope, so it
+is available in every project rather than only the directory you happened to be
+in; `stealth` is the name it appears under; everything after `--` is the
+command Claude Code will run to start the server, and `uvx` fetches and runs
+the published package, so there is nothing to clone or pip-install first. Start
+a fresh Claude Code session afterwards if one was already open, and `/mcp`
+should list `stealth` among the connected servers.
+
+## First run: the download nobody warns you about
+
+Installing the server does not install the browser. The engine is a patched
+Firefox of roughly a quarter of a gigabyte, and it downloads on the first
+request that needs a page - which, from inside a chat, looks like your first
+browsing prompt sitting there doing nothing, and on a slow connection can end
+in a timeout message that says nothing about a download.
+
+Get it over with first, in a terminal where you can watch the progress:
+
+```bash
+uvx invisible-playwright fetch
+```
+
+It is cached afterwards and shared by every way into the engine, including
+AIHawk's own interface if you later run that too.
+
+## What Claude actually gains
+
+A set of browser tools, prefixed with the server name you chose. The
+authoritative list is whatever `/mcp` shows for your installed server version;
+the families, with the names AIHawk's own client code knows them by:
+
+- **Navigation and tabs**: `browser_navigate`, plus `session_new_page`,
+  `session_select_page`, `session_close_page` and `session_list_pages` for
+  working across tabs.
+- **Reading the page**: `browser_read_text`, `browser_read_html`, and
+  `browser_snapshot` for a structural view of what is interactive.
+- **Acting on the page**: `browser_click` and `browser_click_at`,
+  `browser_type`, `browser_press_key`, and - since server 0.10.0 -
+  `browser_select_option` for dropdowns, added precisely so a model never has
+  to fake a selection through script.
+- **Seeing it**: `browser_take_screenshot`.
+
+Behind the tools is the point of the exercise: a real patched Firefox that
+drives pages through actual input events, not a headless toolkit. What that
+buys, and what it honestly does not, is the
+[blocked page's](why-does-my-ai-agent-get-blocked.md) subject.
+
+## Three prompts to try first
+
+Start small, so the first success and the first failure are both legible:
+
+> Go to example.com and tell me the main heading on the page.
+
+One navigation, one read. If this works, the server, the engine and the wiring
+all work. Then something with a decision in it:
+
+> Go to [paste the URL of a docs page you actually read] and find the section
+> about installation. Quote the exact command it recommends.
+
+Then something multi-step, the shape most real use takes:
+
+> Open [paste the URL of a public page with a list on it], read the first ten
+> entries, and give them to me as a table with a link column.
+
+If that last shape is your actual goal, the
+[extract-to-CSV page](how-to-extract-data-to-csv-with-an-ai-agent.md) takes it
+the rest of the way. One habit worth forming from the start: ask for one page
+and one outcome per prompt. The assistant sees the page only through tool
+results, and short steps keep its context small and its mistakes cheap.
+
+## Troubleshooting
+
+- **`stealth` is not listed in `/mcp`.** Run `claude mcp list` in a terminal
+  to see what is registered and at which scope. If the add command was run
+  while a session was open, the running session may not know it yet; start a
+  new one. If `uvx` is not on your PATH, the server can be registered and
+  still fail to start - install uv and try `uvx invisible-playwright-mcp` by
+  hand, which surfaces the real error.
+- **The first browsing prompt hangs or times out.** Almost always the engine
+  download. Run the prefetch command above and retry; afterwards a first page
+  load is seconds, not minutes.
+- **Tools appear but every call fails.** Try the one-line prompt above; if
+  even `example.com` fails, the problem is below the model - the
+  [browser-or-model page](browser-problem-or-model-problem.md) is the
+  systematic version of that diagnosis, and blocks and challenge pages have
+  [their own checklist](why-does-my-ai-agent-get-blocked.md).
+- **You want a proxy, a fixed identity, or a persistent profile.** Those are
+  server-side options, configured where the server is configured; the
+  [server's README](https://github.com/feder-cr/invisible-playwright-mcp)
+  documents them. This page deliberately does not duplicate that reference.
+
+## Short answers to the questions that lead here
+
+**How do I add AIHawk's browser to Claude Code?**
+`claude mcp add -s user stealth -- uvx invisible-playwright-mcp`, once, with uv
+installed. New sessions then have the browser tools in `/mcp`.
+
+**Do I need an OpenRouter key for this?** No. The key is only for AIHawk's own
+interface and CLI, where AIHawk must bring a model. In Claude Code, Claude is
+the model.
+
+**Why does the first browsing request take so long?** The engine, about a
+quarter of a gigabyte, downloads on the first request that needs a page. Run
+`uvx invisible-playwright fetch` once in a terminal to do it up front.
+
+**Is this different from what AIHawk's own UI drives?** No - same server, same
+engine, same tools. The interface is just another MCP client of it, with no
+privileged access.
+
+**Does it work on macOS?** No. The engine ships for Windows and Linux only;
+the last macOS build was `firefox-20`.
+
+**Can Claude Code and the AIHawk UI share the setup?** The downloaded engine
+is cached once and shared. The server process itself is per-client - each
+client starts its own - so a page open in one is not visible in the other.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), this repository's
+  README (the verbatim add command, the prerequisites and platforms, the
+  engine download and prefetch, "anything the interface can do, your assistant
+  can do too") and source: `src/aihawk/link.py` and `src/aihawk/web.py` (the
+  interface reaching the browser over MCP as an ordinary client),
+  `src/aihawk/actions_help.py` (the tool names above), and `pyproject.toml`
+  (the server version floor and why `browser_select_option` is in it).
+- [feder-cr/invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp),
+  the server itself: config blocks for other clients, server-side options, and
+  the current tool list.
+
+**See also:** [running AIHawk with Claude Desktop](running-aihawk-with-claude-desktop.md),
+[running AIHawk with Cursor](running-aihawk-with-cursor.md),
+[how to extract data to CSV with an AI agent](how-to-extract-data-to-csv-with-an-ai-agent.md),
+and [browser problem or model problem?](browser-problem-or-model-problem.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. Claude Code is
+the shortest route into this browser - one command, against a config file
+everywhere else - and the README calls the engine fetch "the download nobody
+warns you about", so consider yourself warned.*

--- a/docs/running-aihawk-with-claude-desktop.md
+++ b/docs/running-aihawk-with-claude-desktop.md
@@ -1,0 +1,196 @@
+---
+title: "Running AIHawk's browser from Claude Desktop"
+description: "Adding the stealth browser to Claude Desktop via its JSON config - what changes in the app, first prompts to try, what tool calls and approvals look like, and the first-run issues."
+parent: "Using the Agent"
+nav_order: 8
+---
+
+
+# Running AIHawk's browser from Claude Desktop
+
+Claude Desktop does not take the one-line command that Claude Code does; it
+reads its MCP servers from a JSON settings file. The exact block to paste and
+the file it goes in are documented once, in the
+[server's README](https://github.com/feder-cr/invisible-playwright-mcp), and
+this page deliberately does not duplicate them - configs copied into wikis rot.
+What this page covers is everything around that block: what actually changes in
+Desktop once the server is in, what to try first, what the tool calls look like
+while Claude works, and the first-run issues that generate most of the
+questions.
+
+One boundary before anything else, because it decides whether to read on:
+Claude Desktop runs on macOS and Windows, and AIHawk's engine ships for Windows
+and Linux, with macOS unsupported. The overlap is Windows. On a Mac, Desktop
+will start the server and the server will have no engine build to run; this
+combination is a Windows setup today.
+
+## What changes after the server is added
+
+Mechanically: you edit the config (Desktop's Settings, under Developer, has an
+Edit Config button that opens the right file), paste the server block from the
+README, then quit Desktop completely and restart it. The full restart is not
+superstition; Desktop loads MCP servers at startup, and the official MCP
+quickstart lists "restart Claude Desktop completely" as the first
+troubleshooting step for a server that does not appear.
+
+After the restart, the same Claude you already talk to has a real browser. The
+server exposes a flat set of tools in two families: session tools that manage
+tabs (`session_new_page`, `session_list_pages` and friends) and page tools that
+act on one (`browser_navigate`, `browser_read_text`, `browser_snapshot`,
+`browser_click`, `browser_type`, `browser_take_screenshot`, and a few more).
+Claude sees the list and decides when to use them; you do not invoke tools
+yourself, you ask for outcomes.
+
+Two things notably do not change. There is no new account and no new key: your
+existing Claude subscription is the model, the server brings only the browser,
+and the config block carries no secret. And nothing happens eagerly: no browser
+launches at startup, and nothing downloads until the first instruction that
+actually needs a page.
+
+## First prompts to try
+
+Start small and visible, because the first prompt doubles as the installation
+test:
+
+> Open https://books.toscrape.com/ and tell me the title and price of the
+> first book on the page.
+
+That one prompt exercises the whole path: server starts, engine found (or
+fetched, see below), page loaded, text read, answer grounded in the page. The
+example site is a sandbox built for practice, which is exactly what a first
+run is.
+
+Then something with a decision in it:
+
+> On that same site, go to page two and tell me whether any book there is
+> priced under ten pounds. Quote the cheapest one.
+
+And when it is earning its keep, point it at your own work: a staging page or a
+local dev server is the best second session, because you know the ground truth.
+For anything form-shaped, [the forms page](ai-agent-fill-out-forms.md) is the
+honest account of what to expect.
+
+Keep early instructions to one clear step. The agent behind these tools works
+observe-act-observe, and short instructions produce transcripts you can read
+when something goes wrong, which at the start is the point.
+
+## What the tool calls look like
+
+Desktop makes the agent loop unusually visible, and it is worth watching once.
+When Claude decides to act, the tool call appears in the conversation by name
+with its arguments - `browser_navigate` with a URL, `browser_click` with a
+selector - and by default Desktop asks for your approval before each action
+runs. You can allow individually, and you can deny; nothing touches the page
+without a click from you. The tool's result then returns into the
+conversation: page text for the reading tools, an image for
+`browser_take_screenshot`.
+
+Two consequences of that design are worth naming. First, the approvals are a
+feature, not friction: a browser that acts on the real web under your account
+deserves a human gate, and the gate is also where you catch a wrong step before
+it happens. Second, the browser itself is headless by default, so there is no
+window to watch; the screenshot tool is your eyes. If you want an actual
+window, the server reads `STEALTHFOX_HEADLESS=0` from its environment - set in
+the same config block, and documented, like the rest of the server's
+environment variables, in its README.
+
+The server list itself lives behind the connectors control at the bottom of
+Desktop's input box; the MCP quickstart walks the exact clicks. If the server
+is missing from that list after a restart, the config did not load, and that
+is a syntax or path problem, not an AIHawk one.
+
+## Common first-run issues
+
+In the order people hit them:
+
+1. **The first real prompt hangs.** The engine is about a quarter of a
+   gigabyte and is not fetched at install or at server start; it arrives on
+   the first tool call that needs a page. On a slow connection that looks
+   like Claude sitting silently on your instruction, and it can end in a
+   timeout message that never mentions a download. Get it over with first, in
+   a terminal where you can watch progress:
+
+   ```bash
+   uvx invisible-playwright fetch
+   ```
+
+   The engine is cached afterwards and shared with every other way into
+   AIHawk.
+
+2. **The server never appears.** Almost always the restart (must be a full
+   quit, not closing the window) or JSON syntax in the config. Desktop writes
+   MCP logs - a general `mcp.log` plus a per-server log carrying the server's
+   own errors - and the MCP quickstart documents where they live on each
+   platform. Read the per-server log before guessing.
+
+3. **`uvx` is not found.** The config launches the server with `uvx`, which
+   means [uv](https://docs.astral.sh/uv/) must be installed, and installed
+   where a GUI application can see it. A shell that finds `uvx` does not
+   guarantee Desktop does, since GUI apps do not always inherit your shell's
+   PATH; if the per-server log shows a not-found error, the server README's
+   troubleshooting is the place to start.
+
+4. **It is a Mac.** No engine build, per the boundary at the top. Nothing to
+   debug.
+
+5. **A page loads but the site pushes back.** That is not a Desktop problem
+   and usually not a browser problem; work through
+   [why agents get blocked](why-does-my-ai-agent-get-blocked.md) before
+   changing anything.
+
+## Short answers to the questions that lead here
+
+**How do I add AIHawk's browser to Claude Desktop?** Paste the server block
+from the [server README](https://github.com/feder-cr/invisible-playwright-mcp)
+into Desktop's MCP config (Settings, Developer, Edit Config), then fully quit
+and restart Desktop. The block and file path live in that README on purpose.
+
+**Do I need an API key for this?** No. Your Claude subscription is the model;
+the server only adds the browser, and its config block contains no secret. The
+OpenRouter key belongs to a different way in, AIHawk's own interface, covered
+in [using AIHawk without an API key](using-aihawk-without-an-api-key.md).
+
+**Why does the first instruction take so long?** The engine downloads on the
+first call that needs a page, about a quarter of a gigabyte, and nothing warns
+you. Prefetch it with `uvx invisible-playwright fetch` and the first
+instruction behaves like every later one.
+
+**Why can I not see the browser?** It runs headless by default; screenshots
+through the `browser_take_screenshot` tool are the intended window. The
+server's `STEALTHFOX_HEADLESS=0` environment variable shows a real window if
+you want one.
+
+**Does Claude act without asking me?** By default, no: Desktop asks approval
+per tool call, and you can deny any of them. Treat that gate as part of the
+workflow, especially for actions with consequences; the position on submissions
+in [the forms page](ai-agent-fill-out-forms.md) applies here unchanged.
+
+**Does this work on a Mac?** Not today. Desktop runs there, but the engine has
+no macOS build, so the working combination is Windows (or Linux through other
+clients).
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [feder-cr/invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp),
+  the server's README, for the config block, the tool list, the environment
+  variables and the engine-download behavior.
+- [Connect to local MCP servers (modelcontextprotocol.io)](https://modelcontextprotocol.io/quickstart/user),
+  for Desktop's Edit Config flow, the restart requirement, per-action
+  approvals, the connectors UI and the MCP log locations.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README in
+  this repository, for the platform support boundary and the shared engine
+  cache.
+
+**See also:** [running AIHawk with Claude Code](running-aihawk-with-claude-code.md),
+[running AIHawk's browser from Cursor](running-aihawk-with-cursor.md),
+[browser problem or model problem?](browser-problem-or-model-problem.md), and
+the rest of [Using the Agent](guides-using-the-agent.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The config block
+lives in one README and is linked from here rather than copied, because a
+config duplicated into a wiki is a config that will one day be wrong in one of
+the two places.*

--- a/docs/running-aihawk-with-cursor.md
+++ b/docs/running-aihawk-with-cursor.md
@@ -1,0 +1,199 @@
+---
+title: "Running AIHawk's browser from Cursor"
+description: "Adding the stealth browser to Cursor via mcp.json - what a real browser adds to an editor workflow, project vs global config, first prompts, and the first-run issues."
+parent: "Using the Agent"
+nav_order: 9
+---
+
+
+# Running AIHawk's browser from Cursor
+
+Cursor reads MCP servers from a JSON file, at one of two levels its docs
+define: `.cursor/mcp.json` inside a project, for tools scoped to that project,
+or `~/.cursor/mcp.json` in your home directory, for tools available everywhere.
+The block to paste is the same either way and it lives in the
+[server's README](https://github.com/feder-cr/invisible-playwright-mcp), which
+this page links rather than copies. What belongs here is the Cursor-side story:
+what a browser is actually for inside an editor, how Cursor runs the tools,
+what to try first, and the first-run issues.
+
+The platform boundary first: AIHawk's engine ships for Windows (x86_64) and
+Linux (x86_64, arm64). There is no macOS build, so on a Mac, Cursor will start
+the server and the server will have nothing to run. This combination works on
+Windows and Linux today.
+
+## What a browser adds to an editor, honestly
+
+Cursor's agent already reads your code and can search the web. A driveable
+browser is a different capability, and it is worth being precise about when it
+earns its place, because for a quick documentation lookup it is overkill:
+
+- **Research that means driving pages, not fetching them.** Docs behind a
+  version switcher, a changelog that loads on scroll, a comparison that
+  requires clicking through three product pages: anything where the answer
+  requires acting on the page rather than downloading it once.
+- **Testing your own web app through a realistic browser.** This is the
+  editor-native use. Point the agent at your dev server and have it register a
+  user, walk the checkout wizard, or hammer the validation on the form you
+  just wrote, then report what it saw. The browser is a real patched Firefox,
+  so what it renders and the events it sends are what a person's browser would
+  render and send, real key presses and clicks rather than scripted value
+  injection. Since the same agent also sees your code, "try to reproduce the
+  bug in the app, then look at the handler and tell me why" is one
+  conversation.
+- **Reading pages that push back on plain fetchers.** A page that returns
+  little or nothing to a simple HTTP fetch may read fine through a real
+  browser. Where a site pushes back beyond that, the honest map of why is
+  [the blocked page](why-does-my-ai-agent-get-blocked.md), and no tool
+  promises you through it.
+
+What it does not add: speed. A browser session plus model turns is the slow,
+deliberate path. If a `curl` would answer the question, the browser is the
+wrong tool, the same boundary
+[the scraping comparison](ai-browser-agents-vs-traditional-scraping.md) draws
+at length.
+
+## Config: project or global, and how Cursor runs the tools
+
+Choose the level by audience. Global (`~/.cursor/mcp.json`) makes the browser
+available in every project, which fits a personal research tool. Project-level
+(`.cursor/mcp.json`) travels with the repository, which fits a team that wants
+"the agent can drive our staging app" to be part of the checkout. The server's
+block contains a command and arguments, no key and no secret - Cursor brings
+the model, and there is nothing to sign up for on the AIHawk side - so
+committing it is as safe as config-committing gets; whether your
+team wants editor tooling in the repo is a team question, not a security one.
+
+On the running side, Cursor's own docs state the two behaviors that matter:
+the agent uses MCP tools automatically when it judges them relevant, and it
+asks for your approval before running a tool by default, with settings that
+let allowlisted tools run without asking. Servers can also be toggled on and
+off from Cursor's settings without deleting their config. Practical
+consequences: you do not call tools, you describe outcomes and approve steps;
+and if you stop wanting the browser in a project, the toggle beats editing
+JSON.
+
+The tools themselves come in two families: session tools for tabs
+(`session_new_page` and friends) and page tools (`browser_navigate`,
+`browser_read_text`, `browser_snapshot`, `browser_click`, `browser_type`,
+`browser_take_screenshot`, among others). You will see these names in the
+agent's transcript as it works, each gated by an approval until you loosen
+that.
+
+## First prompts to try
+
+The first prompt is the installation test, so make it small and checkable:
+
+> Open https://books.toscrape.com/ and tell me the title and price of the
+> first book on the page.
+
+The example site is a sandbox built for practice. If that works, the whole
+path works: server started, engine present, page loaded, text read.
+
+Then the editor-native one, against something you own:
+
+> Start the dev server's page at http://localhost:3000. Register a new user
+> through the signup form with placeholder data, do not submit the final
+> step, and list every validation message you encounter on the way.
+
+Two notes on that prompt. "Do not submit" is deliberate: keeping the
+consequential click human is the standing advice from
+[the forms page](ai-agent-fill-out-forms.md), and it applies to your own app
+the moment the data is real. And the localhost target keeps your first
+sessions where mistakes are free.
+
+The browser is headless by default, so the agent's screenshots
+(`browser_take_screenshot`) are your view of what happened. When you would
+rather watch it drive your app, the server reads `STEALTHFOX_HEADLESS=0` from
+its environment, set in the same config block; the README documents the rest
+of the environment variables (a persistent profile directory and a fixed
+identity seed are the two most useful for repeated testing).
+
+## Common first-run issues
+
+1. **The first page-touching prompt stalls.** The engine, about a quarter of
+   a gigabyte, is not fetched at install or server start; it downloads on the
+   first tool call that needs a page, and on a slow connection that reads as
+   the agent hanging, sometimes ending in a timeout that never mentions a
+   download. Prefetch it once, in a terminal where you can watch:
+
+   ```bash
+   uvx invisible-playwright fetch
+   ```
+
+   The engine is cached and shared with every other way into AIHawk.
+
+2. **The server does not appear in Cursor's MCP list.** Check the JSON, check
+   the file is at one of the two documented locations, and check that `uvx`
+   resolves for Cursor: the config launches the server with `uvx`, so
+   [uv](https://docs.astral.sh/uv/) must be installed where the editor can
+   find it, which is not guaranteed by it working in one particular shell.
+
+3. **Tools exist but every step asks permission.** That is the documented
+   default, and while you are learning what the browser does, leave it on.
+   Cursor's settings allow allowlisting once you trust the pattern; loosen
+   deliberately, not on day one.
+
+4. **It is a Mac.** No engine build; nothing to debug.
+
+5. **A public site loads oddly or pushes back.** Before touching config,
+   separate the layers: [browser problem or model problem](browser-problem-or-model-problem.md)
+   for the local half, and [why agents get blocked](why-does-my-ai-agent-get-blocked.md)
+   for the site half.
+
+## Short answers to the questions that lead here
+
+**How do I add AIHawk's browser to Cursor?** Paste the block from the
+[server README](https://github.com/feder-cr/invisible-playwright-mcp) into
+`.cursor/mcp.json` in a project or `~/.cursor/mcp.json` globally, both
+locations per Cursor's own MCP docs. No key, no signup; Cursor's model does
+the thinking.
+
+**Should the config be project-level or global?** Global for a personal
+research tool, project-level when a team wants the capability versioned with
+the repo. The block carries no secrets, so the choice is about scope, not
+safety.
+
+**Does Cursor's agent use the browser on its own?** It selects MCP tools
+automatically when relevant, but by default each tool run waits for your
+approval; allowlisting for automatic runs is a setting you opt into later.
+
+**What is this actually good for in an editor?** Driving and testing your own
+web app through a realistic browser, and research that requires acting on
+pages rather than fetching them. For lookups a plain search answers, skip the
+browser.
+
+**Why is the first instruction so slow?** Engine download: a quarter of a
+gigabyte on the first call that needs a page, silent from the editor's side.
+`uvx invisible-playwright fetch` in a terminal moves that cost to a moment you
+choose.
+
+**Can I watch the browser work?** By default no, it is headless and the
+screenshot tool is the window. Set `STEALTHFOX_HEADLESS=0` in the server's
+environment block to get a real window, which is genuinely useful when it is
+driving your own app.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [Cursor docs: Model Context Protocol](https://cursor.com/docs/context/mcp),
+  for the two config locations, automatic tool use with default approval, and
+  server toggling.
+- [feder-cr/invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp),
+  the server's README, for the config block, tool list, environment variables
+  and engine-download behavior.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README in
+  this repository, for platform support, the real-input-events behavior and
+  the shared engine cache.
+
+**See also:** [running AIHawk with Claude Code](running-aihawk-with-claude-code.md),
+[running AIHawk's browser from Claude Desktop](running-aihawk-with-claude-desktop.md),
+[getting an AI agent to fill out forms](ai-agent-fill-out-forms.md), and
+[extracting data to a CSV](how-to-extract-data-to-csv-with-an-ai-agent.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The strongest
+Cursor use the maintainer has seen is the least glamorous: the agent filling
+out your own half-built form, badly, and telling you exactly where it broke.*

--- a/docs/using-aihawk-without-an-api-key.md
+++ b/docs/using-aihawk-without-an-api-key.md
@@ -1,0 +1,162 @@
+---
+title: "Using AIHawk without an API key"
+description: "What uvx aihawk ui does with no key: the full interface and the real browser on a literal-command placeholder - what each command does, what the mode is for, and the one-line upgrade."
+parent: "Using the Agent"
+nav_order: 5
+---
+
+
+# Using AIHawk without an API key
+
+`uvx aihawk ui` with no key is not an error state and not a crippled demo. It
+starts the full interface and the real stealth browser; the only thing missing
+is the model. In its place sits a placeholder that understands a fixed set of
+literal commands and no natural language at all, and the startup line says so
+plainly: `model    none: literal commands only.` Everything else is the
+product - the same browser engine, the same tools, the same live view - which
+is exactly what makes the mode useful rather than decorative.
+
+The asymmetry with the other command is deliberate: `aihawk do` refuses to run
+without a key, because its whole job is a model producing an answer. The
+interface runs, because most of what it shows you does not need one.
+
+## What actually runs
+
+With no key, your typed text goes to the placeholder instead of to a model.
+The placeholder does no interpretation: it splits your line into a command and
+an argument, makes exactly one browser tool call, and shows you what came
+back. The commands, as the source defines them:
+
+- `go <url>` - navigate the page there. The words `open` and `navigate` work
+  as synonyms for `go`.
+- `read [selector]` - extract the text of the matching element; with no
+  selector it reads the whole `body`.
+- `click <selector>` - click the matching element.
+- `type <selector> <text>` - type the text into the matching element, through
+  real key events like everything this browser does.
+- `tab` - open a new browser tab.
+- `shot` - take a screenshot; the reply points out, correctly, that the view
+  on the right is live anyway.
+
+Anything else - including a plain English sentence - gets the help line back:
+"I am a placeholder, not a model." That is the entire language. Each command is
+one real tool call on the real engine, so what you see the browser do is
+exactly what the agent's tools do when a model calls them.
+
+The live pane behaves as it always does: the page view refreshes continuously
+while you work, and the address bar and tab strip track the browser. All the
+browser options work in this mode too - `--proxy`, `--seed`, `--headed`,
+`--binary`, `--profile-dir` - because they configure the engine, not the
+model.
+
+## What it is for
+
+**Seeing the interface before deciding anything.** Chat on the left, live
+browser on the right, at http://127.0.0.1:8765. Whether this is a tool you
+want is answerable in two minutes, for free.
+
+**Testing the browser side on its own.** The engine, your network, a proxy
+you are considering, a page you care about: `go` there and `read` what comes
+back, with no model behavior mixed into the result. This is the diagnostic
+instrument that [browser problem or model problem?](browser-problem-or-model-problem.md)
+is built around - a failure that reproduces under literal commands is
+guaranteed not to be a model failure, because no model was present.
+
+**Learning the loop's shape cheaply.** A real agent run is the same
+observe-act-observe rhythm you are performing by hand: read the page, pick one
+action, look at what changed. Driving it manually for ten minutes builds the
+right instincts for writing instructions later - including why one clear step
+at a time beats a paragraph of ambitions. [The explainer](ai-web-agent-explained.md)
+gives the same loop in theory; this is it in your hands.
+
+**Reproducing a bug precisely.** One command, one tool call, one result makes
+a report someone can act on. "click #submit returned this error on this page"
+beats "the agent got confused" in every way that matters.
+
+## What it deliberately cannot do
+
+The boundary is the model, and everything on the model's side of it is absent:
+
+- **No language.** "Go to the docs and find the install command" is not a
+  command, so it gets the help line. The placeholder maps words to tool calls;
+  it never decides anything.
+- **No multi-step work.** One line is one action. It will not chain, retry,
+  or notice that a click failed - noticing is a model behavior.
+- **No answers.** It shows you raw page text; it will not extract, summarize,
+  compare, or conclude. Producing an answer is the paid half of the product.
+- **No `aihawk do`.** The headless command exists to print a model's answer,
+  so keyless it exits with the error naming the two ways to supply a key.
+
+One cost survives keylessness: the engine itself. The browser, roughly a
+quarter of a gigabyte, downloads on the first command that needs a page, even
+in placeholder mode. `uvx invisible-playwright fetch` in a terminal gets it
+done up front where you can watch it - money is not involved either way, only
+bandwidth and patience.
+
+## The one-line upgrade
+
+When you want the real thing, the placeholder is replaced by a model by
+supplying an [OpenRouter](https://openrouter.ai) key:
+
+```bash
+uvx aihawk ui --openrouter-key sk-or-...
+```
+
+or, better, set `OPENROUTER_API_KEY` in the environment - better because a key
+on the command line lands in your shell history, and on Linux in the process
+list. Nothing else changes: same interface, same browser, same live view, and
+your typed sentences now go to a model, `z-ai/glm-4.6` unless you choose
+another with `--model`. [Which model to use](which-model-to-use-with-aihawk.md)
+covers that choice and what tasks actually cost. The key stays with the model
+client: it is stripped from the environment the browser engine starts with, by
+name and by value, and the repository carries a test that fails if that stops
+being true.
+
+## Short answers to the questions that lead here
+
+**Can I try AIHawk without paying anything?** Yes: `uvx aihawk ui` with no
+key runs the full interface and the real browser on a literal-command
+placeholder. The only cost is the one-time engine download.
+
+**What commands does the keyless mode understand?** `go` (also `open` or
+`navigate`), `read`, `click`, `type`, `tab`, and `shot` - each a single real
+browser action. Anything else returns the help line.
+
+**Why does it not understand my sentence?** Because there is no model to
+understand it. The placeholder is a command mapper, not a small language
+model; language arrives only with a key.
+
+**Is the keyless browser the same one the paid mode uses?** Identical: same
+engine, same tools, same options. The key changes what drives the browser,
+never the browser.
+
+**Does keyless mode still download the browser?** Yes, on the first command
+that needs a page. Run `uvx invisible-playwright fetch` first if you want to
+see the download rather than wait through it.
+
+**Why would I use the placeholder after I have a key?** As a diagnostic: a
+failure reproduced under literal commands is browser-side with certainty. The
+[browser-or-model page](browser-problem-or-model-problem.md) turns that into a
+procedure.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), this repository's
+  source: `src/aihawk/brain.py` (the placeholder, its command set, aliases and
+  help line), `src/aihawk/cli.py` (the keyless path, the startup message, the
+  browser options applying either way), `src/aihawk/llm.py` (the key
+  requirement for `do` and the default model), and the README (the engine
+  download, the prefetch command, and the shell-history note).
+
+**See also:** [browser problem or model problem?](browser-problem-or-model-problem.md),
+[which model to use with AIHawk](which-model-to-use-with-aihawk.md),
+[what is an AI web agent?](ai-web-agent-explained.md), and the rest of
+[Using the Agent](guides-using-the-agent.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The placeholder
+was built so the interface could be developed and tested without spending on a
+model; it ships because that turned out to be worth having every day.*

--- a/docs/which-model-to-use-with-aihawk.md
+++ b/docs/which-model-to-use-with-aihawk.md
@@ -1,0 +1,183 @@
+---
+title: "Which model to use with AIHawk"
+description: "The default model, what browser-agent work actually demands from an LLM, real OpenRouter prices, and why cost is turns times context rather than a price-sheet number."
+parent: "Using the Agent"
+nav_order: 2
+---
+
+
+# Which model to use with AIHawk
+
+AIHawk brings the browser and you bring the model, from
+[OpenRouter](https://openrouter.ai) and nowhere else. If you set nothing, you get
+`z-ai/glm-4.6`: that is the default written into the source, and it sits at the
+cheap-and-capable end of the catalog rather than the flagship end. You override it
+with `--model` on either command, or the `AIHAWK_MODEL` environment variable, and
+any model id OpenRouter serves is legal. So the real question is not "which model
+does AIHawk support" - all of them - but which one is worth paying for on this
+kind of work, and that has a less obvious answer than the price sheet suggests.
+
+## How AIHawk actually spends the model
+
+Worth knowing before choosing, because the loop's shape decides the bill. Both
+`aihawk do` and the interface run the same loop: the model receives the task and
+the browser tools, replies with one thought and usually one tool call, the tool
+runs, the result goes into the transcript, and the model is called again. In the
+current source the loop is capped at 25 turns per instruction, each reply is
+capped at 8,192 tokens, temperature is pinned to 0, and each tool result is
+clipped to 8,000 characters before it enters the transcript.
+
+Two consequences follow directly:
+
+- **Every turn resends the whole transcript.** The API is stateless, so turn
+  twelve pays for the task, every earlier thought, and every earlier tool result
+  again. A big page read early in a task is not paid once; it is paid on every
+  turn after it. The interface's token meter shows the last turn's prompt size
+  for exactly this reason: that number is the current occupancy of the context,
+  and it only grows.
+- **A task's cost is roughly turns times context, times the input price.**
+  Output is a minor line item here; a turn's reply is a sentence and a tool
+  call, not an essay. The input side, resent and growing, dominates.
+
+## What browser-agent work demands from a model
+
+This is not creative writing, and rankings built on prose quality mislead here.
+What the loop actually exercises:
+
+- **Tool-call discipline.** Every turn must produce a well-formed call with
+  valid JSON arguments. The loop tolerates a malformed one - it tells the model
+  its arguments were unreadable and lets it retry - but each such retry is a
+  full-price turn that moved nothing.
+- **Instruction following under a system prompt.** The agent is told to inspect
+  before acting, to prefer one action at a time, and to stop calling tools when
+  the task is done. A model that keeps calling tools after the answer is in hand
+  burns turns; one that answers without reading the page invents results.
+- **Reading long, messy context.** By mid-task the transcript is mostly
+  extracted page text. The model has to find the price in the noise, and notice
+  when a click changed nothing.
+- **Knowing when it is done, and when it is stuck.** The worst outcome is not a
+  wrong answer, it is 25 turns of confident wandering: the loop then stops with
+  an error and you have paid for the whole journey with no answer at the end.
+
+Speed matters more than in chat, too: a person watches the interface while up to
+25 round trips happen in sequence, so per-turn latency multiplies.
+
+## Real prices, and one worked comparison
+
+Retrieved from OpenRouter on 2026-09-03. OpenRouter routes each model across
+several providers, so cheap models show a price range rather than one number,
+and all of these move; check the model's page before relying on them.
+
+| Model | Input, per 1M tokens | Output, per 1M tokens |
+|---|---|---|
+| `z-ai/glm-4.6` (the default) | $0.43 - $0.60 | $1.75 - $2.20 |
+| `anthropic/claude-sonnet-4.5` | $3.00 | $15.00 |
+
+Sonnet's figures are the standard tier; above 200,000 prompt tokens a higher
+tier applies ($6.00 / $22.50), which an agent transcript can in principle reach,
+though with this loop's 25-turn cap and clipped tool results it rarely will.
+
+Now the arithmetic, illustrative rather than measured: take a 20-turn task whose
+transcript averages 15,000 tokens per turn. That is about 300,000 input tokens,
+plus a few thousand output tokens.
+
+- On GLM 4.6 at the top of its range: about $0.18 of input and a cent of
+  output. Call it **$0.19**.
+- On Claude Sonnet 4.5: $0.90 of input and $0.06 of output. Call it **$0.96**.
+
+Same task, roughly a 5x multiplier. Both are under a dollar, which is the honest
+scale of a single task; the multiplier is what compounds when you run fifty of
+them, or when a monitoring job runs one every hour.
+
+## The catch: a cheaper model that retries is not cheaper
+
+The table above assumes both models take the same 20 turns, and they do not. A
+weaker model clicks the wrong element and has to notice and recover, re-reads
+pages it already read, or wanders into the 25-turn ceiling - and a task that
+dies at the ceiling costs more than a task that succeeds, because the transcript
+was at its largest exactly when it was being resent most. Three failed cheap
+runs plus one successful one can overtake a single clean run on a model five
+times the price. Neither direction of this is guaranteed, which is why the only
+trustworthy comparison is empirical: same task, both models, read the
+transcripts. [Browser problem or model problem?](browser-problem-or-model-problem.md)
+covers how to make that comparison clean, and passing the same `--seed` keeps
+the browser identity constant between runs so the model is the only variable
+you moved.
+
+## How to choose in practice
+
+1. **Start with the default.** If your tasks succeed on it, there is nothing
+   to optimize; a bigger model would have done the same work for several times
+   the money.
+2. **When a task fails, diagnose before upgrading.** A blocked page or a
+   challenge page is not a model problem, and no model spend fixes it; the
+   [diagnostic page](browser-problem-or-model-problem.md) separates the two.
+3. **Upgrade on model-side symptoms only**: wrong elements, loops, premature
+   "done", turn-ceiling errors on tasks that ought to be short. Try a frontier
+   model on the same task and compare transcripts, not vibes.
+4. **Match the model to the task's stakes.** A nightly check that reads one
+   number can live on the cheapest thing that works ([monitoring is exactly
+   this shape](how-to-monitor-a-page-with-an-ai-agent.md)); a long multi-step
+   extraction where a wrong answer costs you something deserves the stronger
+   model, because the model is the cheapest part of being wrong.
+
+One boundary stated plainly: this page cannot tell you the best model id to
+paste, because that answer decays in weeks and depends on your tasks. The
+criteria above do not.
+
+## Short answers to the questions that lead here
+
+**What model does AIHawk use by default?** `z-ai/glm-4.6`, via OpenRouter. Set
+`--model` or `AIHAWK_MODEL` to use anything else OpenRouter serves.
+
+**Do I need an OpenRouter account?** For the real agent, yes - the model comes
+from OpenRouter and nowhere else in the current source. Without a key, `aihawk
+ui` still runs on a
+[literal-command placeholder](using-aihawk-without-an-api-key.md), which spends
+nothing.
+
+**Is a frontier model worth it for browser automation?** Only when the
+transcript shows model-side failures on a cheaper one. On tasks the default
+handles, a frontier model does the same work at several times the price; on
+tasks the default fumbles, it can be cheaper than the retries.
+
+**Why did a short task cost more than I expected?** Because every turn resends
+the whole transcript, so cost grows with turns times context, not with the
+length of your instruction. One early full-page read is paid again on every
+later turn.
+
+**Does AIHawk send my key anywhere besides OpenRouter?** It is used for the
+OpenRouter API and stripped from the environment the browser engine starts
+with, by name and by value; the repository carries a test that fails if that
+stops being true.
+
+**Can I cap what a task spends?** There is no money cap in the current source.
+The structural caps are 25 turns per instruction and 8,192 tokens per reply,
+and the interface shows running token usage while a task runs, so a runaway is
+visible while it is still cheap.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [OpenRouter: Z.ai GLM 4.6](https://openrouter.ai/z-ai/glm-4.6), for the
+  default model's per-provider pricing range.
+- [OpenRouter: Claude Sonnet 4.5](https://openrouter.ai/anthropic/claude-sonnet-4.5),
+  for the frontier comparison pricing and the long-context tier.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), this repository's
+  source: `src/aihawk/llm.py` (default model, OpenRouter-only base URL, key and
+  model resolution), `src/aihawk/agent.py` (the loop, turn cap, token caps,
+  transcript resending, usage meter), and `src/aihawk/runner.py` with
+  `tests/test_key_isolation.py` (the key never reaching the browser process).
+
+**See also:** [browser problem or model problem?](browser-problem-or-model-problem.md),
+[using AIHawk without an API key](using-aihawk-without-an-api-key.md),
+[agent retry loops and rate limits](agent-retry-loops-rate-limits.md), and the
+rest of [Using the Agent](guides-using-the-agent.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The mechanics
+here - the default, the caps, the resent transcript - are read from the source;
+the prices from OpenRouter on the date shown. Both drift, so trust the criteria
+longer than the numbers.*


### PR DESCRIPTION
## Summary

Wave two of the wiki: the product half the first wave deliberately left out, plus fixes that came out of running the full editorial QA suite on wave one.

**Eight product pages** under Using the Agent, every claim read out of src/ before being written down: which model to run and what a task costs (priced live from OpenRouter, with the honest note that turns times context dominates), the browser-problem-or-model-problem diagnostic the keyless placeholder exists for, running the browser from Claude Code, Claude Desktop and Cursor, the keyless mode as a first-class page, and two task guides (extracting to CSV, monitoring a page - honest that a diff tool beats an agent for byte-level checks; the cron guidance stands on the real `uvx aihawk do`, verified in cli.py).

**Fact-check fixes on five pages**: an independent verification pass against OpenAI's current guide found the computer-use API framing stale - it is generally available now, driven by current models, not the tier-gated `computer-use-preview` research preview the pages described. Fixed everywhere it described the present; historical mentions of January 2025 stay. The retired preview model's per-token price went with it.

**Cannibalization audit outcome**: the two-wiki perimeter came back clean (no Critical or High overlaps, intra-wiki or against the engine wiki); the audit's four link-hygiene findings are fixed here - links that pointed at the engine wiki's pointer stubs now point at the local pages the content lives on.

**Also**: the README gains a wiki section (the wiki had no link from the repo's most-crawled page), the Using the Agent hub lists its nine children, and articles/README.md records the owner's decision that a mainstream site may be the declared subject of a guide - while incidental target-naming in demos, credentials, and site-specific defense-defeating instructions stay out.

## Test plan

- [x] `scripts/check_english_only.py` clean (full tree)
- [x] Zero em/en-dashes, pure ASCII across all docs pages
- [x] All internal links resolve; `build_wiki.py` renders all 33 pages + sidebar with no collisions
- [x] No proxy-provider names; forbidden-names scanner clean
- [x] Every product claim verified against src/; external claims fetched live 2026-09-03

Generated with Claude Code
