### PR TITLE
The two flagged pages, each written inside its own fence

### DIFF
--- a/docs/appointment-bots-explained.md
+++ b/docs/appointment-bots-explained.md
@@ -1,0 +1,179 @@
+---
+title: "Appointment bots: what they are and what an agent can legitimately do"
+description: "The bots that hammer government booking calendars, the paid-slot ecosystem around them, what embassies say about it, and the one legitimate agent task: watching availability for yourself and alerting a human."
+parent: "Using the Agent"
+nav_order: 21
+---
+
+
+# Appointment bots: what they are and what an agent can legitimately do
+
+Searches about appointment bots almost always mean one of two systems:
+embassy and consulate visa-appointment calendars, or DMV-type government
+booking sites, both defined by the same shortage of open slots. Around that
+shortage two very different things have grown: a narrow, legitimate use of
+automation, and a paid ecosystem that embassies now publish warnings about.
+This page separates them, leads with the legitimate one, and quotes the
+official sources on the rest.
+
+## The legitimate slice: watch for yourself, book by hand
+
+There is exactly one appointment-related task this wiki considers an agent fit
+for: watching availability for yourself, and telling you when it changes. That
+is not a special appointment feature, it is ordinary page monitoring, and the
+full treatment already exists on
+[the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md): checking a
+page the way a patient person would, remembering what was seen last, and
+raising an alert instead of taking an action. Applied here, the shape is a
+check of the public availability page at a human cadence, an alert to you when
+something opens, and then you, in your own session, as yourself, doing any
+actual booking by hand.
+
+Three properties separate this from everything described below, and all three
+have to hold: it is your own appointment need, not a service to others; the
+checking rhythm is what a person would do, not what a machine can do; and a
+human makes the booking. This page does not go one step further than that.
+There are no auto-booking instructions here, and the rest of the page is the
+explanation of why.
+
+Conflict of interest, declared where it belongs: you are reading the wiki of a
+browser-automation tool. An agent can be pointed at either half of this
+subject, which is exactly why the boundary is written down rather than left to
+the reader's imagination.
+
+## What an appointment bot actually is
+
+Mechanically, an appointment bot is a program that polls a booking calendar at
+high frequency and reacts the moment a slot appears. The polling is the whole
+trick: cancelled or newly released slots surface at unpredictable times and
+disappear in minutes, so a bot checks many times a minute, around the clock,
+which no person can or would do. What happens on a hit divides the category in
+two: alerting bots notify a human, booking bots seize the slot themselves,
+logged in with someone's credentials, at machine speed.
+
+That polling profile is also the built-in weakness. Checking a page hundreds
+of times an hour is a pure volume signature, the third of the four layers on
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md), and
+the way automated loops amplify it has its own page,
+[agent retry loops and rate limits](agent-retry-loops-rate-limits.md). No
+fingerprint work and no clean address survives a request rate that announces
+itself, and booking systems do not need anything sophisticated to see it:
+they count.
+
+The systems say so themselves. The FAQ of the Italian Consulate General in
+London, on the Italian foreign ministry's own booking platform, explains that
+an account still locked after the ordinary 24 hours "has been automatically
+blocked by the system", and that this "typically occurs when anomalies are
+detected, such as booking attempts that are too rapid to be performed by a
+human operator (e.g., the use of bots) or multiple booking attempts across
+different services." That is a government booking system stating, in its own
+help text, that too fast is the tell and an automatic block is the response.
+
+## The paid slot ecosystem, told honestly
+
+Where slots are scarce, intermediaries run booking bots at scale, seize
+appointments as they are released, and sell them. This is the half of the
+subject that official sources have started addressing by name, and their
+statements are worth reading in full.
+
+The U.S. Embassy in Santo Domingo maintains a page titled "Beware of Visa
+Fixers, Bots, and Offers of Earlier Visa Appointments". It advises applicants
+to "stay far away from visa fixers offering earlier appointments", says the
+embassy "is aware of individuals who are attempting to manipulate the visa
+appointment system through bots and other unauthorized methods", and spells
+out what manipulation costs the applicant: "Potential consequences include:
+appointment cancellation, visa refusal, and visa cancellation." The same page
+adds the sentence that frames the whole ecosystem: "Any attempt to manipulate
+the appointment system is both unfair to other applicants and puts your
+application at risk."
+
+Enforcement is not hypothetical. In March 2025 the U.S. Embassy in India
+publicly announced that it was canceling about 2,000 visa appointments made by
+bots and suspending the scheduling privileges of the associated accounts,
+stating zero tolerance for agents and fixers who violate its scheduling
+policies; the announcement is cited by name in the sources below.
+
+And the question people actually type, answered plainly: **can a visa bot
+guarantee approval?** No, and approval was never the bot's to give. A bot
+touches a calendar; a visa decision is made by a consular officer, on the
+applicant's own case, at the interview the slot merely schedules. A paid slot buys, at
+best, the same interview and the same decision; at worst, per the embassy's
+own list, it costs the appointment or the visa because of how the slot was
+obtained. Anyone selling a "guaranteed"
+outcome is selling something that is not theirs.
+
+## A public queue, degraded for everyone
+
+One more thing needs saying without hedging. Government booking systems are a
+public service with a fixed pool of slots. A bot does not create appointments;
+it moves them, to whoever paid, away from whoever did not. And the polling
+itself has a cost even before any slot is taken: a public calendar hammered
+around the clock by scripts serves everyone worse, and pushes the operator
+toward tighter limits and stricter defenses that ordinary applicants then
+climb over. Hammering a public queue is not a clever trick around scarcity; it
+is queue-jumping that also degrades the queue.
+
+That is the fairness half of why the legitimate slice at the top of this page
+is drawn where it is: watching for yourself at a human cadence takes nothing
+from anyone.
+
+## Short answers to the questions that lead here
+
+**Can a visa bot guarantee approval?** No. Approval is decided by a consular
+officer on your case, not by whoever booked the slot, and it was never the
+bot's to give. Official warnings add that manipulated bookings risk
+appointment cancellation, visa refusal, and visa cancellation.
+
+**Do appointment bots work?** They can seize slots, which is exactly why
+embassies act against them: bot-made appointments have been cancelled by the
+thousands and the accounts behind them suspended. Whatever a bot books, the
+system can unbook.
+
+**Are appointment bots allowed?** The booking systems' own help pages describe
+automatic blocks for bot-speed activity, and embassy statements attach
+consequences up to visa cancellation. Between those two sources there is no
+reading under which they are welcome.
+
+**Can an AI agent watch appointment availability for me?** Watching a public
+availability page for your own need and alerting you is page monitoring, and
+[the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md) covers doing
+it at a human cadence. The booking itself stays yours, by hand.
+
+**Why do booking-site accounts get blocked?** Because high-frequency checking
+is a volume signal the systems watch for; one consulate FAQ names "booking
+attempts that are too rapid to be performed by a human operator" as a trigger
+for automatic blocks. The general mechanics are on
+[the blocked page](why-does-my-ai-agent-get-blocked.md) and
+[the retry-loops page](agent-retry-loops-rate-limits.md).
+
+**Should I pay someone who says they have appointment slots?** The embassy
+warning quoted above tells applicants to stay far away from fixers, and its
+consequence list falls on the applicant, not the seller. The money buys, at
+best, an interview that was never theirs to sell.
+
+## Sources
+
+Retrieved 2026-09-03 unless noted.
+
+- [Beware of Visa Fixers, Bots, and Offers of Earlier Visa Appointments](https://do.usembassy.gov/beware-of-visa-fixers-bots-and-offers-of-earlier-visa-appointments/),
+  U.S. Embassy in the Dominican Republic, for the warning and consequence
+  quotes.
+- [FAQ, booking system, Consulate General of Italy in London](https://conslondra.esteri.it/en/info-utili/f-a-q/faq-sistema-di-prenotazione/),
+  for the automatic-block quote on too-rapid booking attempts.
+- [U.S. Embassy India statement, March 2025](https://x.com/USAndIndia/status/1904843783201583522),
+  cited by name and URL: the platform does not permit retrieval, so nothing is
+  quoted from it here; the cancellation of about 2,000 bot-made appointments
+  and the account suspensions it announced were corroborated across
+  contemporaneous press coverage found in this session's searches.
+
+**See also:**
+[monitoring a page for changes with an AI agent](how-to-monitor-a-page-with-an-ai-agent.md),
+[agent retry loops and rate limits](agent-retry-loops-rate-limits.md),
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md), and
+the rest of [Using the Agent](guides-using-the-agent.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The agent is good
+at watching pages patiently; the maintainer's position is that booking stays a
+human act, in your own name, at the queue's own pace.*

--- a/docs/automating-linkedin-posts-read-this-first.md
+++ b/docs/automating-linkedin-posts-read-this-first.md
@@ -1,0 +1,184 @@
+---
+title: "Automating LinkedIn posts: read this first"
+description: "What LinkedIn's User Agreement says about automation, the routes LinkedIn itself provides, what the unofficial landscape risks, and why this wiki does not publish a LinkedIn walkthrough."
+parent: "Using the Agent"
+nav_order: 20
+---
+
+
+# Automating LinkedIn posts: read this first
+
+"Automate LinkedIn posts" is a search a lot of people make on their way to a
+browser agent, and the honest first page for that search is not a tutorial. You
+will find no walkthrough here, no prompts, no configuration and no steps, and
+the absence is deliberate. What this page does instead is lay out the landscape
+a searcher needs before automating anything on LinkedIn: what the platform's
+own terms say, verified against the current text today; which routes LinkedIn
+itself provides; what the unofficial landscape looks like and what it costs
+when it goes wrong; and why this wiki, which belongs to a browser-automation
+agent, chose not to publish the guide you may have arrived expecting.
+
+## What the User Agreement actually says
+
+LinkedIn's User Agreement carries a section numbered 8.2, the "Don'ts", a list
+of things members agree not to do. Two of its clauses are the ones that matter
+here, quoted from the agreement as it stands today. Members agree not to:
+
+> "Develop, support or use software, devices, scripts, robots or any other
+> means or processes (such as crawlers, browser plugins and add-ons or any
+> other technology) to scrape or copy the Services"
+
+and not to:
+
+> "Use bots or other unauthorized automated methods to access the Services,
+> add or download contacts, send or redirect messages, create, comment on,
+> like, share, or re-share posts, or otherwise drive inauthentic engagement"
+
+Read the second clause again, because it settles the question most searchers
+bring. Automated posting is not a grey area the lawyers forgot: "create,
+comment on, like, share, or re-share posts" names it directly. The one
+load-bearing word is "unauthorized". Authorization exists, and it has a
+specific shape, described in the next section; automated posting that does not
+go through it is the thing the sentence prohibits.
+
+The help center restates the same position in plainer language. LinkedIn's
+page on automated activity says:
+
+> "We don't allow the use of third-party software or browser extensions that
+> scrape, modify the appearance of, or automate activity on LinkedIn's
+> website."
+
+and the account restrictions page connects it to the consequence:
+
+> "Automated inauthentic activity violates the LinkedIn User Agreement and can
+> result in temporary or permanent restriction of your account."
+
+That is the whole legal landscape in four sentences, all of them LinkedIn's.
+
+## The routes LinkedIn itself provides
+
+Two exist, and for most of the demand behind this search they are the complete
+answer.
+
+**Native post scheduling.** LinkedIn ships scheduling as a platform feature,
+no third party involved. The help page for member posts, checked today,
+describes composing a post and picking a publish time, with the constraint
+that "The time selected must be within 10 minutes to 3 months from the current
+time"; a few special post types are excluded. LinkedIn Pages have their own
+scheduling for Page admins, from an hour ahead to three months out. If the
+need underneath "automate my posts" is actually "write now, publish later",
+which it very often is, the platform already covers it, inside the terms, for
+free.
+
+**The official developer platform.** LinkedIn's API documentation describes
+the access model in one sentence: "Most permissions and partner programs
+require explicit approval from LinkedIn. Open Permissions are the only
+permissions that are available to all developers without special approval."
+The small self-service tier includes a product for posting on behalf of the
+member who authorized the app, described as "Post, comment and like posts on
+behalf of an authenticated member". Everything broader, the marketing and
+advertising side in particular, sits behind applying to a LinkedIn partner
+program and being approved. Stated at the category level, which is as far as
+this page goes: an authorized route for programmatic posting exists, it runs
+through LinkedIn's developer portal, and beyond one narrow self-service
+product it involves LinkedIn saying yes to your application.
+
+## Everything else, and what it costs
+
+The unofficial landscape divides into two categories. There are scheduler and
+engagement SaaS products whose LinkedIn support does not run through the
+approved API, operating instead through unofficial means; and there is browser
+automation in all its forms, AI agents included, driving the site the way a
+person would. The clauses quoted above cover both, and the help pages say what
+happens next: detection, then restriction. LinkedIn's automated-activity page
+describes the recovery path for a restricted account, which involves disabling
+the software before the account is re-enabled, and the restrictions page says
+plainly that the outcome can be temporary or permanent.
+
+The cost side deserves one plain sentence. A LinkedIn account is, for most
+people, a professional identity built over years, which makes it about the
+most expensive account there is to lose to a tool experiment.
+
+One line acknowledging the obvious, because pretending otherwise would insult
+you: tools and workflows that automate LinkedIn through the browser exist in
+the wild, and this page does not name, link or describe them.
+
+## Why this wiki does not publish a LinkedIn walkthrough
+
+The social posting series here has per-platform pages for Facebook, Instagram
+and X. LinkedIn is deliberately absent, and this page is the explanation
+rather than the replacement.
+
+An honest LinkedIn automation guide would have to open by telling you that the
+platform's terms prohibit the approach it was about to teach; section 8.2
+names automated post creation in as many words. Every paragraph after that
+opening would be teaching what the terms prohibit, with the reader carrying
+the account risk. We choose not to write that page. This is an editorial
+position, not a technical limitation, and it is worth being explicit about the
+conflict of interest that makes it credible: this wiki documents a
+browser-automation agent, a walkthrough would have been easy traffic, and a
+tool vendor teaching you to automate the most automation-restricted mainstream
+platform would be marketing dressed as documentation. The pages we do publish
+for other platforms open with what their terms say, too; LinkedIn is the
+platform where that opening is the whole story.
+
+If you take one thing from this page: the sanctioned routes, native scheduling
+and the approved developer products, cover the legitimate demand. What they do
+not cover, LinkedIn has written down that it does not want.
+
+## Short answers to the questions that lead here
+
+**Can I automate my LinkedIn posts?** Through LinkedIn's own routes, yes:
+native scheduling covers "write now, publish later", and the developer
+platform covers authorized programmatic posting. Outside those routes, the
+User Agreement's 8.2 list prohibits bots and unauthorized automated methods
+for creating posts, in exactly those words.
+
+**Does LinkedIn have built-in post scheduling?** Yes, verified against the
+help pages today: member posts can be scheduled from 10 minutes to 3 months
+ahead, and Pages have scheduling for admins. No third-party tool is needed for
+scheduling alone.
+
+**Is there an official LinkedIn API for posting?** Yes. A narrow self-service
+product allows an app to post on behalf of the member who authorized it;
+broader access requires applying to LinkedIn's partner programs, and LinkedIn's
+own documentation says most permissions require its explicit approval.
+
+**Will a LinkedIn automation tool get my account restricted?** LinkedIn states
+that it does not allow software or extensions that automate activity on the
+site, and that automated inauthentic activity can lead to temporary or
+permanent restriction. That is the platform's own description of the risk, not
+this wiki's estimate.
+
+**Why is there no AIHawk guide for posting to LinkedIn?** Because an honest
+one would open by saying the terms prohibit the approach, and we choose not to
+teach what the terms prohibit. The neighboring platforms have pages; this one
+has this page instead.
+
+## Sources
+
+All retrieved 2026-09-03.
+
+- [LinkedIn User Agreement](https://www.linkedin.com/legal/user-agreement),
+  section 8.2, for the two "Don'ts" clauses quoted above.
+- [LinkedIn Help: Schedule posts](https://www.linkedin.com/help/linkedin/answer/a1347212),
+  for member post scheduling and the 10-minutes-to-3-months window.
+- [LinkedIn Help: Schedule a LinkedIn Page post](https://www.linkedin.com/help/linkedin/answer/a1419179),
+  for Page scheduling by admins.
+- [LinkedIn Help: Automated activity on LinkedIn](https://www.linkedin.com/help/linkedin/answer/a1340567),
+  for the third-party software statement and the restriction recovery flow.
+- [LinkedIn Help: Account restrictions](https://www.linkedin.com/help/linkedin/answer/a1340522),
+  for the temporary-or-permanent restriction statement.
+- [Getting Access to LinkedIn APIs](https://learn.microsoft.com/en-us/linkedin/shared/authentication/getting-access),
+  for the access model and permission quotes.
+
+**See also:**
+[posting to social media with an AI agent](posting-to-social-media-with-an-ai-agent.md),
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md), and
+the rest of [Using the Agent](guides-using-the-agent.md).
+
+---
+
+*From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. The social series
+has a page per platform; this is the platform where the honest page is the one
+that tells you why there is no walkthrough.*

--- a/docs/guides-using-the-agent.md
+++ b/docs/guides-using-the-agent.md
@@ -31,3 +31,5 @@ and what to expect before you spend model tokens finding out.
 - [Posting to Facebook with an AI agent](post-to-facebook-with-an-ai-agent.md)
 - [Posting to Instagram with an AI agent](post-to-instagram-with-an-ai-agent.md)
 - [Posting to X with an AI agent](ai-agent-post-to-x.md)
+- [Automating LinkedIn posts: read this first](automating-linkedin-posts-read-this-first.md)
+- [Appointment bots: what they are and what an agent can legitimately do](appointment-bots-explained.md)


### PR DESCRIPTION
## Summary

The two owner-flagged pages, each written inside the fence the owner set.

**Automating LinkedIn posts: read this first** - broad on purpose, per the owner's condition, with zero operational instructions anywhere (no steps, no prompts, no config, no code). It quotes the User Agreement's own automation clauses from the English canonical, names the sanctioned routes at category level (LinkedIn's native scheduling - verified on the help pages - and the two-tier API access model read off Microsoft's own docs, stated accurately: most permissions partner-gated, one narrow self-service product), states the restriction risk from LinkedIn's own help pages, and carries its spine in one paragraph: this wiki does not teach what the terms prohibit.

**Appointment bots: what they are and what an agent can legitimately do** - the one honest page in a scam-adjacent SERP. The legitimate slice leads (watching availability for yourself, a human doing any booking, deferring to the monitoring page), the paid-slot ecosystem is called what it is with a real US embassy warning quoted from the fetched source, and the volume section rests on a government booking system's own published words about auto-blocking attempts "too rapid to be performed by a human operator". No faster-appointment claim anywhere, no booking instructions, no per-country guidance, no slot-seller links. Category-level naming only; no private visa-outsourcing companies named.

## Test plan

- [x] English-only clean; zero em-dashes; forbidden-names scanner clean; zero job content
- [x] All internal links resolve; build_wiki renders all 50 pages + sidebar
- [x] Page 1 grep-audited for operational instructions: none
- [x] Page 2 grep-audited for faster/sooner claims and booking instructions: none
- [x] Every quoted source fetched this session; unfetchable ones cited by name with nothing quoted

Generated with Claude Code
