### PR TITLE
Drop the keyless-placeholder line from the choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,6 @@ uvx aihawk ui --openrouter-key sk-or-...
 
 Then open **http://127.0.0.1:8765** and type the same thing.
 
-No key yet? `uvx aihawk ui` starts anyway on a placeholder that takes literal
-commands, which is enough to see the interface work.
-
 **Same patched Firefox behind both.** AIHawk reaches it through that MCP server,
 over MCP, exactly as your assistant would.
 


### PR DESCRIPTION
It sat in the middle of option 2, between the command and the URL a reader is about to open, and answered a question nobody has yet: it offers a way to run the thing without the key the same paragraph has just asked for. The two sentences around it read straight through now.

README only.