### PR TITLE
The infrastructure layer gets compared, with every number read off the vendor's own page

### DIFF
--- a/docs/ai-browser-agent-open-source.md
+++ b/docs/ai-browser-agent-open-source.md
@@ -1,6 +1,6 @@
 ---
 title: "Open-source AI browser agents"
-description: "The open-source agents that drive a real browser - browser-use, Skyvern, Stagehand, Nanobrowser, BrowserOS, AIHawk - compared by license, engine and how each reads a page."
+description: "The open-source agents that drive a real browser - browser-use, agent-browser, Skyvern, Stagehand, Nanobrowser, BrowserOS, AIHawk - compared by license, engine and how each reads a page."
 parent: "Alternatives and Comparisons"
 nav_order: 7
 ---
@@ -49,6 +49,20 @@ through Ollama. The company behind it also runs a paid hosted cloud; the library
 the open part, and it is the default answer to "which one do most people use". If you
 are evaluating it against alternatives, there is a dedicated page for that:
 [browser-use alternatives](browser-use-alternatives.md).
+
+### agent-browser
+
+41.9k stars, Rust, Apache-2.0, from Vercel's labs organization. It is a CLI rather
+than a framework: a native binary with a background daemon, built to be called by a
+coding agent you already run (Claude Code, Cursor and similar), which is where the
+model in the loop comes from. It downloads Chrome for Testing locally and drives it
+over CDP, and it addresses elements through deterministic "refs" instead of
+screenshots, which keeps token cost down. Cloud browsers are pluggable rather than
+bundled: a provider flag can point the same commands at hosted vendors including
+Browserless, Browserbase, Browser Use and Kernel. The star count deserves one honest
+caveat: the repository dates to January 2026, so those 41.9k stars accrued in about
+eight months on the strength of the Vercel name; treat them as attention, not yet as
+miles.
 
 ### Stagehand
 
@@ -106,11 +120,17 @@ layers are yours regardless of the agent you pick; the breakdown is in
 [why agents get blocked](why-does-my-ai-agent-get-blocked.md). Platform limits are
 real too: Python 3.11+, Windows and Linux, no macOS support.
 
+One near miss before the table, for completeness: Notte (~2k stars) pairs an agent
+framework with its own hosted browser infrastructure, but it is licensed SSPL-1.0,
+which the OSI has not approved as open source, so it fails this page's first test
+rather than its second or third.
+
 ## The differences that decide the choice
 
 | Project | Stars (2026-09-03) | Language | License | Browser it drives | How it reads a page |
 |---|---|---|---|---|---|
 | browser-use | 112.1k | Python | MIT | Playwright-driven browser | DOM plus screenshots |
+| agent-browser | 41.9k | Rust | Apache-2.0 | local Chrome for Testing via CDP, pluggable cloud browsers | CLI commands, deterministic element refs |
 | Stagehand | 24.1k | TypeScript, Python, Go | MIT | Playwright-compatible runtime | structured actions, DOM-first |
 | Skyvern | 22.9k | Python | AGPL-3.0 (anti-bot parts cloud-only) | Playwright | vision LLM plus page structure |
 | Nanobrowser | 13.7k | TypeScript | Apache-2.0 | your own Chrome or Edge | in-page, multi-agent |
@@ -121,8 +141,10 @@ A few honest cuts through the table:
 
 - **Most people, most tasks:** browser-use. Largest community, most examples, and
   model quality usually matters more than framework choice for ordinary tasks.
-- **You are writing your own agent:** Stagehand, and it is the only entry here that
-  is honest about being a building block rather than a product.
+- **You are writing your own agent:** Stagehand, and it is one of two entries here
+  that are honest about being a building block rather than a product.
+- **Your agent is a coding assistant in a terminal:** agent-browser, the other
+  building block, a CLI shaped for exactly that loop on a stock Chrome.
 - **Zero infrastructure, your own browser:** Nanobrowser. An extension is also the
   easiest thing on this page to try and to remove.
 - **The browser as the product:** BrowserOS.
