### PR TITLE
LinkedIn gets named, and every page that names it opens with the rules

### DIFF
--- a/docs/ai-agent-linkedin-job-search.md
+++ b/docs/ai-agent-linkedin-job-search.md
@@ -1,0 +1,203 @@
+---
+title: "An AI agent for your LinkedIn job search"
+description: "What an agent genuinely does for a job search - read postings, match them against your background, draft tailored answers, stop before every submit - and the two things it should never become: a spray cannon or an outreach machine."
+parent: "Job Application Automation"
+nav_order: 7
+---
+
+
+# An AI agent for your LinkedIn job search
+
+The useful version of "an AI agent for my LinkedIn job search" is an
+assistant that reads faster than you and never gets tired of postings, with
+you making every decision that matters. The useless version is the same
+software with the human removed - and this project has unusual standing to
+say so, because it built the useless version first, at scale, and the tech
+press documented what happened. This page describes the useful version
+concretely, and is plain about the boundaries that keep it useful.
+
+One boundary sits above all the others, so it goes first. LinkedIn's User
+Agreement (section 8.2) prohibits using "bots or other unauthorized
+automated methods to access the Services," and its help center says accounts
+using prohibited automation tools "risk having their accounts restricted or
+shut down." Any agent acting on LinkedIn itself operates against that
+baseline - the [head page of this cluster](automating-linkedin-job-applications.md)
+carries the full quotes and the enforcement record. The workflow below is
+built to keep the agent's genuine value while keeping you, not the agent, as
+the actor on the platform wherever an action binds you.
+
+## What an agent can genuinely do
+
+**Read postings at volume, so you do not have to.** The most tedious part of
+a search is not applying; it is reading forty postings to find the six worth
+your time. Reading is exactly what an LLM with a browser does well: open a
+posting, extract what the role actually is under the boilerplate, note the
+hard requirements, flag the mismatches. Give the agent your background first
+and the reading becomes screening: "of these postings, which ones want
+something I actually have, and what disqualifies me from the rest."
+
+**Match honestly against your background.** A good prompt here is explicit
+in both directions: surface real fits, and name real gaps. An agent that
+tells you a posting wants five years of something you have two of is doing
+the job; one that rounds you up is manufacturing a bad interview. Instruct
+it that every claim must come from the background you provided - the
+grounding rules from
+[automating job applications with Claude](automate-job-applications-with-claude.md)
+apply verbatim.
+
+**Draft tailored answers and letters.** For the postings that survive
+screening, the agent drafts: a cover letter emphasizing the true things this
+role cares about, answers to written questions from your actual history.
+Tailoring, honestly defined, is choosing which true things to lead with -
+not inventing. The draft is raw material for your edit, not a finished
+artifact.
+
+**Keep a human before every submit.** The project's README states the rule
+in one line: do not submit anything a human has not read. Mechanically that
+means the agent works through a form in front of you and stops - it does
+not click the final button, and it halts on questions that bind you (salary,
+visa status, relocation, legal attestations) rather than answering them in
+your name.
+
+## What it cannot and should not do
+
+**Mass application is out, and not as etiquette - as the documented failure
+mode.** When 404 Media ran this project's old bot, it applied to 17 jobs in
+an hour, in a story built around a user who had reached 2,843 applications;
+TechCrunch's same-day coverage noted that 42 percent of companies were
+already using AI to screen applicants, making the whole exchange a loop of
+machines talking to machines; The Verge's headline said job seekers were
+being enabled to think like spammers. The costs land on the applicant:
+errors replicated thousands of times, generic answers recruiters learn to
+discount, interviews you walk into unprepared because you never read the
+application that earned them - and platform enforcement on top, since
+volume is the most legible signal a logged-in platform reads (see
+[how LinkedIn detects bots](linkedin-bot-detection.md)). An agent run at
+spray volume is the old bot with better prose and a bigger bill.
+
+**Unattended runs on the platform are out.** The value of the agent is
+judgment applied per posting; unattended, that judgment is unreviewed, which
+on a job application means unreviewed claims made in your name. If a task
+needs no judgment, an agent is the wrong tool for it anyway; if it needs
+judgment, the judgment needs checking.
+
+**And the adjacent thing this project does not do:** there is a whole
+industry of LinkedIn outreach automation - connection-request campaigns,
+message sequences, engagement pods, growth-hacking tooling for sales and
+recruiting. It is a real market and this is not it. That category is
+squarely inside the User Agreement's ban on automated methods to "add or
+download contacts, send or redirect messages ... or otherwise drive
+inauthentic engagement," and its output is the noise every LinkedIn user
+already wades through. AIHawk is not an outreach tool, ships nothing for
+campaigns or sequences, and this wiki will not become a manual for them.
+That is the whole paragraph, on purpose.
+
+## Where AIHawk fits, concretely
+
+AIHawk is a general web agent on a hardened Firefox: you say what you want
+in plain language, it drives a real browser - pointer moving, keys pressed,
+no JavaScript shortcuts a page could detect. Two ways in, per the README: if
+you already use Claude Code, Claude Desktop or Cursor, one command adds the
+browser to your assistant (`claude mcp add -s user stealth -- uvx
+invisible-playwright-mcp`); otherwise `uvx aihawk ui` gives you chat beside
+a live browser view with an OpenRouter key, and `uvx aihawk do "..."` runs a
+single instruction headlessly.
+
+The job-search shape that fits inside the boundaries above puts the agent's
+volume where no platform terms are implicated, and the human at every
+binding action:
+
+1. **Ground it.** Paste or point it at your real background once per
+   session. Add the standing instruction: claims only from this background;
+   gaps mean asking, not improvising.
+2. **Let it read and screen.** Collect postings you are interested in and
+   have the agent read each one against your background - fits, gaps, and
+   what a strong application would emphasize. This is reading, at a pace
+   you set, with you present.
+3. **Have it draft off-platform.** Cover letters and question answers are
+   drafted from the posting text and your background - work that does not
+   touch your account at all.
+4. **You act.** You edit the drafts, you fill or approve the form, you
+   click submit, at whatever pace a person applies at - a handful per
+   session. Where the agent works a form in front of you, it stops before
+   the submit and lists everything it left for your judgment.
+
+Steps 2 and 3 are where the agent saves you hours, and they are also -
+not coincidentally - the steps where nothing is acting on your account. If
+your model tooling is the open question,
+[which model to use with AIHawk](which-model-to-use-with-aihawk.md) covers
+the trade-offs, and
+[using AIHawk without an API key](using-aihawk-without-an-api-key.md)
+covers the assistant-hosted route.
+
+## Short answers to the questions that lead here
+
+**Can an AI agent do my LinkedIn job search for me?** It can do the reading,
+screening and drafting - most of the hours - with you doing the judging and
+submitting. Removing the human entirely recreates the spray bot, with the
+documented costs and the account risk that came with it.
+
+**Is using an AI agent on LinkedIn against the terms?** Automated access is
+prohibited by the User Agreement, and the account risk of automation on the
+platform is yours. The workflow above concentrates the agent's work
+off-platform and keeps a human as the actor for anything that binds you.
+Read [the head page](automating-linkedin-job-applications.md) before
+deciding anything.
+
+**How many applications should the agent help with per day?** A number a
+person could genuinely produce and review - single digits in a session,
+each one read before submit. Volume is what broke this approach in 2024,
+and it is entirely your choice.
+
+**Will it write my cover letters?** It will draft them, tailored to the
+posting from your real background. You edit and own the result; instruct it
+explicitly that missing information means asking you.
+
+**Can it also do my LinkedIn networking and outreach?** No, deliberately.
+Automated connection requests and message sequences are inauthentic
+engagement under LinkedIn's own terms, and this project does not build for
+them.
+
+**What does AIHawk actually run on?** A patched Firefox driven over MCP -
+either by your existing assistant (Claude Code, Claude Desktop, Cursor) or
+by the project's own `uvx aihawk ui` / `uvx aihawk do` with an OpenRouter
+key.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [LinkedIn User Agreement](https://www.linkedin.com/legal/user-agreement),
+  section 8.2, for the automated-access and inauthentic-engagement
+  prohibitions quoted.
+- [LinkedIn Help: Prohibited software and extensions](https://www.linkedin.com/help/linkedin/answer/a1341387),
+  for the "restricted or shut down" consequence.
+- [404 Media, "I Applied to 2,843 Roles: The Rise of AI-Powered Job
+  Application Bots"](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/),
+  Jason Koebler, October 10 2024, for the 17-in-an-hour and 2,843 figures.
+- [TechCrunch, "Someone claims to have used AI to apply to 2,843
+  jobs"](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/),
+  Kyle Wiggers, October 10 2024, for the 42 percent AI-screening figure.
+- The Verge's October 10 2024 piece is linked from the
+  [project README](https://github.com/feder-cr/AIHawk#readme); the site
+  blocks automated retrieval, so its framing is cited from the headline as
+  linked there.
+- The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), for the
+  two ways to run the agent, the input-event behavior, and the human-review
+  rule.
+
+**See also:** [automating LinkedIn job applications: what exists and what
+it costs you](automating-linkedin-job-applications.md) for the landscape
+and the terms reality, [automating job applications with
+Claude](automate-job-applications-with-claude.md) for the assistant-driven
+setup this page's workflow runs on, [LinkedIn Easy Apply
+bots](linkedin-easy-apply-bots.md) for the volume-first class this page is
+the alternative to, and [getting an AI agent to fill out
+forms](ai-agent-fill-out-forms.md) for the form mechanics.
+
+---
+
+*Written by the maintainer of [AIHawk](https://github.com/feder-cr/AIHawk).
+The agent got better than the 2024 bot in every way that matters, and the
+most important improvement is the one that looks like a limitation: it
+waits for you.*

--- a/docs/ai-apartment-hunting.md
+++ b/docs/ai-apartment-hunting.md
@@ -1,0 +1,200 @@
+---
+title: "Using an AI agent to hunt for apartments"
+description: "What an agent genuinely does for an apartment search - read listings at volume, compare them against your criteria, watch for new ones - the workflow with uvx aihawk do, and the boundaries that keep the search from becoming scraping."
+parent: "Using the Agent"
+nav_order: 10
+---
+
+
+# Using an AI agent to hunt for apartments
+
+Apartment hunting is a reading problem wearing a browsing costume. The work
+is not clicking through listings; it is holding forty of them in your head
+against a dozen criteria - budget, commute, floor, pets, lease length,
+which "cozy" means small and which "needs love" means broken - and doing it
+again tomorrow when thirty new ones appear. That is judgment applied to
+prose at volume, which is precisely the shape of task an AI agent with a
+real browser is good at, and precisely the shape a scripted scraper is bad
+at, because the facts live in free text and photos, not in stable fields.
+
+This page covers what the agent genuinely does for a search like this, a
+concrete workflow with the `aihawk` CLI, and the boundaries stated up
+front rather than in the fine print - because listing portals have terms
+too, and an agent does not exempt you from them.
+
+## The boundaries, first
+
+**Listing sites have terms of use, and many restrict automation.** The big
+portals - Zillow, Apartments.com, Idealista, Rightmove, ImmobilienScout24,
+whichever ones serve your market - publish terms, and prohibitions on
+scraping and automated access are common; Rightmove's site states flatly
+that it "prohibits the scraping of its content." Read the terms of the
+portal you actually use before pointing an agent at it. An agent reads a
+page the way a person does, one listing at a time under your instruction -
+but the terms are the site's call, not this wiki's.
+
+**Volume is still volume.** A person checking twenty listings a day is a
+reader; a scheduled sweep pulling five hundred listings an hour is a
+scraper, whatever software does the pulling. The signals that get agents
+blocked anywhere - rate, rhythm, fingerprint - apply on listing sites too,
+and the map for them is
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md).
+Keep the ask human-sized and most of that page never becomes relevant to
+you.
+
+**The agent reads; you contact.** Inquiries to landlords and agents are
+messages sent in your name about a place you might live. The agent can
+draft one from a listing's details; a human sends it. Auto-sending
+inquiries at volume is the rental-market version of the spray-application
+pattern whose costs
+[this project documented on itself](open-source-job-application-bot.md),
+and it burns the same thing: your credibility with the people you need to
+say yes.
+
+## What the agent actually does
+
+**Reads listings against your criteria, not just filters.** Portal filters
+stop at structured fields. Your real criteria do not: "ground floor only
+if there is a garden," "top floor only with an elevator," "no
+north-facing," "landlord-managed preferred." An agent holds the full
+criteria list and reads each listing's prose and captions against it,
+returning fits, near-misses with the reason, and the disqualified with the
+disqualifier named - so you can audit its judgment instead of trusting it.
+
+**Compares across sites that do not compare themselves.** Markets are
+fragmented across portals with different layouts and vocabularies. The
+agent does not care; a listing page is a listing page. Ask it to check the
+same neighborhood on two portals and reconcile duplicates - the same flat
+posted twice at different rents is a genuinely useful find.
+
+**Extracts to something you can track.** A search generates state: what you
+saw, where, at what price, its status. Have the agent emit each session's
+findings as CSV rows and you have a running spreadsheet of the market -
+the mechanics and the honest failure modes of that pattern are covered in
+[extracting data to a CSV with an AI agent](how-to-extract-data-to-csv-with-an-ai-agent.md).
+
+**Watches for new listings - with judgment, on a sane schedule.** The
+recurring question in a hot market is "anything new today that fits?" That
+is a monitoring task where the condition needs reading, which is exactly
+when an agent earns its per-run cost over a plain diff tool - the boundary
+[the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md) draws in
+detail, including when the plain tool wins. Daily is a search; every five
+minutes is a bill and a signature.
+
+## The workflow, concretely
+
+AIHawk's headless entrypoint is built for repeatable single instructions
+(the README files it under "for scripts and cron"). A worked example, with
+the portal URL being whatever search-results page you have already set up
+by hand:
+
+```bash
+uvx aihawk do "Go to <your saved search URL>. Read the first 15 listings.
+My criteria: max 1600/month, 2 rooms, pets allowed, available within 60
+days, no ground floor without outdoor space. For each listing output one
+line: title, price, rooms, floor, verdict FIT/NEAR/NO with the deciding
+reason. Read the listing text, do not trust the summary card. If a fact is
+not stated, write UNKNOWN, do not guess." --profile-dir ~/.hawk-flat
+```
+
+The prompt carries the craft, and three parts of it matter more than the
+rest. The criteria are explicit and closed - the agent judges against your
+list, not its taste. The output is one line per listing with the reason
+attached - auditable at a glance. And "UNKNOWN, do not guess" is
+load-bearing: listings omit exactly the facts that matter, and an agent
+that fills gaps optimistically is worse than none, because a wrong "pets
+allowed" costs you a viewing trip.
+
+For the recurring version, put that command in cron or Task Scheduler,
+redirect stdout to a dated file, and keep `--profile-dir` stable so the
+session persists between runs. Once a day, or twice in a genuinely fast
+market. For interactive sessions - "open the third FIT and tell me what
+the photos show about the kitchen" - `uvx aihawk ui` gives you the same
+agent beside a live browser view, and if you already use Claude Code or
+Claude Desktop, the same browser attaches to your assistant instead
+([the setup page](running-aihawk-with-claude-code.md) has the one-liner).
+
+Two practical notes from the field. First, listing portals are heavy,
+banner-laden pages; a stronger model earns its cost here more than on
+simple pages, and
+[which model to use with AIHawk](which-model-to-use-with-aihawk.md) covers
+that trade. Second, keep the geography honest: if you run through a proxy
+for other work, a search "from" the wrong country gets you the wrong
+inventory and prices - plain home connection is the right default for a
+local search.
+
+## What stays yours
+
+The agent compresses the reading. It does not - and should not - replace
+the parts where the stakes live: viewing the place, judging the
+neighborhood at 10pm rather than in the photos, reading the lease, smelling
+the damp the wide-angle lens cropped out. Treat its output as a briefing,
+verify anything that costs money to believe (a "FIT" is a claim, not a
+fact - the listing may have lied, or the agent misread), and never send
+money or documents based on a listing nobody has visited. Rental fraud
+predates AI and an agent does not detect it for you; a deal that reads too
+good in the agent's summary reads that way because it is.
+
+## Short answers to the questions that lead here
+
+**Can an AI agent find me an apartment?** It can read the market for you:
+screen listings against real criteria, compare across portals, track what
+is new, and draft inquiries. Choosing, viewing, and signing stay human -
+as does hitting send on the first message.
+
+**Is it allowed to use an agent on listing sites?** The portal's terms
+decide, and several restrict automated access - Rightmove states it
+prohibits scraping outright. Read the terms of the site you use; a
+human-paced, human-supervised session is a different thing from a scraping
+operation, but the line is drawn by the site, not by your tooling.
+
+**How is this different from setting up portal alerts?** Alerts fire on
+structured filters; the agent judges prose criteria the filters cannot
+express, reconciles across portals, and explains each verdict. Use both:
+alerts for speed, the agent for judgment.
+
+**What does it cost per run?** A browser session plus a handful of model
+calls - cents per check on the default model, roughly a minute of wall
+clock. Fine daily; wasteful as a rapid poller, and a plain diff monitor is
+the better rapid poller anyway.
+
+**Will the agent get blocked by listing sites?** At human pace with the
+project's browser, usually not - and if it does, work the layers in order
+on [the blocking page](why-does-my-ai-agent-get-blocked.md) before blaming
+any one of them. A sweep at scraper volume deserves the block, and this
+page is not the recipe for one.
+
+**Can it fill out rental application forms too?** The same way it works
+job forms: draft from your real information, stop at anything binding,
+human reviews and submits. See
+[getting an AI agent to fill out forms](ai-agent-fill-out-forms.md).
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), for the
+  `uvx aihawk do` / `uvx aihawk ui` commands, the `--profile-dir` and
+  proxy behavior, and the scripts-and-cron framing.
+- [Rightmove's terms-of-use page](https://www.rightmove.co.uk/this-site/terms-of-use.html),
+  for its stated prohibition on scraping its content, cited as the
+  concrete example that listing portals restrict automated access.
+- Portal names (Zillow, Apartments.com, Idealista, ImmobilienScout24) are
+  used as examples of the category only; no claim is made here about any
+  individual site's terms beyond the one quoted above.
+
+**See also:** [monitoring a page for changes with an AI
+agent](how-to-monitor-a-page-with-an-ai-agent.md) for the recurring-check
+mechanics this page leans on, [extracting data to a CSV with an AI
+agent](how-to-extract-data-to-csv-with-an-ai-agent.md) for turning
+sessions into a tracked spreadsheet, [which model to use with
+AIHawk](which-model-to-use-with-aihawk.md) for the model trade-off on
+heavy pages, and [why does my AI agent get
+blocked?](why-does-my-ai-agent-get-blocked.md) for when a portal pushes
+back.
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The agent
+reads the listings; you still take the viewing - and the flat with the
+suspiciously wide-angle photos is still small.*

--- a/docs/automating-linkedin-job-applications.md
+++ b/docs/automating-linkedin-job-applications.md
@@ -1,0 +1,208 @@
+---
+title: "Automating LinkedIn job applications: what exists and what it costs you"
+description: "The four classes of LinkedIn application automation - Easy Apply bots, extensions, SaaS appliers, AI agents - with the User Agreement and the account risk stated up front, and the quality-over-volume lesson this project learned in public."
+parent: "Job Application Automation"
+nav_order: 5
+---
+
+
+# Automating LinkedIn job applications: what exists and what it costs you
+
+Tools that automate LinkedIn job applications exist, they work in the narrow
+mechanical sense, and this project wrote one of the most famous of them. Before
+this page describes any of it, two facts have to come first, because every
+other fact on the page sits downstream of them.
+
+First: LinkedIn's User Agreement prohibits this. Section 8.2 ("Don'ts") has
+members agree not to "develop, support or use software, devices, scripts,
+robots or any other means or processes (such as crawlers, browser plugins and
+add-ons or any other technology) to scrape or copy the Services, including
+profiles and other data from the Services," and separately not to "use bots or
+other unauthorized automated methods to access the Services." LinkedIn's help
+center restates it without hedging: no third-party software, browser plug-in
+or extension "that scrape, modify the appearance of, or automate activity on
+LinkedIn's website."
+
+Second: LinkedIn enforces it against accounts, not just tools. The same help
+pages say members using such tools "risk having their accounts restricted or
+shut down," and that depending on the violation, access "may be restricted
+either temporarily or indefinitely." That is your professional identity, your
+connections, and your application history on the line - not the bot author's.
+
+If you read this page and still automate, you do it knowing both. That is the
+deal for everything below.
+
+## The landscape, in four classes
+
+**Easy Apply scripts on GitHub.** Open-source bots, usually Python plus a
+browser driver, that log into your account, search postings, and submit
+through LinkedIn's Easy Apply flow - the one-click path where the form is
+short and structured enough for a script to survive. This is the oldest and
+largest class, it is where this project started, and it has its own page:
+[LinkedIn Easy Apply bots: the landscape, read honestly](linkedin-easy-apply-bots.md).
+
+**Browser extensions.** Chrome extensions that ride inside your logged-in
+session and auto-fill or auto-advance application forms as you browse. Less
+setup than a script, same account, same policy exposure - LinkedIn's
+prohibited-software page names browser plug-ins and extensions explicitly.
+
+**SaaS auto-appliers.** Paid services that apply on your behalf, either by
+driving a cloud browser with your credentials or session, or by having human
+operators work from your profile. You are outsourcing the automation, not the
+risk: the activity still lands on your account, and you have added a third
+party holding your login.
+
+**AI agents.** The newest class, and a different shape: an LLM driving a real
+browser, reading each posting and each form question, drafting answers from
+your background. This is what AIHawk became, and the difference it makes - and
+does not make - is the next section.
+
+## What an AI agent changes versus a dumb clicker
+
+A scripted bot fills the same answers into every form and submits whatever the
+selectors let it submit. An agent actually reads: it can tell that this
+posting wants a different emphasis than the last one, that this free-text
+question is about relocation and should stop and ask you, that the salary
+field is not something software should answer in your name. Used properly,
+the human stays in the loop: the agent drafts, you read, you submit. The
+project's own README states the rule in one line - do not submit anything a
+human has not read - and the pages on
+[applying with Claude](automate-job-applications-with-claude.md) and
+[the agent-flavored job search](ai-agent-linkedin-job-search.md) are built
+around it.
+
+Now the part an agent does not change. The User Agreement quoted above does
+not distinguish a clever bot from a dumb one; "automate activity" covers
+both. The account risk does not shrink because the cover letter got better.
+And if you run an agent at bot volume, you have rebuilt the bot with a higher
+API bill. The genuine advantage of the agent class is quality per
+application, and that advantage only exists at a volume where a human reads
+each one. Push the volume up and you keep the risk while destroying the one
+thing that made the agent worth having.
+
+## The cautionary tale is this project's own history
+
+AIHawk began as exactly the thing this page describes: a bulk LinkedIn jobs
+applier. In October 2024, 404 Media's Jason Koebler ran it himself, applied to
+17 jobs in an hour, and built his piece around a user who had let it run to
+2,843 applications.
+[TechCrunch covered the same story](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/)
+and named the loop: by the figure it cited, 42 percent of companies were
+already using AI to screen applicants, so automated applications were meeting
+automated screening with humans absent from both ends. The Verge put the
+criticism in its headline: AI was enabling job seekers to think like
+spammers. And
+[Semafor's piece](https://www.semafor.com/article/09/12/2024/linkedins-have-nots-and-have-bots)
+recorded the enforcement side: LinkedIn's Trust and Safety team restricted the
+account of this project's own developer for "repeatedly sharing content that
+facilitates access to tools that automate activity on LinkedIn in violation
+of LinkedIn's user agreement." Not for running a bot - for posting about one.
+
+The criticism was substantially right, and the costs it predicted are the
+costs sprayed applicants actually pay: replicated errors at scale, answers
+that read generic because they are, recruiters discounting what looks
+mass-produced, and platform enforcement on top. That history is why the
+project retired the bulk applier and became a general agent with a
+human-review rule, a story told in full in
+[the open-source job application bot, and what it became](open-source-job-application-bot.md).
+
+## So what is actually worth doing
+
+The honest hierarchy, from safest to riskiest:
+
+1. **Use AI off-platform.** Draft answers, tailor your resume, and prepare
+   from postings you read yourself. No automation touches LinkedIn; nothing
+   in the User Agreement is implicated.
+2. **Use an agent as a supervised assistant, sparingly.** A handful of
+   applications in a session, each one read by you before submit, at a pace a
+   person could sustain. This is the mode this wiki documents. Understand
+   that even this is automation under the Agreement's language, and the
+   account risk is yours.
+3. **Run a bulk bot.** The class the 2024 coverage was about. Mechanically
+   real, strategically self-defeating, and squarely what LinkedIn restricts
+   accounts for. This wiki documents what these tools are, not how to make
+   them survive - see [how LinkedIn detects bots](linkedin-bot-detection.md)
+   for why surviving is not really on the menu anyway.
+
+Volume is the variable that moves you down this list, and volume is entirely
+your choice. Everything this project learned in public says the same thing:
+the metric that pays the applicant is quality per application, and no tool
+changes that.
+
+## Short answers to the questions that lead here
+
+**Is automating LinkedIn applications against the terms of service?** Yes.
+Section 8.2 of the User Agreement prohibits software, scripts, robots and
+"other unauthorized automated methods" that access or automate the Services,
+and LinkedIn's help center applies that to bots, plug-ins and extensions by
+name.
+
+**Will my account actually get banned?** LinkedIn's own pages say accounts
+using prohibited tools risk being "restricted or shut down," temporarily or
+indefinitely, and its enforcement is documented in press coverage - including
+against this project's developer. The risk is real; nobody outside LinkedIn
+can quote you odds.
+
+**Do Easy Apply bots work?** Mechanically, until they do not: selectors
+drift, multi-step forms break them, and account flags end the run. The
+[Easy Apply landscape page](linkedin-easy-apply-bots.md) reads the real ones
+honestly.
+
+**What does an AI agent do that a bot cannot?** Read the posting, tailor
+honest answers from your actual background, and stop where your judgment is
+required. What it cannot do is make automation allowed or bulk volume smart.
+
+**Does AIHawk auto-apply to LinkedIn jobs for me?** Not in the unattended
+sense, by design. The project retired its bulk applier; today's agent works
+through applications in front of you, and the README's rule is that a human
+reads everything before it is submitted.
+
+**What is the safest way to use AI in a job search?** Keep the AI on your
+side of the browser: drafting, tailoring, preparing. The moment software acts
+on LinkedIn for you, you are in the Agreement's territory and the account
+risk is yours.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [LinkedIn User Agreement](https://www.linkedin.com/legal/user-agreement),
+  section 8.2 "Don'ts," for the quoted prohibitions on scraping software and
+  bots.
+- [LinkedIn Help: Prohibited software and extensions](https://www.linkedin.com/help/linkedin/answer/a1341387),
+  for the plug-in and extension prohibition and the "restricted or shut down"
+  consequence.
+- [LinkedIn Help: Account restrictions](https://www.linkedin.com/help/linkedin/answer/a1340522),
+  for restrictions being temporary or indefinite and automation as a listed
+  cause.
+- [Semafor, "LinkedIn's have nots and have bots"](https://www.semafor.com/article/09/12/2024/linkedins-have-nots-and-have-bots),
+  Mizy Clifton, September 12 2024, for the documented account restriction and
+  LinkedIn's quoted enforcement language.
+- [404 Media, "I Applied to 2,843 Roles: The Rise of AI-Powered Job
+  Application Bots"](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/),
+  Jason Koebler, October 10 2024.
+- [TechCrunch, "Someone claims to have used AI to apply to 2,843
+  jobs"](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/),
+  Kyle Wiggers, October 10 2024, for the 42 percent AI-screening figure.
+- The Verge's October 10 2024 piece is linked from the
+  [project README](https://github.com/feder-cr/AIHawk#readme); the site
+  blocks automated retrieval, so its framing is cited from the headline as
+  linked there.
+- The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), for the
+  human-review rule and the project's current shape.
+
+**See also:** [LinkedIn Easy Apply bots: the landscape, read
+honestly](linkedin-easy-apply-bots.md) for the tool-by-tool ecosystem,
+[an AI agent for your LinkedIn job search](ai-agent-linkedin-job-search.md)
+for the supervised alternative in practice,
+[how LinkedIn detects bots](linkedin-bot-detection.md) for the enforcement
+mechanics, and [the open-source job application bot, and what it
+became](open-source-job-application-bot.md) for the history this page keeps
+pointing at.
+
+---
+
+*Written by the maintainer of [AIHawk](https://github.com/feder-cr/AIHawk),
+which was the LinkedIn bot in the 2024 headlines and is now a general web
+agent. This page states LinkedIn's rules plainly because the project learned
+what ignoring them costs - in public, on its own account.*

--- a/docs/guides-job-application-automation.md
+++ b/docs/guides-job-application-automation.md
@@ -11,11 +11,17 @@ TechCrunch, Business Insider, Wired and The Verge along the way. The project
 has since become a general web agent, but the job-application use case is
 still real, still asked about, and still where much of this community started.
 
-One rule these pages keep, everywhere: no job board or company site is named.
-Naming who is being automated against turns a guide into a target list, so
-examples use generic forms and pages you serve yourself.
+One rule these pages keep, everywhere: a platform is named only as the
+subject of a guide - what it is, what its terms actually say, what the risks
+are - never as the target of evasion instructions. The LinkedIn pages below
+state the User Agreement and the account risk before anything else, and the
+how-to pages keep their worked examples on generic forms and pages you serve
+yourself.
 
 - [Automating job applications with Claude](automate-job-applications-with-claude.md)
 - [Automating job applications with ChatGPT](automate-job-applications-with-chatgpt.md)
 - [Automating job applications in Python](automate-job-applications-python.md)
 - [The open-source job application bot, and what it became](open-source-job-application-bot.md)
+- [Automating LinkedIn job applications: what exists and what it costs you](automating-linkedin-job-applications.md)
+- [LinkedIn Easy Apply bots: the landscape, read honestly](linkedin-easy-apply-bots.md)
+- [An AI agent for your LinkedIn job search](ai-agent-linkedin-job-search.md)

--- a/docs/guides-using-the-agent.md
+++ b/docs/guides-using-the-agent.md
@@ -21,3 +21,4 @@ and what to expect before you spend model tokens finding out.
 - [Monitoring a page for changes with an AI agent](how-to-monitor-a-page-with-an-ai-agent.md)
 - [Running AIHawk's browser from Claude Desktop](running-aihawk-with-claude-desktop.md)
 - [Running AIHawk's browser from Cursor](running-aihawk-with-cursor.md)
+- [Using an AI agent to hunt for apartments](ai-apartment-hunting.md)

--- a/docs/guides-when-the-agent-gets-blocked.md
+++ b/docs/guides-when-the-agent-gets-blocked.md
@@ -23,3 +23,4 @@ check, in what order.
 - [Agent retry loops trip rate limits, not fingerprints](agent-retry-loops-rate-limits.md)
 - [Claude computer use detected as a bot](claude-computer-use-detected-as-bot.md)
 - [browser-use getting blocked: what you can and cannot change](browser-use-getting-blocked.md)
+- [How LinkedIn detects bots, at the level you can reason about](linkedin-bot-detection.md)

--- a/docs/linkedin-bot-detection.md
+++ b/docs/linkedin-bot-detection.md
@@ -1,0 +1,227 @@
+---
+title: "How LinkedIn detects bots, at the level you can reason about"
+description: "What LinkedIn states publicly about automation enforcement, the three signal families a logged-in platform can read - rate, rhythm, fingerprint - and the restriction ladder, with no evasion advice anywhere on the page."
+parent: "When the Agent Gets Blocked"
+nav_order: 6
+---
+
+
+# How LinkedIn detects bots, at the level you can reason about
+
+Nobody outside LinkedIn knows LinkedIn's detection systems, and this page will
+not pretend to. What can be done honestly is smaller and more useful: read
+what LinkedIn states publicly, apply the general mechanics of bot detection -
+which are well documented and the same everywhere - to the specific situation
+of a logged-in professional network, and describe the enforcement ladder
+members actually report climbing. One thing this page deliberately is not: a
+guide to evading any of it. The reasons are at the end, and they are practical
+as much as principled.
+
+## What LinkedIn says publicly
+
+The policy layer is not secret. The User Agreement's section 8.2 has members
+agree not to "develop, support or use software, devices, scripts, robots or
+any other means or processes (such as crawlers, browser plugins and add-ons
+or any other technology) to scrape or copy the Services," and not to "use
+bots or other unauthorized automated methods to access the Services, add or
+download contacts, send or redirect messages, create, comment on, like,
+share, or re-share posts, or otherwise drive inauthentic engagement." The
+help center's prohibited-software page applies this to "crawlers", bots,
+browser plug-ins and extensions by name, and states the consequence: accounts
+"restricted or shut down," and prohibited tools that "may become
+non-operational without notice" - that last phrase being LinkedIn saying,
+publicly, that it actively breaks automation tooling, not merely that it
+disapproves.
+
+Enforcement is documented beyond LinkedIn's own pages.
+[Semafor's September 2024 piece](https://www.semafor.com/article/09/12/2024/linkedins-have-nots-and-have-bots)
+on job-application bots - which featured this project's own developer -
+recorded LinkedIn's Trust and Safety team removing posts about bot tools and
+restricting an account for "repeatedly sharing content that facilitates
+access to tools that automate activity on LinkedIn in violation of LinkedIn's
+user agreement." Note what that implies about scope: enforcement reached
+content about automation, not only automation itself.
+
+## The structural fact: the account is the tracking cookie
+
+Most bot-detection writing is about anonymous traffic: a scraper with no
+session, identified by fingerprint and IP because there is nothing else to
+key on. LinkedIn's situation is the opposite, and reasoning about it starts
+here. Almost everything that matters on LinkedIn happens logged in, which
+means every action is already attributed to a persistent identity with a
+history: account age, typical hours, typical volume, device history, network
+history. A platform in that position does not need to answer "is this browser
+a bot?" from a cold start; it can ask the much easier question "is this
+account behaving like itself?"
+
+That inverts the usual weighting. For anonymous scraping, the browser
+fingerprint is the front line. For a logged-in platform, behavioral signals
+attached to the account are the front line, and the fingerprint is a
+supporting witness. Keep that in mind through the three signal families
+below.
+
+## Signal family one: rate
+
+The bluntest signals are counts, and they need no sophistication at all:
+applications per hour, connection requests per day, messages sent, profiles
+viewed, searches run, sessions per day. A human job seeker on a bad week has
+a ceiling; scripts advertise breaking it - one bot in
+[the Easy Apply landscape](linkedin-easy-apply-bots.md) claims 100-plus
+applications an hour, and the 2024 coverage of this project's old bot
+documented 17 in an hour as a reporter's casual test. A platform that can see
+per-account counts does not need machine learning to notice a 50x outlier; it
+needs a threshold. Rate is also the signal the account owner controls most
+directly, which matters later.
+
+## Signal family two: rhythm
+
+Between the counts there is cadence. Automated sessions have a shape human
+sessions do not: actions at machine-regular intervals, forms completed with
+no reading time, navigation that never hesitates, never backtracks, and never
+gets distracted, activity that runs for hours without the gaps a human life
+imposes. This is the same timing signal any agent gives off anywhere - the
+general anatomy is on [the timing-signal page](ai-agent-timing-signal.md) -
+but a logged-in platform gets a stronger version of it, because it can
+compare a session's rhythm against the account's own history, not just
+against "humans in general." A related self-inflicted variant: automation
+that retries on failure produces bursts of identical actions, the signature
+covered in [agent retry loops and rate limits](agent-retry-loops-rate-limits.md).
+
+## Signal family three: the fingerprint layer
+
+Underneath behavior, the browser itself is readable: the TLS handshake's
+shape on the network, and in the page, the joined-up picture from canvas
+rendering, GPU strings, fonts, screen values and their mutual consistency.
+Automation stacks leak here in characteristic ways - stock automation
+browsers have known tells, and tools patched against detection have tells of
+their own when the patching is inconsistent. The mechanics are engine-level
+and site-agnostic, so this wiki keeps them on the engine's own pages:
+[how websites detect bots](https://github.com/feder-cr/invisible_playwright/wiki/how-do-websites-detect-bots)
+for the model,
+[JA3/JA4 TLS fingerprinting](https://github.com/feder-cr/invisible_playwright/wiki/ja3-ja4-tls-fingerprint)
+for the network side, and
+[ASN and IP reputation](https://github.com/feder-cr/invisible_playwright/wiki/asn-and-ip-reputation-in-bot-detection)
+for the address layer that rides along with it.
+
+For LinkedIn specifically, remember the structural fact: fingerprints likely
+serve as corroboration and as linkage - recognizing a returning device across
+accounts, spotting a session that suddenly looks like different software than
+the account's history - rather than as the primary verdict. A clean browser
+does not launder bot-shaped behavior on a platform that can see the behavior
+directly, per account, forever.
+
+## The restriction ladder
+
+LinkedIn's public pages describe graduated enforcement rather than a single
+trapdoor. Assembled from the
+[account-restrictions help page](https://www.linkedin.com/help/linkedin/answer/a1340522):
+
+- **Challenges and verification.** Restricted members may be asked to verify
+  identity or "follow the onscreen prompts" - the platform interposing a
+  human check before restoring access.
+- **Temporary restriction.** Access "may be restricted either temporarily or
+  indefinitely," in LinkedIn's own words - the temporary form being the
+  warning shot: the account comes back, the message is that the behavior was
+  seen.
+- **Permanent restriction.** The same page notes some violations "may result
+  in permanent account restriction after a single violation." For a
+  professional network account carrying your history and connections, this
+  is the whole downside, concentrated.
+
+The ladder's existence is itself information: enforcement begins well short
+of a ban, which means an account holder usually gets a signal before the
+worst outcome - and what they do with that signal is the one lever they
+genuinely hold.
+
+## Why this page teaches no evasion
+
+Two reasons, one principled and one practical. The principled one: the
+detection described here is a platform enforcing terms its members agreed
+to, against behavior those terms prohibit. Teaching evasion of it is
+teaching someone to burn their own professional account with better
+technique.
+
+The practical one follows from the structure of the signals. Of the three
+families, the fingerprint layer is the only one tooling can address, and on
+a logged-in platform it is the least decisive of the three. Rate and rhythm
+are produced by what you ask automation to do - they are choices, made
+upstream of any tool. The honest lever, for anyone using an agent near
+LinkedIn at all, is the one this wiki repeats everywhere: human volume,
+human pacing, a human reading everything before it is submitted, which is
+[the project's own stated rule](https://github.com/feder-cr/AIHawk#readme).
+That is not an evasion technique. It is the absence of the thing being
+detected - and the only configuration in which the question "will I be
+caught?" stops mattering, because there is no bot-shaped behavior to catch.
+The general debugging map for agents blocked anywhere is at
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md).
+
+## Short answers to the questions that lead here
+
+**How does LinkedIn detect bots?** Publicly: it prohibits them, says it
+breaks their tooling, and restricts accounts. Structurally: as a logged-in
+platform it can read per-account rate, session rhythm, and browser
+fingerprint, with the account history making the behavioral signals far
+stronger than they are against anonymous traffic.
+
+**Does LinkedIn detect Easy Apply bots specifically?** Its help pages
+prohibit the class by name (bots, plug-ins, extensions that automate
+activity), and application velocity is among the most legible signals a
+platform can read. Documented enforcement exists; per-tool detection rates
+do not, from anyone honest.
+
+**Can a stealth browser make LinkedIn automation safe?** No. A hardened
+browser addresses the fingerprint family only - and on a logged-in platform
+the account's own behavior is the primary evidence. Rate and rhythm are
+produced by what the automation does, and no browser changes what you asked
+it to do.
+
+**What triggers a LinkedIn restriction?** LinkedIn lists automation among
+several causes (content, identity and profile violations are others) and
+does not publish thresholds. Reported experiences cluster around volume
+spikes - but that is community reporting, not LinkedIn documentation.
+
+**Is a temporary restriction a ban?** No; LinkedIn's pages distinguish
+temporary from indefinite restriction, with verification steps to recover.
+Treat it as the platform saying it saw something - the response it invites
+is stopping the behavior, not upgrading the tooling.
+
+**Where do I read about the detection mechanics in depth?** The engine
+wiki:
+[how websites detect bots](https://github.com/feder-cr/invisible_playwright/wiki/how-do-websites-detect-bots)
+and its linked pages cover fingerprinting and the vendor landscape at the
+mechanism level, site-agnostically.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [LinkedIn User Agreement](https://www.linkedin.com/legal/user-agreement),
+  section 8.2, for the quoted prohibitions on scraping software, bots, and
+  inauthentic engagement.
+- [LinkedIn Help: Prohibited software and extensions](https://www.linkedin.com/help/linkedin/answer/a1341387),
+  for the tool-class prohibition, "restricted or shut down," and tools
+  becoming "non-operational without notice."
+- [LinkedIn Help: Account restrictions](https://www.linkedin.com/help/linkedin/answer/a1340522),
+  for the temporary/indefinite distinction, single-violation permanent
+  restriction, and recovery prompts.
+- [Semafor, "LinkedIn's have nots and have bots"](https://www.semafor.com/article/09/12/2024/linkedins-have-nots-and-have-bots),
+  Mizy Clifton, September 12 2024, for the documented enforcement episode
+  and LinkedIn's quoted restriction language.
+- [invisible_playwright wiki](https://github.com/feder-cr/invisible_playwright/wiki/how-do-websites-detect-bots),
+  for the mechanism-level detection model this page applies.
+
+**See also:** [why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md)
+for the four-layer map this page is a platform-specific reading of,
+[the timing signal AI agents give off](ai-agent-timing-signal.md) for the
+rhythm family in depth,
+[agent retry loops and rate limits](agent-retry-loops-rate-limits.md) for
+the burst signature, and
+[automating LinkedIn job applications](automating-linkedin-job-applications.md)
+for the decision this page is meant to inform.
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The project
+builds the best fingerprint layer it can, and this page still tells you that
+layer decides the least on a logged-in platform - because that is what is
+true.*

--- a/docs/linkedin-easy-apply-bots.md
+++ b/docs/linkedin-easy-apply-bots.md
@@ -1,0 +1,206 @@
+---
+title: "LinkedIn Easy Apply bots: the landscape, read honestly"
+description: "The real GitHub bots, the extension class and the SaaS class - what each actually does, what breaks first, the lineage that leads back to this project, and the User Agreement reality none of them change."
+parent: "Job Application Automation"
+nav_order: 6
+---
+
+
+# LinkedIn Easy Apply bots: the landscape, read honestly
+
+Easy Apply is LinkedIn's short-form application flow: instead of bouncing to
+an employer's own site, you answer a few structured questions inside LinkedIn
+and submit. That structure is exactly what makes it automatable - a bounded
+form, predictable fields, one platform's markup instead of every employer's -
+and so it became the target of an entire class of bots. This page reads that
+class honestly: the real tools, what they actually do, what breaks, and the
+two facts that frame all of it.
+
+The facts first, because they apply to every tool named below equally.
+LinkedIn's User Agreement, section 8.2, prohibits members from using
+"software, devices, scripts, robots or any other means or processes" to
+scrape the Services, and from using "bots or other unauthorized automated
+methods to access the Services." Its help center adds that members using such
+tools "risk having their accounts restricted or shut down," and that the
+tools themselves "may become non-operational without notice." Every bot in
+this landscape operates against that baseline, whatever its README says, and
+the account the risk lands on is yours.
+
+## The GitHub bots, factually
+
+These are the real, findable, open-source tools a searcher encounters. All
+three were checked on 2026-09-03; descriptions are theirs, not ours.
+
+**[nicolomantini/LinkedIn-Easy-Apply-Bot](https://github.com/nicolomantini/LinkedIn-Easy-Apply-Bot)**
+(about 1,100 stars) describes itself simply: "Automate the application
+process on LinkedIn." You configure positions, locations and constraints in a
+YAML file, supply credentials, and the bot applies to matching Easy Apply
+postings. The author's companion write-up is titled "How to apply for 1,000
+jobs while sleeping," which tells you the design goal in one line: volume,
+unattended.
+
+**[GodsScion/Auto_job_applier_linkedIn](https://github.com/GodsScion/Auto_job_applier_linkedIn)**
+(about 2,800 stars) pitches "Make your job hunt easy by automating your
+application process with this Auto Applier." It is the maximal version of the
+class: it searches for relevant postings, answers application questions,
+tailors resumes per job with the OpenAI API, and its README claims it can
+apply to more than 100 jobs in an hour. It is built on Selenium, and its
+repository topics include undetected-chromedriver - worth noticing, because a
+tool that needs a detection-evading driver is telling you the platform is
+looking for it.
+
+**[jomacs/linkedIn_auto_jobs_applier_with_AI](https://github.com/jomacs/linkedIn_auto_jobs_applier_with_AI)**
+(about 54 stars) matters less for its size than for what it is: a fork of
+this repository, frozen under the project's old name. Its description still
+reads "LinkedIn_AIHawk is a tool that automates the jobs application process
+on LinkedIn. Utilizing artificial intelligence, it enables users to apply for
+multiple job offers in an automated and personalized way" - which is a
+faithful description of what this project was in 2024.
+
+## The lineage, stated plainly
+
+That last repo is the visible end of a real lineage. AIHawk began life as the
+LinkedIn_AIHawk jobs applier - an AI-powered bulk application bot for
+LinkedIn, the one 404 Media ran to 17 applications in an hour and TechCrunch
+and The Verge covered in October 2024. Forks taken in that era keep the name
+and README the project carried then, so a searcher who finds
+"linkedIn_auto_jobs_applier_with_AI" or "LinkedIn_AIHawk" today is finding
+descendants of this project's old code. They are legitimate forks - the code
+was open source and forking it is exactly what the license allowed - and
+nothing here is a criticism of the people maintaining them. The original,
+meanwhile, retired the bulk applier and became AIHawk, a general web agent;
+that whole arc is told in
+[the open-source job application bot, and what it became](open-source-job-application-bot.md).
+
+The practical consequence for a reader comparing tools: the forks continue
+the 2024 design - unattended LinkedIn volume - while the original now takes
+the opposite position, supervised work with a human reading every submission.
+Same ancestor, opposite answers to the volume question.
+
+## The extension class
+
+Chrome extensions occupy the low-friction end: they run inside your existing
+logged-in session and auto-fill or auto-advance Easy Apply forms as you
+browse, sometimes with an AI layer drafting the free-text answers. No
+separate driver, no credential handoff, which makes them feel safer than they
+are: LinkedIn's prohibited-software page names "browser plug-ins, or browser
+extensions that scrape, modify the appearance of, or automate activity" on
+the site explicitly, and an extension operates in the one place LinkedIn's
+own JavaScript can see. The convenience is real; the policy exposure is
+identical to the scripts'.
+
+## The SaaS class
+
+Paid services sit at the other end: you hand over your profile, preferences
+and often your credentials or an active session, and the service applies for
+you - some driving cloud browsers, some using human operators, most
+advertising volume per week as the headline feature. Two things distinguish
+this class, neither favorable. The activity still lands on your account, so
+the User Agreement exposure is unchanged. And you have added a third party
+holding your login and acting in your name at their pace, not yours - an
+arrangement you cannot audit from outside.
+
+## What breaks, in the order it breaks
+
+**Selectors drift.** Every scripted bot is welded to LinkedIn's markup, and
+the markup changes - ordinary redesign or otherwise. When it changes, the bot
+mis-clicks, skips required fields, or silently submits garbage until its
+maintainer catches up. An open-source bot's issue tracker is the honest
+changelog of this arms race.
+
+**Multi-step forms filter the class.** Easy Apply's short path is automatable;
+the longer variants - conditional questions, file uploads, free-text answers
+that get read by a human - are where scripted bots either stop or answer
+badly. The AI-augmented bots push further into this territory by generating
+answers, which replaces "blank field" failures with "confidently wrong
+field" failures, at volume.
+
+**Account flags end the run.** The failure mode that matters most is not
+technical. Application velocity is visible to the platform in a way no
+selector fix addresses, and LinkedIn's stated response to prohibited tools is
+restriction of the account - covered mechanically in
+[how LinkedIn detects bots](linkedin-bot-detection.md). Every bot in this
+landscape shares this exposure completely, whatever driver it ships.
+
+## The honest read
+
+Read as a landscape, the Easy Apply bot class is a machine for converting a
+real frustration - application forms are repetitive and screening is already
+automated on the employer side - into a specific bad trade: volume you
+cannot review, sent from an account you cannot afford to lose, against terms
+that prohibit it. This project made that trade at scale in 2024, got the
+star count and the headlines, and concluded the criticism was right; the
+[head page of this cluster](automating-linkedin-job-applications.md) carries
+that history and the quality-over-volume position it produced. If what you
+actually want is AI help with a job search rather than a volume machine,
+that is a different shape of tool entirely -
+[an AI agent for your LinkedIn job search](ai-agent-linkedin-job-search.md)
+describes it.
+
+## Short answers to the questions that lead here
+
+**What is the best LinkedIn Easy Apply bot?** The premise buys the wrong
+contest. The bots differ in polish, but they share markup fragility and,
+completely, the account risk - LinkedIn prohibits the whole class. The
+differences that matter are in what you are risking, not which bot clicks
+faster.
+
+**Are Easy Apply bots against LinkedIn's terms?** Yes. Section 8.2 of the
+User Agreement prohibits scripts, robots and unauthorized automated access,
+and the help center names bots, plug-ins and extensions, with account
+restriction as the stated consequence.
+
+**Do the GitHub bots still work?** They work between markup changes and
+account flags. Their issue trackers document both failure modes better than
+any review could.
+
+**Is AIHawk one of these bots?** It was - it began as LinkedIn_AIHawk, the
+bulk applier the 2024 press covered, and forks of that code still circulate
+under the old name. The current project is a general agent with a
+human-review rule, which is the opposite design.
+
+**Are the forks scams?** No claim of that here. They are legitimate forks of
+open-source code, maintained by their own authors, continuing the original
+design. The reservations on this page are about that design - unattended
+volume against prohibiting terms - not about the people running the forks.
+
+**What breaks these bots most often?** Selector drift first, multi-step and
+free-text forms second, account restriction third - and the third is the one
+no update fixes.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [LinkedIn User Agreement](https://www.linkedin.com/legal/user-agreement),
+  section 8.2, for the quoted prohibitions.
+- [LinkedIn Help: Prohibited software and extensions](https://www.linkedin.com/help/linkedin/answer/a1341387),
+  for the extension-class prohibition, "restricted or shut down," and tools
+  becoming "non-operational without notice."
+- [nicolomantini/LinkedIn-Easy-Apply-Bot](https://github.com/nicolomantini/LinkedIn-Easy-Apply-Bot),
+  [GodsScion/Auto_job_applier_linkedIn](https://github.com/GodsScion/Auto_job_applier_linkedIn),
+  and
+  [jomacs/linkedIn_auto_jobs_applier_with_AI](https://github.com/jomacs/linkedIn_auto_jobs_applier_with_AI),
+  for each tool's own description, star count, and stated capabilities.
+- [404 Media, "I Applied to 2,843 Roles: The Rise of AI-Powered Job
+  Application Bots"](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/),
+  Jason Koebler, October 10 2024, for the first-hand account of the original
+  AIHawk bot.
+- The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), for the
+  project's current shape and the human-review rule.
+
+**See also:** [automating LinkedIn job applications: what exists and what it
+costs you](automating-linkedin-job-applications.md) for the full landscape
+this page zooms into, [how LinkedIn detects
+bots](linkedin-bot-detection.md) for the enforcement layer, [an AI agent for
+your LinkedIn job search](ai-agent-linkedin-job-search.md) for the
+supervised alternative, and [the open-source job application bot, and what
+it became](open-source-job-application-bot.md) for the lineage from the
+inside.
+
+---
+
+*Written by the maintainer of [AIHawk](https://github.com/feder-cr/AIHawk),
+the project several of these bots descend from. Nobody gets to describe this
+landscape from higher ground; this page settles for describing it
+accurately.*

--- a/docs/open-source-job-application-bot.md
+++ b/docs/open-source-job-application-bot.md
@@ -66,9 +66,11 @@ There was a second, quieter problem: the original bot was welded to the markup
 of the pages it automated. Selectors written for a specific flow break when the
 page changes, and pages change constantly - some of that is ordinary
 redesign, some of it is aimed. A tool built as a collection of site-specific
-scripts is in a maintenance race it cannot win, which is why this wiki's pages
-name no job platforms at all: the durable knowledge is the mechanics that are
-the same everywhere, not any one site's layout.
+scripts is in a maintenance race it cannot win, which is why this wiki's
+how-to pages teach the mechanics that are the same everywhere, never any one
+site's layout - and why the pages that do name a platform, like
+[the LinkedIn cluster](automating-linkedin-job-applications.md), describe
+what exists and what its terms say rather than how to script it.
 
 So the project's answer to the criticism is not a defense of spray. It is
 agreement, followed by a change of direction: the metric that pays the


### PR DESCRIPTION
## Summary

The owner opened the door this wiki's rules kept shut: a mainstream site may now be the declared subject of a guide, with the risk laid out in writing first (the project's own LinkedIn-entangled history, the archiviation, the press framing). These five pages walk through that door in the register the decision was made under.

**Every LinkedIn page opens with the rules**: LinkedIn's User Agreement section 8.2 quoted verbatim (fetched, not paraphrased), the account-restriction ladder from LinkedIn's own help pages, and an explicit no-evasion stance - the detection page has a section saying why it teaches none. The history is told straight: this project began as the LinkedIn jobs applier; the forks a searcher still finds under the old name (verified live: jomacs/linkedIn_auto_jobs_applier_with_AI still carries the LinkedIn_AIHawk description) descend from that code; the media wave is cited from the articles themselves.

**The five pages**: automating LinkedIn job applications (the head page), the Easy Apply bot ecosystem read honestly (real repos named factually: nicolomantini's, GodsScion's, the forks), how LinkedIn detects bots (funneling to the engine wiki for fingerprint mechanics), an AI agent for LinkedIn job search (human-before-every-submit stance), and AI apartment hunting - the one non-LinkedIn vertical whose demand survived verification.

**Measured, not guessed**: the LinkedIn cluster's autocomplete and SERPs came back rich (community and GitHub results ranking everywhere, including an AIHawk fork at position 6 on "linkedin auto apply ai"); travel came back a SaaS wall and price tracking thin - both skipped, recorded here so nobody re-derives it.

Two hub paragraphs that declared "no job board is named" stopped being true the moment these pages landed; they now state the actual rule: subject yes, target list no.

## Test plan

- [x] English-only gate clean (full tree)
- [x] Zero em/en-dashes, pure ASCII
- [x] All internal links resolve; build_wiki renders all 38 pages + sidebar
- [x] Forbidden-names scanner clean
- [x] LinkedIn User Agreement, help pages, and all named repos fetched live 2026-09-03

Generated with Claude Code
