### PR TITLE
Posting to social media, with the API named first and one honest cannot

### DIFF
--- a/docs/ai-agent-post-to-x.md
+++ b/docs/ai-agent-post-to-x.md
@@ -1,0 +1,181 @@
+---
+title: "Posting to X with an AI agent"
+description: "X has a real write API at pay-per-usage prices and a dedicated automation policy; this page does the arithmetic honestly and locates the narrow case where a browser agent still makes sense."
+parent: "Using the Agent"
+nav_order: 19
+---
+
+
+# Posting to X with an AI agent
+
+X is the platform where the API-versus-agent question is genuinely close,
+so this page does the arithmetic instead of picking a side first. X has a
+real, working write API; it costs money per request; and X publishes a
+dedicated automation policy that governs whichever route you take. All
+three facts were checked on 2026-09-03, and the honest conclusion is at the
+end rather than assumed at the start.
+
+Scope, as on every page in this set: your own posts, your own account, one
+at a time, with you in the loop. Not engagement automation - no automated
+likes, reposts, replies or follows - not mass posting, not multiple
+accounts. X's spam enforcement is aimed at exactly that cluster, and its
+automation policy addresses it directly.
+
+## The write API, and what it costs now
+
+Creating a post through the X API v2 is one endpoint:
+
+```
+POST /2/tweets
+```
+
+authenticated with an OAuth 2.0 user token carrying the `tweet.write`
+scope. The documented rate limits are far above human posting: 100 requests
+per 15 minutes per user, 10,000 per 24 hours per app.
+
+The part that changed and that older articles get wrong: X API pricing is
+now pay-per-usage, no subscription tiers. Per X's own pricing page, a
+standard post costs $0.015 per request, and a post containing a URL costs
+$0.200 per request. There is no free allowance; every call is charged.
+
+Do the math for the register this page assumes. A person posting three
+times a day, every day, spends about $1.35 a month at the standard rate,
+or around $18 a month if every post carries a link. That is not free the
+way Mastodon's or Bluesky's APIs are free, but for text posts it is coffee
+money, and it buys the supported channel: documented behavior, no
+interface drift, no session to keep alive. If you can hold your nose
+through the developer-portal setup, the API is the robust answer for
+anything programmatic, and this wiki says so even though it maintains a
+browser agent.
+
+The URL price is the one honest wrinkle. At $0.200 per link post, a
+link-heavy posting habit costs real money through the API - more than
+thirteen times the standard rate - and that asymmetry is presumably not an
+accident. It
+is also the one place where the economics stop being negligible and the
+browser route earns a look.
+
+## The automation policy you are bound by either way
+
+X maintains a dedicated automation rules page:
+[help.x.com/en/rules-and-policies/x-automation](https://help.x.com/en/rules-and-policies/x-automation).
+That page returns a 403 to plain fetchers - it did to this wiki's checks
+this session - so nothing from it is quoted here, because quoting a page
+you could not read is how documentation rots. It exists, it is X's
+governing document on automated behavior, and you should read it in a
+browser before automating anything on X, through the API or otherwise.
+
+The risk statement, plainly: X suspends and restricts accounts for
+automated behavior it classifies as spam or platform manipulation, and an
+account driven through the web interface by an agent is automated behavior
+in the ordinary sense of the words, whatever the volume. Single posts of
+your own content with human review is the defensible end of the spectrum;
+it is not a guarantee. The account is yours and so is the risk. If the
+account matters commercially, the API route also has the advantage of
+being the channel X itself sells for this purpose.
+
+## Where the browser agent honestly fits
+
+Given a working API at these prices, the agent's slot on X is narrow, and
+it is not "saving money" for most people. It is three specific situations:
+
+- **No developer setup, ever.** The API route means a developer account, an
+  app, OAuth tokens and a credit card on file at the portal. For someone
+  who posts occasionally and will not do that setup, an agent driving
+  their existing logged-in session is the only automation they will
+  actually use.
+- **Mixed sessions.** An agent can read your timeline context, draft a
+  reply-shaped post about something it just looked up on the web, show
+  you, and post after your approval - one conversational loop in one
+  browser. The API splits that across tools; the agent keeps it in one
+  place with you watching. The drafting half of that loop is
+  [web research](ai-agent-web-research.md), which the agent does anyway.
+- **Link-heavy, low-volume posting**, where the $0.200 per-request price
+  makes the API cost visible and the browser costs what your model tokens
+  cost.
+
+The mechanics mirror the other platforms. Keep the session with
+`--profile-dir` and log in yourself once; ask for the post to be typed and
+for the agent to stop before the Post button; read it; click it yourself.
+AIHawk types through real input events rather than script injection, the
+composer is an ordinary rich-text widget by
+[the forms page's](ai-agent-fill-out-forms.md) standards, and the
+human-review rule is the README's own: nothing submits that a person has
+not read. Media carries the same boundary as everywhere: the toolset has no
+file-upload action, so an image post needs your hands for the attachment
+in a headed session; text and link posts are fully within reach.
+
+```bash
+uvx aihawk ui --profile-dir ~/.aihawk-x
+```
+
+> Go to x.com. Open the composer, type exactly this post, and stop without
+> clicking Post. Tell me when it is ready for review: "New write-up on the
+> wiki: how the three posting routes actually compare."
+
+## The honest conclusion
+
+For programmatic posting on X, use the API: it works, its per-post price
+is small for text, and it is the channel built for the purpose. The browser
+agent is for the person who will never open the developer portal, for
+sessions where reading and posting mix, and for the occasional link post
+priced oddly by the API - always at human frequency, always with the final
+click human. If your plan involves volume on either route, X's automation
+policy is the document standing in your way, and no tool changes that.
+
+## Short answers to the questions that lead here
+
+**Can an AI agent post to X (Twitter) for me?** Yes - it drives your own
+logged-in session, types the post and leaves the final click to you. But
+check the API first: `POST /2/tweets` at $0.015 per standard post is the
+supported route, and for anything programmatic it is the better one.
+
+**How much does the X API cost for posting?** Pay-per-usage, per X's
+pricing page fetched 2026-09-03: $0.015 per standard post, $0.200 per post
+containing a URL, no subscriptions and no free allowance. Per-user rate
+limit on the endpoint: 100 requests per 15 minutes.
+
+**Is automating posts against X's rules?** X publishes dedicated
+automation rules at help.x.com (linked above; it blocks plain fetchers, so
+read it in a browser). Automated engagement and spam are the enforced
+core; posting your own content at human frequency with review is the
+defensible end. Account risk exists on every route and it is yours.
+
+**Can the agent post with an image?** Not unattended - the toolset has no
+file-upload action. Text and link posts work; attach media yourself in a
+headed session, or use the API, which has proper media upload endpoints.
+
+**Should I use the agent to save on API costs?** Mostly no. At $0.015 a
+post, three posts a day costs under two dollars a month through the API,
+less than the model tokens the agent would spend. The exception worth
+naming is link-heavy low-volume posting at the $0.200 URL price.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [X API: creation of a post](https://docs.x.com/x-api/posts/creation-of-a-post),
+  for `POST /2/tweets`, the `tweet.write` scope and media constraints.
+- [X API: rate limits](https://docs.x.com/x-api/fundamentals/rate-limits),
+  for the 100 per 15 minutes per user and 10,000 per 24 hours per app
+  figures.
+- [X API: pricing](https://docs.x.com/x-api/getting-started/pricing), for
+  the pay-per-usage model and the per-request prices quoted above.
+- [X automation rules](https://help.x.com/en/rules-and-policies/x-automation),
+  cited by reference; it returned 403 to plain fetches this session, so no
+  text from it is quoted.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README
+  and source in this repository, for `--profile-dir`, real input events,
+  the absence of a file-upload tool, and the human-review rule.
+
+**See also:** [the social posting decision page](posting-to-social-media-with-an-ai-agent.md),
+[posting to Facebook](post-to-facebook-with-an-ai-agent.md),
+[posting to Instagram](post-to-instagram-with-an-ai-agent.md),
+[AI agents for web research](ai-agent-web-research.md), and the rest of
+[Using the Agent](guides-using-the-agent.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The page that
+tells you to pay X fifteen cents a day instead of running our agent is the
+page you can trust about the cases where the agent is the right call.*

--- a/docs/guides-using-the-agent.md
+++ b/docs/guides-using-the-agent.md
@@ -27,3 +27,7 @@ and what to expect before you spend model tokens finding out.
 - [AI agents for web research](ai-agent-web-research.md)
 - [Using an AI agent to test your own website](ai-agent-to-test-website.md)
 - [Running AIHawk's browser from Cline](running-aihawk-with-cline.md)
+- [Posting to social media with an AI agent](posting-to-social-media-with-an-ai-agent.md)
+- [Posting to Facebook with an AI agent](post-to-facebook-with-an-ai-agent.md)
+- [Posting to Instagram with an AI agent](post-to-instagram-with-an-ai-agent.md)
+- [Posting to X with an AI agent](ai-agent-post-to-x.md)

--- a/docs/post-to-facebook-with-an-ai-agent.md
+++ b/docs/post-to-facebook-with-an-ai-agent.md
@@ -1,0 +1,199 @@
+---
+title: "Posting to Facebook with an AI agent"
+description: "For a Facebook Page the Graph API is the right tool and this page proves it; for a personal profile no posting API exists, and that is the narrow slot where a browser agent honestly fits."
+parent: "Using the Agent"
+nav_order: 17
+---
+
+
+# Posting to Facebook with an AI agent
+
+Whether an AI agent should post to Facebook for you depends on one question
+with a verifiable answer: are you posting as a Page or as a personal profile?
+The two surfaces have opposite answers, both checked against Meta's own
+documentation on 2026-09-03, and this page takes them in that order: the API
+case first because it is the right tool where it applies, then the profile
+case where the agent has its one honest slot, then the walkthrough and the
+terms-of-service reality you accept by doing any of it.
+
+Scope, before anything else: this is about publishing your own posts to your
+own Page or your own profile, one at a time, with you reading them before
+they go out. It is not about posting into groups at volume, not about
+engagement automation of any kind - likes, follows, comments at scale - not
+about mass posting, and not about running more than one account. Meta's
+enforcement is aimed squarely at that cluster, and no tool choice makes it a
+good idea.
+
+## Posting as a Page: the Graph API is the right tool
+
+If you manage a Facebook Page, stop here and use the API. Publishing is one
+documented call:
+
+```
+POST /page_id/feed
+```
+
+with a `message` (and optionally a `link`), authenticated by a Page access
+token, requiring the `pages_manage_posts` and `pages_manage_engagement`
+permissions alongside the read permissions. Scheduling is native: send
+`published=false` plus a `scheduled_publish_time`, and Meta's documentation
+states the publish date "must be between 10 minutes and 30 days from the time
+of the API request". That is a supported, stable, terms-compliant channel
+with scheduling built in, and an agent clicking through the Page composer
+would be a slower, costlier, more fragile way to do the same thing.
+
+The secondary question people arrive with - how to automate Facebook posts
+from Python - has the same answer for Pages: a few lines against the Graph
+API, no browser anywhere.
+
+```python
+import requests
+
+requests.post(
+    "https://graph.facebook.com/PAGE_ID/feed",
+    data={"message": "Release notes are up.", "access_token": PAGE_TOKEN},
+)
+```
+
+Setting up the token takes a developer account and an app; that one-time cost
+is the whole price of doing this the supported way.
+
+## The personal profile: where no API exists
+
+Personal profiles are the opposite case, and it is not a gap in your reading:
+there is no API for publishing to a personal timeline. The Graph API
+reference for the User/feed edge marks the create operation as unavailable:
+the edge is for reading, and no permission exists that would change that.
+Every third-party tool that claims to post to profiles is driving the web
+interface, whatever its landing page implies.
+
+So the honest options for a profile are exactly two: post by hand, or have
+something operate the same web interface you would - which is what a browser
+agent is. That makes the profile the agent's slot by elimination, and it
+also means the terms question cannot be skipped, because the web interface
+is governed by Meta's Terms of Service and the automated path through it is
+precisely what those terms address.
+
+## What Meta's terms say, and the risk you carry
+
+Quoted from Meta's Terms of Service, section 3.2 ("What you can share and do
+on Meta Products"), fetched 2026-09-03:
+
+> "You may not access or collect data from our Products using automated means
+> (without our prior permission) or attempt to access data you do not have
+> permission to access, regardless of whether such automated access or
+> collection is undertaken while logged-in to a Facebook account."
+
+The clause is written around data collection, and posting your own content is
+not collecting data - but do not read that as a safe harbor. The terms give
+Meta broad discretion over automated interaction with its products, and
+Meta's enforcement systems do not adjudicate intent: an account behaving
+automatically can be checkpointed, asked to verify, restricted or disabled,
+and appeals for personal accounts are slow and uncertain. Plainly: if you
+point an agent at your own profile, you accept a real, non-zero risk to that
+account. Occasional single posts with a human reviewing each one is the
+lowest-risk end of the spectrum; anything resembling volume is the highest.
+This wiki's position is to state that trade honestly and leave the decision
+with the account's owner, who is the only person entitled to make it.
+
+## The walkthrough, as it actually goes
+
+What a session looks like with AIHawk, and what to expect from each step:
+
+**Login persists; do it yourself, once.** Start with a profile directory so
+the session survives restarts - the README describes `--profile-dir` as a
+directory that keeps logins and cookies across runs:
+
+```bash
+uvx aihawk ui --profile-dir ~/.aihawk-facebook
+```
+
+Log in by hand in that first session. A login page is where a site's
+defenses concentrate, and your password does not belong in a prompt anyway.
+Every later session finds the cookies in place and starts logged in.
+
+**Tell it the post, tell it to stop.** The instruction that works is
+explicit about both the content and the boundary:
+
+> Go to facebook.com. Open the composer ("What's on your mind?"), type
+> exactly this post, and stop. Do not click Post. Tell me when the text is
+> in place: "Shipped the new release this morning. Changelog in the
+> comments."
+
+The composer is a custom widget of the kind
+[the forms page](ai-agent-fill-out-forms.md) documents: expect a click to
+open it, a pause, then typing through real key events - AIHawk refuses to
+inject text by script, because pages can tell the difference. Then you read
+the draft in the browser and the final click is yours. That division is not
+caution theater; it is the README's own rule for the whole tool: do not
+submit anything a human has not read.
+
+**Know the media boundary.** AIHawk's toolset has no file-upload action, so
+the agent cannot attach a photo: text posts and link posts are within its
+reach, and a photo post needs your hands for the attachment step (run with
+`--headed` and the browser is a normal window you can click in). Link
+previews generate on their own once the URL is typed, so link posts work
+fine.
+
+**If something fails, read before rerunning.** A composer that never opens,
+or a session that lands on a checkpoint page, is not a prompt problem - see
+[why agents get blocked](why-does-my-ai-agent-get-blocked.md) before
+spending more tokens. And resist retry loops: repeated identical attempts
+are themselves a signal, covered in
+[retry loops and rate limits](agent-retry-loops-rate-limits.md).
+
+## Short answers to the questions that lead here
+
+**Can an AI agent post to Facebook for me?** To a Page, yes, but the Graph
+API is the better tool and this page shows the call. To a personal profile,
+a browser agent is the only kind of automation that can, because no posting
+API exists for profiles; do it with your own session, one post at a time,
+reviewing before the click, and accepting the account risk stated above.
+
+**How do I automate Facebook posts with Python?** For a Page:
+`POST /page_id/feed` via the Graph API with a Page access token and the
+`pages_manage_posts` permission; scheduling is native. For a profile there
+is no API to call from Python or anything else; the web interface is the
+only surface.
+
+**Is it against Facebook's terms?** Meta's terms restrict automated access -
+section 3.2 is quoted above - and give Meta wide enforcement discretion.
+Your own content on your own account with human review is the defensible
+end; volume, groups, engagement automation and multiple accounts are the
+prohibited end. The risk to the account is real in all cases and it is
+yours.
+
+**Can it post with an image?** Not unattended: the toolset has no
+file-upload action. Have the agent handle the text and do the attachment
+yourself in a headed session, or use the Page API, which takes media
+properly.
+
+**Can it post to groups?** This page does not cover posting to groups, and
+at volume that is exactly the pattern this wiki's scope rules out. If you
+have one group you genuinely participate in, post there yourself.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [Meta Terms of Service](https://www.facebook.com/legal/terms), section 3.2,
+  quoted verbatim above.
+- [Facebook Pages API: posts](https://developers.facebook.com/docs/pages-api/posts/),
+  for the endpoint, permissions and the scheduling window.
+- [Graph API reference: User/feed](https://developers.facebook.com/docs/graph-api/reference/user/feed/),
+  for the create operation being unavailable on the personal-profile edge.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README and
+  source in this repository, for `--profile-dir`, the real-input-events
+  behavior, the absence of a file-upload tool, and the human-review rule.
+
+**See also:** [the social posting decision page](posting-to-social-media-with-an-ai-agent.md),
+[posting to Instagram](post-to-instagram-with-an-ai-agent.md),
+[posting to X](ai-agent-post-to-x.md),
+[getting an AI agent to fill out forms](ai-agent-fill-out-forms.md), and the
+rest of [Using the Agent](guides-using-the-agent.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The rule about
+keeping the final click human is not legal decoration; it is how the
+maintainer uses the agent on accounts that matter to him.*

--- a/docs/post-to-instagram-with-an-ai-agent.md
+++ b/docs/post-to-instagram-with-an-ai-agent.md
@@ -1,0 +1,166 @@
+---
+title: "Posting to Instagram with an AI agent"
+description: "The official publishing API covers professional accounts and is the right tool there; for everyone else this page says the uncomfortable part out loud: an Instagram post needs media, and the agent cannot upload a file."
+parent: "Using the Agent"
+nav_order: 18
+---
+
+
+# Posting to Instagram with an AI agent
+
+Instagram is the platform where this wiki's honesty costs it the most, so
+here is the summary up front. If you have a professional account, an official
+publishing API exists and is the right tool. If you have a personal account,
+no API exists - and the browser route has a hard limit that most pages on
+this subject quietly skip: an Instagram post requires media, attaching media
+in a browser means a file picker, and AIHawk's agent has no file-upload tool.
+Verified against the source, not the marketing, on 2026-09-03. What remains
+is a narrower, honest slot, described below without inflation.
+
+The register first, and on Instagram it matters more than anywhere: this
+page is about publishing your own posts to your own account, with you
+reviewing each one. It is not about growth - no automated likes, follows or
+comments, no volume, no multiple accounts. Instagram's enforcement history
+against engagement automation is long and public, and nothing here is a tool
+for it.
+
+## The official API: professional accounts, two calls, real limits
+
+Meta documents content publishing for Instagram professional accounts
+(business and creator), and it works in two steps: create a media container,
+then publish it.
+
+```
+POST /<IG_ID>/media           (the container: image URL, caption)
+POST /<IG_ID>/media_publish   (publishes the container)
+```
+
+The limits are stated plainly in the documentation and worth quoting,
+because they define what "supported automation" means here: "Instagram
+accounts are limited to 100 API-published posts within a 24-hour moving
+period. Carousels count as a single post." Images must be JPEG, the media
+must sit at a publicly accessible URL at publish time, and an unpublished
+container expires after 24 hours.
+
+If you have a professional account, or your use of Instagram would justify
+switching to one, this is the answer. One hundred posts a day
+is two orders of magnitude beyond any human posting schedule, the calls are
+documented and stable, and every scheduler product supports Instagram
+through exactly this door. There is no honest reason to point a browser
+agent at instagram.com when this API covers you.
+
+## Personal accounts, and the limit this page exists to state
+
+A personal Instagram account is outside the publishing API. That leaves the
+web interface, and the web interface is where the claim you came to verify
+falls apart, so here it is with its evidence.
+
+Posting on instagram.com starts with a file: the create flow's first real
+step is "select from computer", an OS file picker. AIHawk's agent operates
+the browser through a fixed set of tools - navigate, read, click, type,
+screenshot, and their session-management siblings - and that set contains no
+file-upload action. This is checked against the tool server's source, not
+inferred from a failed attempt. The agent can log in with your saved
+session, open the create dialog and write a caption, but it cannot hand a
+file to the picker. Since a feed post cannot exist without media, **AIHawk
+cannot post to Instagram end to end, and this page will not pretend
+otherwise.**
+
+What works instead is a division of labor that is honest about who does
+what. Run headed, so the browser is a normal window on your desktop:
+
+```bash
+uvx aihawk ui --profile-dir ~/.aihawk-instagram --headed
+```
+
+Log in yourself once; the profile directory keeps the session for later
+runs. When you want to post, you click through the media selection - the
+one step that needs hands - and the agent is useful on either side of it:
+navigating to the right place, typing a caption you dictated, reading back
+what the review screen shows before you press Share. Whether that division
+is worth a running agent for your posting volume is a fair question, and
+for many people the answer is "post it by hand, it is faster". A tool page
+that cannot say that sentence is selling something.
+
+The final click stays yours either way. AIHawk's stated rule for every
+surface applies verbatim here: do not submit anything a human has not read.
+
+## The terms, and the account you are risking
+
+Instagram is a Meta product, and Meta's Terms of Service, section 3.2,
+fetched 2026-09-03, reads:
+
+> "You may not access or collect data from our Products using automated means
+> (without our prior permission) or attempt to access data you do not have
+> permission to access, regardless of whether such automated access or
+> collection is undertaken while logged-in to a Facebook account."
+
+Instagram additionally maintains its own
+[Terms of Use](https://help.instagram.com/581066165581870); that page is
+rendered by script and could not be read by a plain fetch this session, so
+it is cited here by name rather than quoted - read it in a browser before
+deciding, because it binds you either way.
+
+The risk statement, plainly: automated behavior on an Instagram account can
+trigger action against the account - challenges, feature blocks,
+restriction, or loss of the account - and Instagram has enforced against
+automation more visibly than almost any platform. A personal account driven
+by an agent, even gently, carries that risk, and the account is yours, not
+the tool's. The lowest-risk shape is the one this page describes: your
+session, your media click, your review, single posts at human frequency.
+
+## Short answers to the questions that lead here
+
+**Can an AI agent post to Instagram for me?** With a professional account,
+use the official API instead: two documented calls, 100 API-published posts
+per 24 hours, JPEG media at a public URL. With a personal account there is
+no API, and AIHawk specifically cannot complete a browser post alone,
+because posting requires media and its toolset has no file-upload action.
+
+**Can AIHawk upload an image to Instagram?** No. The agent's tool
+vocabulary has no file-upload action, so it cannot operate the file picker
+that Instagram's create flow starts with. It can handle navigation and the
+caption around a media selection you make yourself in a headed session.
+
+**Is there an Instagram posting API for personal accounts?** No. The
+content-publishing API covers Instagram professional accounts - business
+and creator. Switching to a creator account is the supported path if you
+want API publishing.
+
+**Is automating Instagram against the terms?** Meta's terms restrict
+automated access without prior permission - section 3.2 is quoted above -
+and Instagram's own Terms of Use apply on top. Engagement automation is the
+clearly-enforced end; your own single posts with human review is the
+defensible end; the account risk in between is real and yours.
+
+**What about scheduling posts?** Schedulers support Instagram through the
+professional-account API, which is why they all ask you to connect a
+professional account. Scheduling for a personal account does not exist
+through any supported channel, whatever a landing page implies.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [Instagram platform: content publishing](https://developers.facebook.com/docs/instagram-platform/content-publishing),
+  for the endpoints, the professional-account requirement, and the
+  100-posts-per-24-hours quote.
+- [Meta Terms of Service](https://www.facebook.com/legal/terms), section
+  3.2, quoted verbatim above.
+- [Instagram Terms of Use](https://help.instagram.com/581066165581870),
+  cited by reference; not readable by plain fetch this session, as noted.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its source and
+  the tool server's source in this repository's family, for the exact tool
+  vocabulary and the absence of a file-upload action.
+
+**See also:** [the social posting decision page](posting-to-social-media-with-an-ai-agent.md),
+[posting to Facebook](post-to-facebook-with-an-ai-agent.md),
+[posting to X](ai-agent-post-to-x.md),
+[getting an AI agent to fill out forms](ai-agent-fill-out-forms.md), and the
+rest of [Using the Agent](guides-using-the-agent.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The paragraph
+admitting the agent cannot finish this task is the most useful one on the
+page, which is exactly why it is here.*

--- a/docs/posting-to-social-media-with-an-ai-agent.md
+++ b/docs/posting-to-social-media-with-an-ai-agent.md
@@ -1,0 +1,198 @@
+---
+title: "Posting to social media with an AI agent"
+description: "Three honest routes for getting your own posts onto social platforms - official APIs, schedulers, and an AI web agent - with the verified API facts that decide which route you actually need."
+parent: "Using the Agent"
+nav_order: 16
+---
+
+
+# Posting to social media with an AI agent
+
+You wrote something and you want it on your own social accounts without opening
+five tabs and pasting five times. Three genuinely different routes exist:
+official platform APIs, scheduler tools, and an AI agent driving a real
+browser. This page is the decision between them, made with the API facts
+verified rather than assumed, and it will send you away from the agent more
+often than a page in an agent's wiki is supposed to. The per-platform
+mechanics live on the sibling pages for
+[Facebook](post-to-facebook-with-an-ai-agent.md),
+[Instagram](post-to-instagram-with-an-ai-agent.md) and
+[X](ai-agent-post-to-x.md).
+
+First, the boundary, because it decides everything downstream: this page is
+about publishing your own content to your own account, with you in the loop.
+It is not about engagement automation - likes, follows or comments at scale -
+not about mass posting, not about running multiple accounts, and not about
+blasting the same thing into groups at volume. That is the behavior platforms
+actively hunt, it is what their terms prohibit most explicitly, and it is the
+fastest known way to lose an account. Nothing below applies to it.
+
+## Route one: the official API, which wins more often than you expect
+
+Where a platform gives you a supported way to publish, that is the right tool:
+free or cheap, documented, stable, and inside the terms instead of adjacent to
+them. The facts below were checked against each platform's own documentation
+on 2026-09-03.
+
+| Platform | Posting API | The fact that decides it |
+|---|---|---|
+| Threads | Yes, official | `POST /{threads-user-id}/threads_publish`, capped at 250 API-published posts per 24 hours |
+| Bluesky | Yes, fully open | `com.atproto.repo.createRecord` on the AT Protocol, an `app.bsky.feed.post` record, your own account credentials |
+| Mastodon | Yes, official | `POST /api/v1/statuses`, with a `scheduled_at` parameter, so scheduling is native |
+| Facebook Page | Yes | `POST /page_id/feed` with the Pages permissions; native scheduling too |
+| Facebook personal profile | No | the user feed edge does not accept creation |
+| Instagram professional account | Yes | media container plus `media_publish`, 100 API-published posts per 24 hours |
+| Instagram personal account | No | the publishing API covers professional accounts |
+| X | Yes | `POST /2/tweets`, pay-per-usage pricing, $0.015 per standard post |
+
+Read the first three rows again, because they are the ones this page exists to
+say plainly. Threads has an official publishing API with a quota - 250
+API-published posts in a 24-hour window - that no human posting schedule will
+ever touch. Bluesky is built on an open protocol: creating a post is
+`com.atproto.repo.createRecord`, which its own lexicon describes as "Create a
+single new repository record. Requires auth, implemented by PDS", and nothing
+stands between you and it except your own credentials. Mastodon's
+`POST /api/v1/statuses` even takes `scheduled_at`, which its documentation
+says "Must be at least 5 minutes in the future" - scheduling built into the
+platform itself. For all three, "use the API" is the complete, honest answer.
+An AI agent clicking through their web interfaces to post would be paying
+model tokens to do badly what one HTTP request does well.
+
+The API route has one real cost: a small amount of one-time setup - creating
+an app or token, reading a quickstart - and on some platforms an account-type
+or money gate. Facebook's API publishes to Pages, not personal profiles.
+Instagram's publishes for professional accounts only. X charges per request.
+Those gates are exactly where the other two routes begin.
+
+## Route two: schedulers, which solve a calendar problem
+
+If your actual problem is "this post, on these three accounts, at 9am
+Tuesday, every week", the tool category built for it is the scheduler:
+Buffer-class SaaS products with a content calendar, previews per platform, a
+drafts queue, team approvals and retry handling. They do that work well, and
+they do it through the same official APIs from route one, which means they
+inherit both the APIs' legitimacy and their gates - a scheduler cannot post
+to a Facebook personal profile either, because there is no API for anyone to
+use.
+
+The category has an open-source end worth knowing about:
+[Postiz](https://github.com/gitroomhq/postiz-app), AGPL-3.0, self-hostable,
+describing itself as "An alternative to: Buffer.com, Hypefury, Twitter
+Hunter, etc..." and sitting at roughly 35 thousand GitHub stars as of this
+writing. If you want scheduling without a SaaS subscription, that is the
+shape of thing to evaluate.
+
+To be clear about what this wiki's own tool is not: AIHawk is not a
+scheduler. It has no calendar, no queue, no per-platform account connections
+and no analytics. If the previous paragraph described your problem, close
+this tab and go set one up. Conflict of interest declared once for the whole
+page: you are reading the wiki of one of the tools being compared, which is
+why the comparison spends most of its words recommending the other routes.
+
+## Route three: an AI web agent, and the slot it honestly fills
+
+An agent like AIHawk drives a real browser through your own logged-in
+session, doing what you would do by hand: open the site, click the composer,
+type the post, and - if you follow the rule this wiki repeats everywhere -
+stop before submitting so you can read what is about to go out. That
+architecture gives it exactly two honest advantages:
+
+- **It works where no API does.** A Facebook personal profile has no posting
+  API; the web interface is the only door, and a browser agent is the only
+  kind of automation that can walk through it. Same for any surface a
+  platform never exposed programmatically.
+- **A person stays in the loop by construction.** The browser is visible, the
+  session is yours, and the submit click can be yours too. For occasional
+  posting where you want to read before publishing - the register this whole
+  page assumes - that is a feature, not a limitation.
+
+And the honest costs, stated with the same bluntness: an agent spends model
+tokens and minutes where an API spends a fraction of a cent and milliseconds.
+Web composers are exactly the custom widgets
+[the forms page](ai-agent-fill-out-forms.md) warns about. Media is a hard
+boundary today: AIHawk's toolset has no file-upload action, so a post that
+needs a photo or video attached needs your hands for that step - the
+platform pages spell out what that means per site. And an agent posting at
+volume is indistinguishable from the behavior platforms ban, which is why
+volume is out of scope here in the first place.
+
+## Choosing, in four questions
+
+1. **Does an official API cover your platform and account type?** Then use
+   it, directly or through a scheduler. Threads, Bluesky, Mastodon: always
+   yes. Facebook Pages, Instagram professional, X: yes with gates.
+2. **Is the task calendar-shaped and recurring?** Scheduler, on top of those
+   APIs. Open-source options exist if SaaS is the objection.
+3. **Is it a personal profile, posted occasionally, with you reading before
+   it ships?** That is the agent's slot. The platform pages walk it:
+   [Facebook](post-to-facebook-with-an-ai-agent.md),
+   [Instagram](post-to-instagram-with-an-ai-agent.md),
+   [X](ai-agent-post-to-x.md).
+4. **Is it any form of scale - accounts, volume, engagement?** Then it is
+   outside this page, outside this tool, and inside every platform's
+   enforcement priorities.
+
+## Short answers to the questions that lead here
+
+**Can an AI agent post to social media for me?** Yes, by driving the web
+interface of your own logged-in account, and it is the right tool only where
+no API exists or where you want to review each post before it goes out.
+Where an official API covers your case - Threads, Bluesky, Mastodon, Facebook
+Pages, Instagram professional accounts, X - the API is the better answer.
+
+**What is the best way to automate my own posts?** In order: the platform's
+official API if it covers your account type; a scheduler on top of those APIs
+if the problem is recurring and calendar-shaped; a browser agent only for the
+surfaces APIs do not reach, with a human reviewing each post.
+
+**Is using an AI agent to post against platform rules?** Platform terms
+restrict automated access in different ways - Meta's terms require prior
+permission for automated data collection, X publishes dedicated automation
+rules - and the platform pages linked above quote the relevant text per site.
+The register matters: your own content on your own account with human review
+is the defensible end of the spectrum; scaled engagement automation is the
+banned end. Account risk is yours either way, and the pages say so plainly.
+
+**Can the agent attach images to posts?** Not by itself today: AIHawk's tool
+vocabulary has no file-upload action. Text and link posts are within reach;
+media posts need your hands for the file-picker step. The Instagram page
+covers the hardest version of this, since Instagram posts require media.
+
+**Is AIHawk a Buffer alternative?** No. AIHawk is a browser agent, not a
+scheduler: no calendar, no queue, no account connections. If you want an
+open-source Buffer-class tool, Postiz is that category; AIHawk is for tasks
+that need a real browser and a person in the loop.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [Threads API overview](https://developers.facebook.com/docs/threads/overview),
+  for the `threads_publish` endpoint and the 250 posts per 24 hours cap.
+- [AT Protocol lexicon: com.atproto.repo.createRecord](https://github.com/bluesky-social/atproto/blob/main/lexicons/com/atproto/repo/createRecord.json),
+  for the procedure name and description quoted above.
+- [Mastodon API: statuses](https://docs.joinmastodon.org/methods/statuses/),
+  for `POST /api/v1/statuses` and the `scheduled_at` parameter.
+- [Facebook Pages API: posts](https://developers.facebook.com/docs/pages-api/posts/)
+  and the [Graph API User/feed reference](https://developers.facebook.com/docs/graph-api/reference/user/feed/),
+  for Page publishing and for the personal-profile edge not accepting creation.
+- [Instagram platform: content publishing](https://developers.facebook.com/docs/instagram-platform/content-publishing),
+  for the professional-account endpoints and the 100 posts per 24 hours limit.
+- [X API: creation of a post](https://docs.x.com/x-api/posts/creation-of-a-post)
+  and [X API pricing](https://docs.x.com/x-api/getting-started/pricing), for
+  `POST /2/tweets` and the pay-per-usage rates.
+- [Postiz on GitHub](https://github.com/gitroomhq/postiz-app), for the
+  open-source scheduler facts and self-description.
+
+**See also:** [posting to Facebook](post-to-facebook-with-an-ai-agent.md),
+[posting to Instagram](post-to-instagram-with-an-ai-agent.md),
+[posting to X](ai-agent-post-to-x.md),
+[getting an AI agent to fill out forms](ai-agent-fill-out-forms.md), and the
+rest of [Using the Agent](guides-using-the-agent.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The maintainer
+posts release announcements through the platforms' own tools and reads
+everything before it ships; the agent earns its keep on the surfaces that
+never got an API.*


### PR DESCRIPTION
## Summary

Four pages open the social-posting vertical, and every one puts the official route before the agent - that ordering is the register.

The umbrella decision page (agent vs scheduler vs official API) says plainly that Threads, Bluesky and Mastodon have APIs good enough that an agent adds nothing there. The Facebook page teaches the Pages Graph API (endpoint and permissions verified live) before describing the one surface without an API - a personal profile - and quotes Meta's terms from the English canonical. The X page does the arithmetic on the current pay-per-use API pricing and concludes the API wins for most posting. The Instagram page carries the most honest line of the batch, read out of the source rather than assumed: the agent's MCP tool vocabulary has no file-upload action and Instagram posts require media, so AIHawk cannot post there end to end - the page says exactly that.

The two pages that could not be fetched (X's automation rules behind a 403, Instagram's ToU behind JS) are cited by name and URL with an explicit note that nothing from them is quoted. The scope line rides every page: your own content, your own account, never engagement automation, never mass posting, never groups at volume. LinkedIn is deliberately absent from this wave.

Skips recorded from the demand verification so nobody re-derives them: Reddit (near-zero demand, engagement-automation register), TikTok (content-farm register owns the SERP), YouTube community posts (no API exists, near-zero demand), Threads/Bluesky/Mastodon standalone pages (the API is the whole answer - folded into the umbrella).

## Test plan

- [x] English-only gate clean; zero em/en-dashes, pure ASCII
- [x] All internal links resolve; build_wiki renders all 48 pages + sidebar
- [x] Forbidden-names scanner clean; zero job/LinkedIn content
- [x] Every API/ToS fact fetched live; unfetchable sources cited by name with nothing quoted

Generated with Claude Code