@@ -167,10 +189,12 @@ All retrieved 2026-09-03. Star counts and claims were read from each project's o
 repository page on that date.
 
 - [browser-use/browser-use](https://github.com/browser-use/browser-use)
+- [vercel-labs/agent-browser](https://github.com/vercel-labs/agent-browser)
 - [browserbase/stagehand](https://github.com/browserbase/stagehand)
 - [Skyvern-AI/skyvern](https://github.com/Skyvern-AI/skyvern)
 - [nanobrowser/nanobrowser](https://github.com/nanobrowser/nanobrowser)
 - [browseros-ai/BrowserOS](https://github.com/browseros-ai/BrowserOS)
+- [nottelabs/notte](https://github.com/nottelabs/notte), for the near-miss note.
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README in this
   repository.
 

--- a/docs/browser-use-alternatives.md
+++ b/docs/browser-use-alternatives.md
@@ -57,7 +57,10 @@ business, genuinely useful for teams that want managed scale. But if you came
 to open source to keep the agent local, keyed to providers you chose, some of
 the ecosystem's energy is now pointed somewhere you do not want to go. The
 open MIT core still works standalone; you should just know which direction
-the wind blows.
+the wind blows. As of 2026-09-03 the split is explicit on browser-use's own
+site, which sells two commercial products, "Browser Use Agents" and "Browser
+Infrastructure" (managed cloud browsers for your own code) - the
+[infrastructure layer itself is explained here](cloud-browser-infrastructure-for-ai-agents.md).
 
 ### What is not on this list
 
@@ -157,6 +160,7 @@ for whether you need an agent at all.
 ## Sources
 
 - The [browser-use repository](https://github.com/browser-use/browser-use), retrieved 2026-09-03: stars, license, description, model support and the cloud material.
+- [browser-use.com](https://browser-use.com/), retrieved 2026-09-03, for the two commercial products named above.
 - [SiliconANGLE: Browser Use raises $17M](https://siliconangle.com/2025/03/23/browser-use-raises-17m-help-steer-ai-agents-internet/), surfaced via search 2026-09-03.
 - [browser-use getting blocked: what you can and cannot change](browser-use-getting-blocked.md), this wiki's own analysis, which reads `BrowserProfile`'s fields from browser-use's source.
 - The [Skyvern](https://github.com/Skyvern-AI/skyvern), [Agent-S](https://github.com/simular-ai/Agent-S) and [AIHawk](https://github.com/feder-cr/AIHawk) repositories, retrieved 2026-09-03.

--- a/docs/browserbase-alternatives.md
+++ b/docs/browserbase-alternatives.md
@@ -1,0 +1,180 @@
+---
+title: "Browserbase alternatives"
+description: "Two different searches hide in this query: another place to run cloud browser fleets (Steel, BrowserStation, Browserless, Hyperbrowser, Anchor), or an agent that removes the infra bill entirely. Both halves, honestly."
+parent: "Alternatives and Comparisons"
+nav_order: 12
+---
+
+# Browserbase alternatives
+
+"Browserbase alternatives" is two different searches wearing one query, and
+the honest first step is deciding which one is yours. Either you need what
+Browserbase actually sells - managed browser fleets in the cloud - and want a
+different vendor or a self-hosted version of the same thing. Or you arrived
+here from the top of the funnel, wanting "an agent that browses", found that
+the famous name in the space is an infrastructure company, and what you
+actually need is an agent, at which point the infrastructure bill is optional.
+
+This page answers both, with the disclosure up front: it lives on the wiki of
+[AIHawk](https://github.com/feder-cr/AIHawk), an open-source local agent that
+appears in the second half. Every claim about Browserbase and the other
+vendors below was read from their own sites, pricing pages and repositories
+on 2026-09-03.
+
+## What Browserbase gets right, first
+
+Fairness before alternatives. Browserbase is the mindshare leader of the
+[browser infrastructure category](cloud-browser-infrastructure-for-ai-agents.md)
+and earned it. The pricing is legible: a free tier (3 concurrent browsers,
+sessions capped at 15 minutes), a $20/mo Developer tier with 100 browser
+hours then $0.12/hr, a $99/mo Startup tier with 500 hours, and custom above
+that. Its homepage claims "10,000+ companies building beyond the API"; that
+is the company's own number, but the ecosystem gravity around it is checkable
+another way: it open-sourced [Stagehand](https://github.com/browserbase/stagehand)
+(MIT, ~24.1k stars), an SDK for browser agents that people use who never buy
+the cloud, and it gives away [Director](https://www.browserbase.com/director),
+which turns plain-English instructions into working agents and exports real
+Stagehand code. A vendor whose free, open layers are this good is not one you
+leave casually.
+
+So the reasons to look elsewhere are specific, not general: you want open
+source you can self-host and audit; you want to own the metered costs at
+scale; you want a different point on the price curve; or, second half of the
+page, you never needed managed fleets at all.
+
+## Half one: you need cloud browser fleets, elsewhere
+
+If concurrent browsers in the cloud are genuinely your requirement - a
+product feature, CI, scale beyond one machine - these are the real
+alternatives, one line of facts each, read from their own pages on
+2026-09-03.
+
+| Alternative | Open? | The one-line honest version |
+|---|---|---|
+| [Steel](https://github.com/steel-dev/steel-browser) | Apache-2.0, ~7.6k stars | The credible open-source answer: a browser API you self-host with one `docker run`, Chrome over CDP, Puppeteer/Playwright/Selenium supported, plus a paid cloud if you want one |
+| [BrowserStation](https://github.com/ReinforceNow/browserstation) | MIT, ~166 stars | New and small, but architecturally serious: Kubernetes plus Ray, Chrome sidecars exposing CDP, self-described as an open-source alternative to Browserbase |
+| [Browserless](https://github.com/browserless/browserless) | SSPL-1.0 OR commercial, ~13.7k stars | The veteran (repo since 2017), Docker-deployable, but the SSPL is source-available, not OSI-approved open source; read the license before you build on it |
+| [Hyperbrowser](https://hyperbrowser.ai/docs) | SaaS | Hosted sessions plus scraping and crawl APIs, reachable over Playwright, Puppeteer and CDP |
+| [Anchor Browser](https://anchorbrowser.io/) | SaaS | Sells its own Chromium fork it calls "humanized chromium", in credit tiers from free to $2,000/mo; the fork's properties are Anchor's claims, untested by us |
+| [Kernel](https://www.kernel.sh/) | SaaS | Chromium sessions over Playwright, CDP or WebDriver BiDi, and a hosted MCP server so tool-calling assistants can drive it directly |
+| [Cloudflare Browser Run](https://developers.cloudflare.com/browser-rendering/) | Big-cloud SaaS | Headless Chrome on Cloudflare's network, driven over Puppeteer, Playwright, CDP or Stagehand; the safe-default choice if you are already on Workers |
+
+Three notes the table cannot hold. First, Steel is the head-to-head
+comparison most people searching this query actually want: open code, Apache
+license, self-host by default, cloud optional - the inverse of Browserbase's
+shape. Second, if your reason for leaving is price at scale, self-hosting
+moves the spend from browser-hours to your own compute and the engineering
+time to run it; that trade has a break-even, not a winner. Third, every entry
+in the table, Browserbase included, runs Chromium or speaks its protocol, so
+switching vendors changes your operations and your bill, not what a website
+sees when it inspects the browser. The category-wide explainer covers that
+through-line:
+[cloud browser infrastructure for AI agents](cloud-browser-infrastructure-for-ai-agents.md).
+
+## Half two: what you wanted was an agent, and the bill is optional
+
+Now the other search. If you are one person or one team wanting tasks done
+in a browser - not building a product that hosts browsers for others - then
+managed fleets are an answer to a question you do not have. An agent that
+runs on your own machine does the browsing where you are, and the
+infrastructure line item is zero because there is no infrastructure vendor.
+
+The open-source agent field is surveyed properly on
+[open-source AI browser agents](ai-browser-agent-open-source.md); the short
+version relevant here:
+
+- **browser-use** (MIT, the most-adopted agent framework) runs locally
+  against a Chromium-family browser, and its company also now sells hosted
+  infrastructure if you later grow into wanting it.
+- **Stagehand itself is MIT**, which is worth restating in a page about its
+  maker: the SDK layer is not what you pay Browserbase for; the managed
+  fleet is. If your usage of Browserbase is "I like Stagehand", the code is
+  open. How Stagehand compares to the agent frameworks is its own page:
+  [Stagehand vs browser-use](stagehand-vs-browser-use.md).
+- **AIHawk** (MIT, ~30k stars) - ours, disclosure above. It runs locally and
+  ships its own browser: a Firefox patched at the C++ level rather than a
+  stock Chromium build, driven through an MCP server from an assistant you
+  already run (Claude Code, Claude Desktop, Cursor) or from its own UI with
+  an OpenRouter key. The costs are model tokens and nothing else.
+
+And the concessions, because this half is where our interest lives:
+a local agent gives you no fleet, no concurrency beyond your machine, no
+session cloud, no CI story, and AIHawk specifically is Windows and Linux
+only. A hardened browser changes what a page reads from the browser; it does
+not change your IP, your pacing, or a site's limits, and nothing here
+promises otherwise -
+[why agents get blocked](why-does-my-ai-agent-get-blocked.md) draws that
+boundary in full. If your workload is a product's workload, half one is your
+half.
+
+## How to decide
+
+- **You operate browser fleets for a product or pipeline, want managed:**
+  stay on Browserbase, or price Hyperbrowser, Kernel, Anchor and Cloudflare
+  against your usage shape.
+- **Same requirement, but open source and self-hosted:** Steel first;
+  BrowserStation if you are Kubernetes-native and early-adopter tolerant;
+  Browserless only after reading the SSPL.
+- **You want an agent for your own tasks on your own machine:** the agent
+  field above; the infra bill disappears. AIHawk is our entry in it,
+  conflict of interest noted.
+- **You mainly want Stagehand:** it is MIT; you can use it without the
+  cloud, and [Stagehand vs browser-use](stagehand-vs-browser-use.md) maps
+  that choice.
+
+## Short answers to the questions that lead here
+
+**What is the best open-source alternative to Browserbase?** Steel
+(Apache-2.0) is the mature one: self-hosted browser API, Chrome over CDP,
+one Docker command to try. BrowserStation (MIT) is the newer
+Kubernetes-native option. Browserless self-hosts but is SSPL-licensed, which
+is not OSI open source.
+
+**Is Browserbase free?** It has a real free tier: 3 concurrent browsers, 1
+browser hour, 15-minute session cap (read 2026-09-03). Paid starts at
+$20/mo. Stagehand and Director are free layers around the paid cloud.
+
+**Can I self-host Browserbase?** No; the cloud is the product. Stagehand,
+its MIT SDK, runs wherever you want. For the managed fleet itself, the
+self-host equivalents are Steel and BrowserStation.
+
+**Do I need Browserbase to run an AI browser agent?** No. Every major
+open-source agent runs on your own machine. The cloud earns its cost at
+fleet scale, in CI, or inside products; for personal and single-machine use,
+a local agent (AIHawk among them, disclosure above) has no infra cost at
+all.
+
+**Is Browserbase open source?** The platform is not; Stagehand (MIT) and
+Director's exported code are the open layers. That split - open SDK, paid
+cloud - is the category's standard shape, not a Browserbase quirk.
+
+**See also:**
+[Cloud browser infrastructure for AI agents](cloud-browser-infrastructure-for-ai-agents.md)
+for the whole category explained,
+[Stagehand vs browser-use](stagehand-vs-browser-use.md) for the SDK-level
+choice, [open-source AI browser agents](ai-browser-agent-open-source.md) for
+the agent field, and [browser-use alternatives](browser-use-alternatives.md)
+for the same exercise applied to the biggest agent framework.
+
+## Sources
+
+All retrieved 2026-09-03; prices, limits and star counts were read from each
+vendor's own page on that date and will drift.
+
+- [Browserbase](https://www.browserbase.com/), [its pricing page](https://www.browserbase.com/pricing), [its docs](https://docs.browserbase.com/introduction) and [Director](https://www.browserbase.com/director).
+- [browserbase/stagehand](https://github.com/browserbase/stagehand).
+- [steel-dev/steel-browser](https://github.com/steel-dev/steel-browser).
+- [ReinforceNow/browserstation](https://github.com/ReinforceNow/browserstation).
+- [browserless/browserless](https://github.com/browserless/browserless).
+- [Hyperbrowser docs](https://hyperbrowser.ai/docs).
+- [Anchor Browser](https://anchorbrowser.io/).
+- [Kernel](https://www.kernel.sh/).
+- [Cloudflare Browser Run](https://developers.cloudflare.com/browser-rendering/).
+- [browser-use.com](https://browser-use.com/), for its hosted infrastructure product.
+
+---
+
+*Written while maintaining [AIHawk](https://github.com/feder-cr/AIHawk),
+which competes with exactly one half of this page. That is why the other
+half opens with what Browserbase gets right and sends you to Steel, not to
+us.*

--- a/docs/cloud-browser-infrastructure-for-ai-agents.md
+++ b/docs/cloud-browser-infrastructure-for-ai-agents.md
@@ -1,0 +1,239 @@
+---
+title: "Cloud browser infrastructure for AI agents, explained"
+description: "What the browser-infrastructure layer actually is, the real vendors in it - Browserbase, Steel, Browserless, Hyperbrowser, Anchor, Kernel, Airtop, Cloudflare, Lightpanda - and the honest question of whether you need the layer at all."
+parent: "Alternatives and Comparisons"
+nav_order: 11
+---
+
+# Cloud browser infrastructure for AI agents, explained
+
+Search for "browser infrastructure for AI agents" and every result is a vendor
+describing itself. That is not a criticism of the vendors; it is just what
+happens in a young category where the only people writing about the layer are
+the people selling it. This page is the missing neutral explainer: what the
+layer is, who is actually in it, what they all have in common, and the
+question the vendor pages skip, which is whether your setup needs the layer at
+all.
+
+Disclosure before anything else: this wiki belongs to
+[AIHawk](https://github.com/feder-cr/AIHawk), an open-source agent that ships
+its own browser and runs locally, which is one of the two answers to that last
+question. Our interest runs against the category, so read the closing section
+knowing that, and read the vendor descriptions knowing that every fact in them
+was checked against that vendor's own site, repository or docs on 2026-09-03.
+
+## What the layer actually is
+
+An AI browser agent has two halves. The agent loop - a model reading a page
+and deciding the next action - is code you run or a product you use. The
+browser that loop drives is a heavy, stateful, crash-prone OS process, and
+"browser infrastructure" is the business of running that process for you,
+somewhere else.
+
+Concretely, a browser infrastructure vendor gives you an API that starts a
+browser in their cloud and hands back a connection URL. Your code, unchanged,
+connects to it over the same protocols it would use locally - Playwright,
+Puppeteer, or raw CDP - and everything else is their problem: spawning and
+recycling processes, keeping sessions alive between calls, session recordings
+and live debug views, egress routing, and scaling from one browser to
+hundreds. You pay per browser-hour, per credit, or per seat.
+
+That is the whole idea. It is the same move as any managed service: the
+database did not change when you stopped hosting it, and the browser does not
+either.
+
+## Why the category exists
+
+Three facts about browsers make the business real. They are expensive to run
+at density: a real page can hold a Chromium process at hundreds of megabytes,
+so a fleet of fifty is a machine-sizing problem, not a loop. They are terrible
+citizens in CI: no display, missing system dependencies, fonts, and sandbox
+flags that differ per distro. And agent workloads are bursty: you want zero
+browsers most of the day and two hundred for ten minutes.
+
+If your agent is a product feature - a SaaS that browses on behalf of your
+users - those three facts arrive on day one, and renting the layer is usually
+the right call. Hold that thought against the closing section, because none of
+the three facts applies to one person running one agent on one machine.
+
+## The vendors, one honest line each
+
+Facts below were read from each vendor's own site, pricing page or repository
+on 2026-09-03; prices and star counts drift.
+
+**[Browserbase](https://www.browserbase.com/)** is the category's mindshare
+leader: a SaaS with a free tier (3 concurrent browsers, sessions capped at 15
+minutes), then $20/mo, $99/mo and custom tiers, its homepage claiming
+"10,000+ companies". Two things distinguish it beyond scale: it open-sourced
+[Stagehand](https://github.com/browserbase/stagehand) (MIT, ~24.1k stars),
+the SDK layer many agents use whether or not they buy Browserbase, and it
+gives away [Director](https://www.browserbase.com/director), which turns
+plain-English instructions into exportable Stagehand code. The open SDK is a
+funnel to the paid cloud, and it is a good funnel because the SDK is good.
+
+**[Steel](https://github.com/steel-dev/steel-browser)** is the credible
+open-source answer: Apache-2.0, ~7.6k stars, a browser API you self-host with
+a single `docker run` against their published image, driving Chrome over CDP
+with Puppeteer, Playwright and Selenium support. If "open source" in this
+category matters to you, this is the project to evaluate first.
+
+**[Browserless](https://github.com/browserless/browserless)** is the veteran:
+its repository dates to November 2017, years before agents were the customer,
+and it has ~13.7k stars. Know the license before you build on it: the SPDX
+line reads "SSPL-1.0 OR Browserless Commercial License". The SSPL is a
+source-available license the OSI has not approved as open source, so
+"self-hostable" and "open source" are not the same word here.
+
+**[Hyperbrowser](https://hyperbrowser.ai/docs)** is a hosted SaaS selling
+"fast, reliable cloud browsers and sandboxes for AI automation", reachable
+over Playwright, Puppeteer and CDP, with scraping and crawl APIs alongside
+the raw sessions.
+
+**[Anchor Browser](https://anchorbrowser.io/)** is a SaaS whose pitch is the
+browser build itself: its own Chromium fork it calls "humanized chromium",
+sold in credit tiers from free (5 credits) through $50, $500 and $2,000 per
+month, with $1.00 per credit overage. The fork's properties are Anchor's own
+claims; we did not test them.
+
+**[Kernel](https://www.kernel.sh/)** runs isolated Chromium sessions you
+reach over Playwright, CDP or WebDriver BiDi, and is notable for meeting
+agents where they now live: it also exposes a hosted MCP server, so a
+tool-calling assistant can drive its browsers without you writing glue.
+
+**[Airtop](https://www.airtop.ai/)** is a SaaS one level up the stack: less
+"here is a browser" and more an agent-builder, where you describe a workflow
+in plain language and it compiles it into a deterministic agent that runs on
+a schedule on their cloud browsers.
+
+**[Cloudflare](https://developers.cloudflare.com/browser-rendering/)** is the
+big-cloud entrant. Its product, recently renamed Browser Run (formerly
+Browser Rendering), runs headless Chrome on Cloudflare's network, driven over
+Puppeteer, Playwright, CDP or Stagehand, with REST endpoints for one-shot
+screenshots, PDFs and markdown. When a company that size treats the layer as
+a platform primitive, the category has stopped being a startup experiment.
+
+**[Lightpanda](https://github.com/lightpanda-io/browser)** is the odd one
+out and the most interesting engineering bet on the list: not hosted
+Chromium but a new headless browser written from scratch in Zig, AGPL-3.0,
+~34.4k stars, claiming roughly 9x faster execution and 16x less memory than
+Chrome on its own benchmark. The honesty is in its README too: it is beta,
+web API coverage is partial, and some sites will error or crash. A browser
+for machines, not yet a browser for the whole web.
+
+**[BrowserStation](https://github.com/ReinforceNow/browserstation)** is the
+newest self-host option: MIT, tiny today (~166 stars), Kubernetes-native via
+Ray, each worker pod running a Chrome sidecar that exposes CDP, and
+explicitly described by its authors as an open-source alternative to
+Browserbase. Early, but the architecture is the one an infra team would ask
+for.
+
+One more entrant matters because of where it came from:
+**[browser-use](https://browser-use.com/)**, the most-adopted open-source
+agent framework, now sells "Browser Use Agents" and "Browser Infrastructure"
+as its two commercial products. The agent side of the market arriving at
+infra confirms the direction of the money: the layer is where browser-agent
+companies monetize.
+
+## The through-line: it is Chromium all the way down
+
+Check the engine column across the list and one fact repeats. Every vendor
+that names its browser runs Chrome, Chromium or a Chromium fork: Steel and
+BrowserStation say Chrome, Kernel says Chromium, Anchor is a Chromium fork,
+Cloudflare says headless Chrome. The vendors that do not name an engine still
+speak CDP, which is Chromium's protocol. The only exception is Lightpanda,
+which escaped Chromium by writing a new browser and is paying the price in
+web compatibility.
+
+Two consequences follow. The convenient one: your automation code is
+portable, because the whole category standardized on one engine and its
+protocols, and switching vendors is mostly a connection-string change. The
+inconvenient one: a cloud browser is the same browser. Moving a stock
+Chromium automation build from your laptop to a vendor's cloud changes where
+it runs, not what a page inspecting it sees, and it typically swaps your
+residential IP for datacenter egress, which is why most of these vendors also
+sell proxy routing as an add-on. The layer solves operations. It does not
+solve the questions covered in
+[why does my AI agent get blocked](why-does-my-ai-agent-get-blocked.md), and
+the serious vendors do not claim it does.
+
+## When you need the layer, and when you do not
+
+You need cloud browser infrastructure when the three facts from the top
+apply: fleets of concurrent browsers, agents running in CI or on servers with
+no display, bursty scale, sessions that must outlive any one machine, or a
+product whose users bring the workload. If that is you, the split that
+matters is managed versus self-host: Browserbase, Hyperbrowser, Anchor,
+Kernel, Airtop and Cloudflare on one side; Steel, BrowserStation and (with
+the license caveat) Browserless on the other.
+
+You do not need it when the agent is yours, personal, and local. One person
+running one agent for their own tasks has no fleet, no CI, and no burst; the
+laptop that is already on is the infrastructure. This is AIHawk's route, and
+the disclosure from the top applies in full: AIHawk ships its own browser, a
+Firefox patched at the C++ level rather than a hosted Chromium, runs it on
+your machine, and there is no per-hour or per-credit bill because there is no
+vendor in the loop. Model tokens are the only metered cost. The trade is
+real in both directions: you get no fleet, no managed scaling and no session
+cloud, and it is Windows and Linux only. For what that local route looks like
+against the rest of the agent field, see
+[open-source AI browser agents](ai-browser-agent-open-source.md).
+
+## Short answers to the questions that lead here
+
+**What is browser infrastructure for AI agents?** A managed place for your
+agent's browser process to run: a vendor API that starts browsers in their
+cloud and hands your code a Playwright/CDP connection, plus the scaling,
+session persistence and debugging around it.
+
+**What is the best headless browser for AI agents?** The engine answer is
+almost settled: the category runs Chromium, so the real choice is who
+operates it (the vendors above) or whether you run it yourself. The one
+non-Chromium bet, Lightpanda, is fast but openly partial on web
+compatibility today.
+
+**Is there an open-source Browserbase?** Steel (Apache-2.0) is the mature
+answer; BrowserStation (MIT, Kubernetes-based) is the new one and describes
+itself in exactly those words. Browserless self-hosts but is SSPL-licensed,
+which is source-available, not OSI open source.
+
+**Do I need cloud browsers to run an AI agent?** No. Every major open-source
+agent runs on your own machine, and a local agent that ships its own browser
+(AIHawk is one, disclosure above) has no infra bill at all. The layer earns
+its cost at fleet scale, in CI, or inside products.
+
+**How much does it cost?** Entry tiers are cheap ($0 to $99/mo across the
+SaaS vendors above); the real spend is metered browser-hours, credits and
+proxy gigabytes at scale, which is exactly when self-hosting starts to look
+attractive.
+
+**See also:** [Browserbase alternatives](browserbase-alternatives.md) for the
+vendor-by-vendor version of this decision,
+[browser-use alternatives](browser-use-alternatives.md) for the agent layer
+above this one, and
+[AI browser agents vs traditional scraping](ai-browser-agents-vs-traditional-scraping.md)
+for whether you need a browser in the loop at all.
+
+## Sources
+
+All retrieved 2026-09-03. Star counts, prices and tier limits were read from
+each project's own page on that date and will drift.
+
+- [Browserbase](https://www.browserbase.com/), [its pricing page](https://www.browserbase.com/pricing), [its docs introduction](https://docs.browserbase.com/introduction) and [Director](https://www.browserbase.com/director).
+- [browserbase/stagehand](https://github.com/browserbase/stagehand).
+- [steel-dev/steel-browser](https://github.com/steel-dev/steel-browser).
+- [browserless/browserless](https://github.com/browserless/browserless); creation date read from the repository's GitHub API record.
+- [Hyperbrowser docs](https://hyperbrowser.ai/docs).
+- [Anchor Browser](https://anchorbrowser.io/).
+- [Kernel](https://www.kernel.sh/).
+- [Airtop](https://www.airtop.ai/).
+- [Cloudflare Browser Run](https://developers.cloudflare.com/browser-rendering/).
+- [lightpanda-io/browser](https://github.com/lightpanda-io/browser).
+- [ReinforceNow/browserstation](https://github.com/ReinforceNow/browserstation).
+- [browser-use.com](https://browser-use.com/), for the two commercial products.
+
+---
+
+*Written while maintaining [AIHawk](https://github.com/feder-cr/AIHawk), a
+local agent that exists so its users do not need this layer. That bias is
+stated because it is real; the vendor facts above are theirs, checked against
+their own pages.*

--- a/docs/firecrawl-vs-ai-browser-agents.md
+++ b/docs/firecrawl-vs-ai-browser-agents.md
@@ -1,0 +1,204 @@
+---
+title: "Firecrawl vs an AI browser agent"
+description: "A crawl API turns URLs into LLM-ready markdown; an agent drives a real browser through a task. For bulk content, Firecrawl-shaped tools win and it is not close. The one question that decides which you need."
+parent: "Alternatives and Comparisons"
+nav_order: 13
+---
+
+# Firecrawl vs an AI browser agent
+
+Here is the answer before the article. If your task is "URLs go in,
+LLM-ready content comes out" - feeding a RAG pipeline, summarizing pages,
+building a corpus - Firecrawl or something shaped like it wins over a browser
+agent on cost, speed and simplicity, and it is not close. If your task needs
+things to happen - logged-in sessions, forms filled, multi-step flows where
+the next click depends on what the page said - a crawl API is the wrong tool
+category, and an agent driving a real browser is the right one. Everything
+below is the reasoning, the numbers, and the overlap where the choice gets
+genuinely interesting.
+
+Disclosure first: this wiki belongs to
+[AIHawk](https://github.com/feder-cr/AIHawk), an open-source AI browser
+agent, so we are a vendor of exactly one side of this comparison. Every
+Firecrawl fact below was read from Firecrawl's own repository, site or
+documentation on 2026-09-03, and the paragraph conceding their side is not
+smaller than the one favoring ours.
+
+## What Firecrawl actually is
+
+Firecrawl calls itself "the context API to search, scrape, and interact with
+the web at scale", and the shape of the product is exactly that sentence: an
+API. You send a URL and get back clean markdown or structured JSON built for
+model consumption; a `/crawl` endpoint follows links across a site; a
+`/search` endpoint returns results with full-page markdown included. It is
+the most-adopted project of its kind by a huge margin - about 176,000 GitHub
+stars when read on 2026-09-03.
+
+The licensing is worth thirty seconds because it is layered. The core
+repository is AGPL-3.0; the SDKs and some UI components are MIT. And the
+hosted cloud is more than the open code: Firecrawl's own self-hosting guide
+states that Fire-engine, the fetching layer it credits with the cloud's
+"advanced anti-bot behavior" and some capabilities like screenshots, "is not
+included" in the self-hosted stack. Their words, their architecture, and a
+fair thing to know before you assume the AGPL repo equals the product at
+firecrawl.dev.
+
+One more of their claims, quoted because it is the honest center of their
+pitch: clean markdown "with 93% fewer input tokens for your model" compared
+to raw page content. That number is Firecrawl's own measurement, but the
+direction is obviously right - stripped markdown is far smaller than raw
+HTML, and token cost is the tax every LLM pipeline pays.
+
+## What an AI browser agent actually is
+
+An agent is a different machine entirely: a language model in a loop with a
+real browser, reading the page, deciding an action, performing it, and
+repeating until the goal is met.
+[The explainer](ai-web-agent-explained.md) covers the loop; the property that
+matters here is that nothing is scripted in advance. The model decides at run
+time, which is what lets an agent do errands - sign in, navigate, fill,
+submit, retry - and also what makes it slower and more expensive per page
+than any API call will ever be.
+
+## The one question that decides it
+
+Does your task read the web, or act on it?
+
+Reading at volume is Firecrawl's home game. Acting is the agent's. The
+boundary is sharper than it first looks, because Firecrawl does have an
+interaction feature and it is worth describing precisely: its scrape can run
+a caller-provided sequence of actions before extraction - write, press,
+click, wait, screenshot. That is scripting, not deciding. You write the
+sequence in advance against a page structure you already know, which puts it
+in the same family as a Playwright script: excellent when the steps are known
+and stable, brittle when the page changes, and unable to handle a flow whose
+next step depends on judgment. The distinction between scripted and decided
+is the entire subject of
+[AI browser agents vs traditional scraping](ai-browser-agents-vs-traditional-scraping.md);
+this page is the named-tool version of it, and the general cost math lives
+there, not here.
+
+## Where Firecrawl wins, said loudly
+
+For content-to-LLM at any real volume, the crawl API side wins on every axis
+that pays the bills:
+
+- **Cost per page.** An API call versus an agent loop that sends the page
+  through a model at least once, usually several times. The agent's cost per
+  page is orders of magnitude higher, and their "93% fewer input tokens"
+  framing shows they know exactly which axis they are selling.
+- **Speed and parallelism.** Requests fan out; an agent's loop turns are
+  serial and model-latency bound.
+- **Operational simplicity.** No browser fleet, no loop to supervise, no
+  non-deterministic wandering to cap. URL in, markdown out.
+- **The ecosystem agrees.** This is the category that feeds RAG pipelines
+  and model context, and Firecrawl's adoption is the measure of the fit.
+
+If that list is your task, use the API. An agent aimed at bulk extraction is
+a misallocation: slower, costlier, and non-deterministic where determinism
+was on offer, and this is an agent's own wiki saying so.
+
+## Where the agent wins
+
+The agent's territory is everything an API request cannot be:
+
+- **State.** A logged-in session that persists across steps, a cart, a
+  wizard, a dashboard behind auth that expects a real, continuous visitor.
+- **Actions with consequences.** Submitting, booking, applying, replying,
+  changing settings: tasks where the deliverable is a changed website, not
+  a document ([the forms page](ai-agent-fill-out-forms.md) is the honest
+  account of how well that goes).
+- **Judgment mid-flow.** "Find the cheapest of these that ships this week
+  and order it" cannot be pre-scripted, because the branch points depend on
+  content nobody has seen yet.
+- **Unknown structure.** One instruction across twenty differently-built
+  sites, where writing twenty action sequences costs more than the answer.
+
+AIHawk sits on this side, and the differentiator we bring is the browser
+itself: a real Firefox patched at the C++ level rather than a headless
+Chromium in a datacenter, running locally, with identity derived from a seed
+so a failing run replays. The boundary stays where our wiki always puts it:
+that addresses what a page reads from the browser, and does nothing for your
+IP, pacing, or a site's limits -
+[why agents get blocked](why-does-my-ai-agent-get-blocked.md) is the full
+map, and it applies to hosted crawl APIs and agents alike.
+
+## The hybrid, because production usually wants both
+
+The two categories compose better than they compete:
+
+- **Agent for the errand, API for the volume.** Use an agent to reach the
+  state that matters (find the section, work out the path), then hand the
+  URL space to a crawl API for the thousand-page sweep.
+- **API for the corpus, agent for the exceptions.** Route everything through
+  the cheap path and send only the pages that need interaction or judgment
+  to the agent, keeping the blended cost near the API's.
+- **Monitoring split.** Watching pages for change is API-shaped work;
+  reacting to a change with a multi-step task is agent-shaped
+  ([the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md) walks
+  that line).
+
+## Short answers to the questions that lead here
+
+**Is Firecrawl an AI agent?** No, and it does not claim to be. It is a
+hosted API that turns web pages into LLM-ready markdown and JSON, with
+optional pre-scripted page actions. No model decides the next step inside
+Firecrawl's loop; your pipeline consumes its output.
+
+**Firecrawl vs Playwright?** Different layers. Playwright is a library you
+program to drive a browser you run; Firecrawl is a hosted service that does
+the fetching and cleaning for you. A Playwright script and Firecrawl's
+action sequences are cousins; an agent is the third thing, a model deciding
+at run time.
+
+**Firecrawl vs Browserbase?** Also different layers, easy to conflate
+because both are infrastructure: Firecrawl sells extracted content,
+Browserbase sells the browsers themselves for your code to drive. The
+[infrastructure explainer](cloud-browser-infrastructure-for-ai-agents.md)
+covers that category.
+
+**Can Firecrawl log in and fill forms?** It can execute a scripted sequence
+you provide (write, click, press, wait) before extracting. What it cannot do
+is decide the sequence: flows that branch on page content need an agent.
+
+**Is Firecrawl open source?** The core repo is AGPL-3.0 and the SDKs are
+MIT, but the cloud's fetching layer (Fire-engine) is a separate service
+their self-host docs say is not included. Self-hosters get a real product,
+not the whole product.
+
+**Which is cheaper?** For reading pages at volume, Firecrawl-shaped APIs, by
+orders of magnitude per page. For a task, the comparison stops making sense:
+an API cannot do a task, so the agent's token bill is the price of the
+category, not a premium over the API.
+
+**See also:**
+[AI browser agents vs traditional scraping](ai-browser-agents-vs-traditional-scraping.md)
+for the category-generic version of this trade-off,
+[cloud browser infrastructure for AI agents](cloud-browser-infrastructure-for-ai-agents.md)
+for the layer Firecrawl gets confused with,
+[extracting data to CSV with an agent](how-to-extract-data-to-csv-with-an-ai-agent.md)
+for the agent-side extraction workflow, and
+[open-source AI browser agents](ai-browser-agent-open-source.md) for the
+agent field itself.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [firecrawl/firecrawl](https://github.com/firecrawl/firecrawl): stars,
+  description, AGPL-3.0 core and MIT SDK licensing.
+- [firecrawl.dev](https://www.firecrawl.dev/): the markdown, crawl and
+  search endpoints, and the "93% fewer input tokens" claim quoted above.
+- [Firecrawl self-hosting guide](https://docs.firecrawl.dev/contributing/self-host):
+  the Fire-engine exclusion quoted above.
+- [Firecrawl scrape documentation](https://docs.firecrawl.dev/features/scrape):
+  the pre-extraction action types.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), for the agent-side
+  claims about our own tool.
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. AIHawk is an
+agent, and this page's first paragraph hands bulk extraction to the other
+category anyway. If we only won half the comparisons, we would rather be
+trusted on that half.*

--- a/docs/guides-alternatives-and-comparisons.md
+++ b/docs/guides-alternatives-and-comparisons.md
@@ -23,3 +23,6 @@ another tool covers more, the page says so.
 - [Open-source computer-use agents](computer-use-agent-open-source.md)
 - [What is an AI web agent?](ai-web-agent-explained.md)
 - [AI browser agents vs traditional scraping](ai-browser-agents-vs-traditional-scraping.md)
+- [Cloud browser infrastructure for AI agents, explained](cloud-browser-infrastructure-for-ai-agents.md)
+- [Browserbase alternatives](browserbase-alternatives.md)
+- [Firecrawl vs an AI browser agent](firecrawl-vs-ai-browser-agents.md)

--- a/docs/skyvern-alternatives.md
+++ b/docs/skyvern-alternatives.md
@@ -1,0 +1,188 @@
+---
+title: "Skyvern alternatives"
+description: "Skyvern's own README states that its anti-bot measures are exclusive to the managed cloud, and the core is AGPL-3.0. Which half of that sentence sent you looking, and which alternative actually answers it."
+parent: "Alternatives and Comparisons"
+nav_order: 14
+---
+
+# Skyvern alternatives
+
+Skyvern keeps one of the most honest sentences in this category near the top
+of its README, and this page is organized around it: "All of the core logic
+powering Skyvern is available in this open source repository licensed under
+the AGPL-3.0 License, with the exception of anti-bot measures available in
+our managed cloud offering." Read on 2026-09-03, at roughly 22.9k GitHub
+stars. Most projects bury a trade like that in a pricing page; Skyvern states
+it in plain text, and it deserves credit for doing so. It also means the
+search that brought you here is usually not "is Skyvern good" - it is - but
+"which half of that sentence is a problem for me, and what answers it".
+
+Disclosure before anything else: this wiki belongs to
+[AIHawk](https://github.com/feder-cr/AIHawk), an open-source agent that
+competes with Skyvern and appears below as one of the alternatives. Every
+claim about Skyvern here traces to its own repository, and where Skyvern is
+the better tool this page says so.
+
+## What Skyvern is, stated fairly
+
+Python, Playwright underneath, AGPL-3.0, installable via pip or Docker
+Compose, with Skyvern Cloud as the hosted option. The architectural bet is
+vision: LLMs read the rendered page and plan actions against what they see,
+rather than depending on XPath or CSS selectors, and the README describes the
+result as a "Playwright-compatible SDK that adds AI functionality". On top of
+that sit parameterized workflows: multi-step automations you define once and
+rerun with different inputs. The bet - pay tokens to look at pixels so that a
+site redesign does not break your script - is coherent, and for form-heavy
+pages that change layout often it is the right one. Nothing below disputes
+any of this.
+
+## The two halves of the sentence
+
+### The license half: AGPL-3.0
+
+AGPL is strong copyleft that extends to network use: if you build Skyvern
+into a service you offer to other people, you take on source-sharing
+obligations that MIT and Apache tools do not carry. That is a one-line
+summary, not legal advice, and for an individual automating their own
+browser work the license costs nothing at all. But it is the single most
+common reason companies evaluating Skyvern end up on a page like this one,
+and it is why every other tool named below is MIT or Apache-2.0.
+
+### The other half: the hard part lives in the cloud
+
+The part of the sentence after the comma is the part self-hosters feel. What
+the README calls anti-bot measures is precisely the piece kept out of the
+repository, and two fair things need saying about that. First, it is a
+legitimate design: code of that kind is kept private by essentially everyone
+who ships it, because publishing it shortens its useful life, and the cloud
+is what funds the open core. Second, the consequence for you: what `pip
+install skyvern` runs locally is standard Playwright Chromium, and its
+sessions answer a page's questions the way any stock automation build does.
+That is not a Skyvern defect - it is the shared box of the whole
+Playwright-Chromium class, documented on this wiki for browser-use in
+[what configuration can and cannot change](browser-use-getting-blocked.md).
+And before you attribute a challenged run to any tool, read
+[why an agent gets blocked](why-does-my-ai-agent-get-blocked.md): machine
+and network facts decide most of these outcomes, and nothing on this page
+changes your IP.
+
+## The alternatives, sorted by which half moved you
+
+### browser-use: same class, different interaction model
+
+Roughly 112.2k stars, MIT, Python. Not a workflow builder: you construct an
+`Agent` with a task and a model, call `run()`, and its loop does the rest -
+a conversational agent rather than a parameterized pipeline. If the license
+half was your problem, this is the most direct swap in the same
+Playwright-Chromium class. If the cloud half was, know that the structure
+repeats: browser-use's README points production users at Browser Use Cloud
+and describes it with features including what it calls built-in stealth and
+proxy rotation - vendor claims we did not test. The MIT core runs locally
+either way. Full treatment on
+[browser-use alternatives](browser-use-alternatives.md).
+
+### Stagehand: buy an SDK instead of a platform
+
+Roughly 24.1k stars, MIT, TypeScript with Python and Go SDKs, built by
+Browserbase. Three primitives - `act()`, `observe()`, `extract()` - on a
+Playwright-style API, under the banner "Playwright was built for testing,
+Stagehand is built for agents". This is the alternative for people who liked
+Skyvern's Playwright compatibility more than they liked adopting a platform:
+you keep your own loop and mix AI steps with plain deterministic calls in
+the same script. The full referee comparison is
+[Stagehand vs browser-use](stagehand-vs-browser-use.md), and the hosted
+side of that ecosystem is covered in
+[Browserbase alternatives](browserbase-alternatives.md).
+
+### The UI-TARS class: put the capability in the model
+
+UI-TARS (roughly 11.4k stars, Apache-2.0) is not a framework but a
+vision-language agent model: the GUI-operating capability is trained into
+the weights, and you bring your own scaffold or use its desktop companion.
+It is the furthest departure on this page - no workflow engine, real
+inference costs, research-grade edges - but if your read on Skyvern was
+"vision-driven operation is the right idea", this is that idea without a
+platform around it. Context in
+[open-source computer-use agents](computer-use-agent-open-source.md).
+
+### AIHawk: the hard part ships in the product - ours
+
+Roughly 30k stars, MIT, and the conflict of interest from the top of the
+page applies to this section. The contrast maps directly onto Skyvern's
+sentence: where Skyvern's README places its anti-bot measures in the managed
+cloud, AIHawk's equivalent hard part is the browser itself - a Firefox
+patched at the C++ level (the invisible_playwright engine) that presents a
+normal desktop fingerprint - and it ships inside the open-source product,
+running on your machine. That is a different placement of the same problem,
+not magic: we make no promise of non-detection anywhere, sites remain free
+to challenge any visitor, and the engine wiki documents
+[how to test the difference yourself](https://github.com/feder-cr/invisible_playwright/wiki/how-to-test-bot-detection)
+rather than asking you to take a claim on faith. The interaction model is
+also different in kind: AIHawk is a conversational agent that plugs into an
+MCP assistant you already run (Claude Code, Claude Desktop, Cursor) or its
+own local UI, not a vision-workflow engine, and it runs on Windows and Linux
+only.
+
+## Where Skyvern wins outright
+
+Fairness requires its own section. The vision-workflow model is the most
+resilient approach on this page to layout churn, and none of the
+alternatives replaces it like for like: browser-use gives you an agent, not
+rerunnable parameterized workflows; Stagehand gives you primitives, not a
+workflow engine; AIHawk gives you a different browser and a conversational
+loop, not structured pipelines. Skyvern also has a hosted option for teams
+that want managed scale, a straightforward pip and Docker story, and the
+rare virtue of a README that tells you its own limits. If neither the
+license nor the placement of the hard part bothers you, stay on Skyvern and
+close this tab; it is a good tool.
+
+## Short answers to the questions that lead here
+
+**Is Skyvern open source?** The core is, under AGPL-3.0. Its README states
+the exception itself: the measures it describes as anti-bot are available in
+the managed cloud offering, not the repository.
+
+**Skyvern vs browser-use - what is the actual difference?** Same class
+(LLM agents driving Playwright Chromium), different models of use:
+parameterized vision-workflows versus a conversational agent loop, AGPL
+versus MIT. Neither changes what the browser underneath looks like.
+
+**Is Skyvern free to self-host?** Yes, via pip or Docker, plus whatever
+your model provider charges in tokens. The cloud is a paid product.
+
+**Can self-hosted Skyvern handle sites that challenge automation?** Its
+README reserves that category for the cloud. Self-hosted, you are running
+standard Playwright Chromium, and outcomes mostly track the machine and
+network facts covered in
+[why an agent gets blocked](why-does-my-ai-agent-get-blocked.md).
+
+**Is AIHawk better than Skyvern?** Not in general, and this is our own wiki
+saying so. It differs where the browser itself or the AGPL is your problem;
+Skyvern is better where workflow authoring, vision resilience to layout
+change, or a hosted option matter.
+
+**See also:** [Stagehand vs browser-use](stagehand-vs-browser-use.md) for
+the SDK half of this page expanded,
+[browser-use alternatives](browser-use-alternatives.md) for the mirror-image
+survey, and [Choosing an AI browser agent](best-ai-browser-agent.md) for the
+full decision framework.
+
+## Sources
+
+- The [Skyvern repository](https://github.com/Skyvern-AI/skyvern), retrieved
+  2026-09-03: star count, license, the quoted README sentence, install
+  paths, and the vision-LLM and Playwright-SDK descriptions.
+- The [browser-use repository](https://github.com/browser-use/browser-use),
+  retrieved 2026-09-03: star count, license, the agent API shape, and the
+  cloud description quoted attributively.
+- The [Stagehand repository](https://github.com/browserbase/stagehand),
+  retrieved 2026-09-03: star count, license, languages, and API primitives.
+- The [UI-TARS repository](https://github.com/bytedance/UI-TARS), retrieved
+  2026-09-03: star count, license, and model positioning.
+
+---
+
+*Written while maintaining [AIHawk](https://github.com/feder-cr/AIHawk),
+which competes with Skyvern. That is why the page opens by crediting
+Skyvern's honesty, closes its survey with where Skyvern wins, and quotes the
+README instead of paraphrasing it.*

--- a/docs/stagehand-vs-browser-use.md
+++ b/docs/stagehand-vs-browser-use.md
@@ -1,0 +1,198 @@
+---
+title: "Stagehand vs browser-use"
+description: "An SDK for building browser agents versus a framework that ships one: what act(), observe() and extract() buy you against Agent().run(), which languages each serves, and which features sit behind each vendor's cloud."
+parent: "Alternatives and Comparisons"
+nav_order: 15
+---
+
+# Stagehand vs browser-use
+
+This comparison reads like a rivalry and mostly is not one. Both projects
+are MIT licensed, actively maintained, and descended from the same idea of
+putting an LLM in charge of a Playwright-driven Chromium browser. The real
+difference fits in one line: Stagehand is a kit for building an agent;
+browser-use is an agent someone already built. Almost everything else on
+this page is a consequence of that line.
+
+Disclosure: this wiki belongs to
+[AIHawk](https://github.com/feder-cr/AIHawk), an open-source agent that
+competes in the same space as both tools. Neither subject of this page is
+ours, which is what makes it a referee page; our own tool appears exactly
+once, near the end, clearly labeled. All facts were retrieved 2026-09-03
+from the two repositories and Stagehand's documentation.
+
+## Day one with each
+
+**Stagehand** ([browserbase/stagehand](https://github.com/browserbase/stagehand),
+roughly 24.1k stars, a monorepo with TypeScript, Python and Go packages,
+built by Browserbase) gives you three primitives on a Playwright-style page
+object: `act()` executes an action described in natural language,
+`observe()` enumerates what is actionable on the page, and `extract()`
+returns structured data against a schema. The README's positioning sentence
+is the whole thesis: "Playwright was built for testing, Stagehand is built
+for agents." The property that matters most in practice is that the
+primitives are per-step: you can mix an AI-interpreted `act()` with plain
+deterministic `goto`, `click` and `locator` calls in the same script, and
+decide for every step how much model you want in the loop.
+
+**browser-use** ([browser-use/browser-use](https://github.com/browser-use/browser-use),
+roughly 112.2k stars, Python) is the most-starred project in the category,
+and you do not write steps at all. You construct an `Agent` with a task
+description and a model, call `run()`, and the loop - perceive the page,
+decide, act, retry - is the product. It supports its own hosted models as
+well as OpenAI, Anthropic and Google under your keys.
+
+## The axis that decides it: who owns the loop
+
+With an SDK, the agent loop is your code. Its memory, its retries, when it
+gives up, what it logs, how it recovers from a half-finished form - all
+yours. That costs you a design: nothing in Stagehand prevents you from
+building a bad agent, and the blank page is real. What it buys is
+embedding: agentic steps can go inside software you already have, an
+existing test suite can adopt `act()` for its three most brittle steps
+without adopting anything else, and every part you did not delegate to a
+model stays deterministic.
+
+With a framework, the loop arrives built and tuned, and you get a working
+automation the first afternoon. The cost is opinion: when the built-in loop
+does the wrong thing on your case, you are debugging someone else's control
+flow and working through a framework's extension points rather than editing
+your own.
+
+The honest rule of thumb: teams that already have software and want agency
+inside it lean Stagehand; teams whose deliverable is the automation itself
+lean browser-use.
+
+## Language ecosystems
+
+Stagehand's monorepo is TypeScript-first with official Python and Go
+packages. browser-use is Python, full stop. A TypeScript or Go shop
+therefore chooses Stagehand almost by default, and a Python-native data
+team will find browser-use the more natural fit - though the existence of
+Stagehand's Python package means the language argument alone no longer
+settles it in either direction.
+
+## Who runs the browser
+
+Both drive Chromium-family browsers, and both run locally by default.
+Stagehand's browser configuration documents a local environment that "runs
+browsers directly on your machine" with a custom Chrome path, a fixed CDP
+debugging port and user-data persistence; Firefox and WebKit appear nowhere
+in it. The docs are also candid about the vendor's preference:
+"Browserbase recommends running Stagehand on Browserbase. A hosted browser
+is what enables server-side caching and the Model Gateway."
+
+browser-use has the same shape with a different vendor: local by default,
+with the README pointing production users at Browser Use Cloud and
+describing it with features including what it calls built-in stealth, proxy
+rotation and CAPTCHA solving - vendor claims we did not test and quote as
+theirs.
+
+So the deciding question is not local-versus-cloud, since both offer both.
+It is which features sit behind each cloud door: with Stagehand, caching
+and the Model Gateway per its own docs; with browser-use, the
+harder-environment features per its own README. And either way, both open
+cores put a stock automation Chromium on the wire, and neither reaches the
+machine and network facts that decide most challenge outcomes - the
+groundwork is in [why an agent gets blocked](why-does-my-ai-agent-get-blocked.md)
+and the infrastructure angle in
+[cloud browser infrastructure for AI agents](cloud-browser-infrastructure-for-ai-agents.md).
+
+## Where each one breaks first
+
+Stagehand breaks first at the loop you have to write. Retries, memory
+across steps, stopping conditions: browser-use ships all of it, and with
+Stagehand you will reimplement some of it, well or badly. There is also
+vendor gravity to read clearly: the docs tie the platform's most
+interesting operational features to the hosted product, which is fair
+business but belongs in your plan.
+
+browser-use breaks first at the framework boundary. Embedding an
+autonomous loop inside an existing product is harder than embedding a
+function call, and disagreement with the loop's behavior sends you into
+framework internals. The counterweight is community scale: at roughly
+112.2k stars, the odds someone has already filed your exact issue are the
+best in the category.
+
+## How to choose
+
+If you have an existing codebase - a Playwright test suite, a product, a
+pipeline - and want to add agentic steps to it, take Stagehand. If you want
+a working automation today and Python is acceptable, take browser-use. If
+your constraint is TypeScript or Go, Stagehand is the only one of the two
+on offer. And if you are really choosing infrastructure for a fleet of
+agents rather than an API to write against, the browser and where it runs
+matter more than the SDK - start from
+[Browserbase alternatives](browserbase-alternatives.md) instead.
+
+## If you would rather not build an agent at all
+
+One labeled aside, and the disclosure from the top applies. Both subjects
+of this page assume you want to assemble or adopt an agent loop around a
+Chromium browser. If what you actually want is to hand browsing tasks to an
+assistant you already run, our own
+[AIHawk](https://github.com/feder-cr/AIHawk) (roughly 30k stars, MIT) is an
+agent that plugs into MCP assistants (Claude Code, Claude Desktop, Cursor)
+and differs from both at the browser layer, driving a Firefox patched at
+the C++ level rather than an automation-build Chromium. It is not an SDK,
+it does not compete with Stagehand as one, and it makes no promise of
+non-detection; if you are building, build with the two tools above. The
+labeled comparison against this page's bigger subject is
+[browser-use alternatives](browser-use-alternatives.md).
+
+## Short answers to the questions that lead here
+
+**Can I use Stagehand without Browserbase?** Yes. It is MIT licensed and
+its documented local environment runs Chrome or Chromium directly on your
+machine with your own model keys. Its docs add that server-side caching and
+the Model Gateway are enabled by the hosted browser, so plan on Browserbase
+if you want those two.
+
+**Is Stagehand a framework like browser-use?** No. It is an SDK: primitives
+to build an agent with, on a Playwright-style API. The loop is yours to
+write, which is the point.
+
+**Does browser-use support TypeScript?** The repository is Python. For a
+TypeScript-native equivalent you are in Stagehand territory or writing the
+loop yourself.
+
+**Do either of them support Firefox?** No. Both drive Chromium-family
+browsers; Stagehand's browser configuration documents Chrome and Chromium
+only.
+
+**Which is more popular?** browser-use by a wide margin - roughly 112.2k
+stars against 24.1k, read 2026-09-03. Within the SDK-shaped lane, Stagehand
+is the biggest thing there is.
+
+**Are they free?** Both cores are MIT. You pay your model provider for
+tokens either way, and both vendors run paid hosted products.
+
+**See also:** [Browserbase alternatives](browserbase-alternatives.md) for
+the hosted side of Stagehand's ecosystem,
+[browser-use alternatives](browser-use-alternatives.md) for the survey
+around this page's bigger subject,
+[Skyvern alternatives](skyvern-alternatives.md) for the workflow-shaped
+neighbor, and [Choosing an AI browser agent](best-ai-browser-agent.md) for
+the full decision framework.
+
+## Sources
+
+- The [Stagehand repository](https://github.com/browserbase/stagehand),
+  retrieved 2026-09-03: star count, license, languages, the three
+  primitives, and the positioning quote.
+- The [browser-use repository](https://github.com/browser-use/browser-use),
+  retrieved 2026-09-03: star count, license, the `Agent` API shape, model
+  providers, and the cloud description quoted attributively.
+- The [Stagehand documentation home](https://docs.stagehand.dev/), retrieved
+  2026-09-03: the "Browserbase recommends running Stagehand on Browserbase"
+  quote.
+- The [Stagehand browser configuration docs](https://docs.stagehand.dev/v3/configuration/browser),
+  retrieved 2026-09-03: the local environment, Chrome path and CDP port
+  options, and the absence of non-Chromium browsers.
+
+---
+
+*Written while maintaining [AIHawk](https://github.com/feder-cr/AIHawk),
+which competes with both tools compared here - reason enough to keep our
+own tool out of the verdict and every load-bearing claim quoted from the
+vendors' own material.*


### PR DESCRIPTION
## Summary

Five comparison pages the hub was missing, all in the agent-infrastructure space the owner flagged: the neutral cloud-browser-infrastructure explainer nobody had written (Browserbase, Steel, Hyperbrowser, Anchor, Kernel, Browserless, Airtop, Cloudflare, Lightpanda, BrowserStation - every vendor that names its engine runs Chromium, and the explainer says plainly when a local agent needs none of it), Browserbase alternatives split by what the searcher actually wants, Firecrawl vs an AI browser agent (conceding bulk content-to-LLM loudly), Skyvern alternatives organized around Skyvern's own README sentence about which half is open source, and a Stagehand-vs-browser-use referee page where this project appears in exactly one labeled aside.

Written under the fresh anti-penalty checklist: every vendor fact fetched from that vendor's own site or repo on 2026-09-03; one unverifiable claim dropped mid-write rather than shipped; three deliberately different page structures, because template sameness is the one production pattern the scaled-content policy actually punishes. COI disclosure tops every page.

Also folds agent-browser (Apache-2.0, 41.9k stars - the largest omission) and Notte into the open-source landscape page, and notes browser-use's own move into selling infrastructure where alternatives are weighed.

Loud skips, recorded so nobody re-derives them: Kernel (zero query volume, un-SEO-able name), a dedicated Browserless page (their own blog owns those SERPs end to end), Stagehand-vs-AIHawk (SDK vs finished product - a dishonest comparison).

## Test plan

- [x] English-only gate clean (full tree)
- [x] Zero em/en-dashes, pure ASCII
- [x] All internal links resolve; build_wiki renders all 43 pages + sidebar, no collisions
- [x] Forbidden-names scanner clean
- [x] Every vendor claim traced to a same-day fetch of that vendor's own page

Generated with Claude Code
