### PR TITLE
Three commands, because the heading promised more than one client

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,37 @@
 
 The only question is where the model comes from.
 
-### 1. You already use Claude Code, Claude Desktop or Cursor
+### 1. You already use an assistant that can run tools
 
 Your assistant brings the model. You add this browser to it, and nothing changes
 about how you work.
 
+**Claude Code:**
+
 ```bash
 claude mcp add -s user stealth -- uvx invisible-playwright-mcp
+```
+
+**Codex:**
+
+```bash
+codex mcp add stealth -- uvx invisible-playwright-mcp
+```
+
+**Gemini CLI:**
+
+```bash
+gemini mcp add -s user stealth uvx invisible-playwright-mcp
 ```
 
 Then ask your assistant, in the window you already have open:
 
 > Go to news.ycombinator.com and give me the top five titles.
 
-For Claude Desktop, Cursor and the rest, which take a config file instead, the
-block to paste is in the [server's README](https://github.com/feder-cr/invisible-playwright-mcp).
+Claude Desktop, Cursor, VS Code, Windsurf, Zed and Cline take a config file
+instead, and the file is not the same shape for all of them. Each one is
+written out in the
+[server's README](https://github.com/feder-cr/invisible-playwright-mcp#adding-it-to-your-client).
 
 ### 2. You don't, or you want to watch it work
 

--- a/docs/automate-job-applications-python.md
+++ b/docs/automate-job-applications-python.md
@@ -1,0 +1,211 @@
+---
+title: "Automating job applications in Python"
+description: "The build-it-yourself route: browser automation plus an LLM API, the four components a real pipeline needs, why naive scripts break on wizards, validation and anti-bot layers, and the honest case for using what already exists."
+parent: "Job Application Automation"
+nav_order: 3
+---
+
+
+# Automating job applications in Python
+
+Building a job-application bot in Python is a genuinely instructive project: it
+touches browser automation, LLM integration, state, and the parts of the web
+that push back. This page lays out what the real components are, shows why the
+obvious eighty-line script breaks, and closes with the honest note that this
+exact project has already been built in the open, because that is literally how
+AIHawk started.
+
+One rule this page keeps, like every page under this parent: no job platform is
+named, and the examples run against generic forms or pages you serve yourself.
+The mechanics are the same everywhere, which is exactly why the generic version
+is worth writing down.
+
+## The naive version, to have something to break
+
+Every attempt starts roughly here: Playwright opens the form, an LLM drafts the
+answers, the script fills and submits.
+
+```python
+from playwright.sync_api import sync_playwright
+
+BACKGROUND = open("background.md").read()   # your real history, as text
+
+def draft(question: str) -> str:
+    # any LLM API; the contract is what matters:
+    # answer from BACKGROUND only, say "ASK" when the answer is not in it
+    ...
+
+with sync_playwright() as p:
+    browser = p.firefox.launch()
+    page = browser.new_page()
+    page.goto("http://127.0.0.1:8000/application-form")  # a page you serve
+    for field in page.locator("form [data-question]").all():
+        answer = draft(field.get_attribute("data-question"))
+        field.fill(answer)
+    page.click("#submit")
+```
+
+On a form you wrote yourself, this works on the first try, which is what makes
+the approach look one weekend wide. The distance between this and a pipeline
+that survives real pages is the rest of this page.
+
+## The four components a real pipeline needs
+
+**Form detection.** Real forms do not label themselves with `data-question`.
+Fields associate with their questions through `<label for>`, `aria-label`,
+`aria-labelledby`, placeholder text, or nothing but visual proximity; required
+markers and error text sit in separate nodes; some forms arrive inside an
+embedded iframe with its own document. Mapping "what is this field asking" to
+"which element do I fill" is a real subproblem, and it is where an LLM earns its
+place: handed the rendered page, a model can read the form the way a person
+does, which is the approach described in
+[getting an AI agent to fill out forms](ai-agent-fill-out-forms.md).
+
+**Answer generation.** The model needs your background as grounding and a
+contract that keeps it honest: every claim from the provided history, an
+explicit escape hatch ("ASK") for questions it cannot answer from it, and no
+improvisation. Tailoring - picking which true things to emphasize for this role
+- is the value. Fabricating qualifications is a bug, and it is one your own
+pipeline will happily ship at scale if the prompt does not forbid it.
+
+**Session persistence.** Applying is logged-in work spread over days. That
+means a persistent browser profile rather than a fresh context per run, so
+cookies and logins survive; it also means the same browser identity each time,
+because a login that hops between fingerprints looks stolen. Plan for a profile
+directory and for state you can resume after a crash mid-wizard.
+
+**Pacing.** The component most builds skip and the first one to matter in
+production. Per-account and per-IP rate limits are real, and a submission every
+few seconds is a signature no fingerprint work can hide. Pacing is jitter
+between actions, minutes between applications, a daily cap, and backoff on
+anything that looks like throttling. It is also the ethical component: the
+volume ceiling is where "my bot" stops being distinguishable from spam, a
+lesson this project's own history documents in detail on
+[the history page](open-source-job-application-bot.md).
+
+## Why naive scripts break
+
+**Multi-step wizards.** Real applications are three to eight steps with state:
+conditional fields that appear based on earlier answers, a review step that
+re-renders everything, a back button that resets more than it should. A script
+that models "the form" as one page loses to the first wizard it meets. You need
+a loop over steps - read, fill, advance, re-read - and idempotent resume,
+because step four is where the timeout happens.
+
+**Client-side validation.** Fields validate on blur and on keystroke; masked
+inputs reformat as you type; selects are custom widgets that only respond to
+real interaction. Setting `element.value` from JavaScript skips the events the
+page listens for, so the value silently fails validation, or arrives empty at
+submit. Fill through real typing and clicking. It is telling that AIHawk's own
+agent, per its README, refuses to set form fields from JavaScript even when it
+would be faster, because a page can tell the difference.
+
+**File uploads.** The resume field is a file input, often behind a styled
+button, sometimes a drag-and-drop zone. Playwright's `set_input_files` covers
+the plain case; the styled cases need the real input located first. And a
+tailored resume means generating a file per application, which is its own
+pipeline stage.
+
+**The anti-bot layer.** This is the wall that surprises builders most, because
+it has nothing to do with your code being correct. Stock automation is
+detectable below your script: driver artifacts, headless tells, a fingerprint
+inconsistent with the claimed platform, a TLS handshake that does not match the
+user agent. No amount of selector work fixes a page that has already decided
+what you are. The mechanism layer - fingerprinting surfaces, detection vendors,
+network tells - is documented in depth on the
+[invisible_playwright wiki](https://github.com/feder-cr/invisible_playwright/wiki),
+and the agent-level symptoms in
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md). If
+you stay on the build-it-yourself road, that engine is usable as a library:
+[invisible_playwright](https://github.com/feder-cr/invisible_playwright) is a
+Firefox patched at the C++ level, driven through the standard Playwright API,
+so the code above ports by changing the launch.
+
+## Or use what exists
+
+Here is the honest close. The pipeline this page describes - form reading,
+grounded answer generation, persistent sessions, pacing, on a browser built to
+look like a real one - is an open-source project you can read instead of
+rediscover. [AIHawk](https://github.com/feder-cr/AIHawk) began in 2024 as
+exactly this Python bot, reached about 30,000 stars and a wave of press
+coverage, and grew into a general web agent on that same hardened engine. It is
+MIT-licensed; run it as an interface with `uvx aihawk ui`, script it headless
+with `uvx aihawk do "..."`, or take just the browser layer as a library and
+keep your own agent logic on top.
+
+Building your own is still a fine choice when the point is learning or when
+your flow is unusual. But go in knowing which parts are the actual work: not
+the form filling, which a weekend gets you, but the wizard state, the
+validation-safe input, the stable identity, and the restraint.
+
+## Conclusion
+
+A real job-application pipeline in Python is four components - form detection,
+grounded answer generation, session persistence, pacing - sitting on a browser
+that can survive being looked at. The naive script fails on multi-step wizards,
+event-driven validation, uploads, and an anti-bot layer that inspects the
+browser underneath your code. All four components, on a hardened engine, exist
+in the open already; whether you build or adopt, the volume ceiling and the
+review-before-submit rule are the parts that keep the pipeline worth running.
+
+## Short answers to the questions that lead here
+
+**Can I automate job applications with Python and Playwright?** Yes, and the
+form-filling part is genuinely easy. The real work is wizard state,
+validation-safe typing, persistent sessions, pacing, and a browser that does
+not advertise itself as automation.
+
+**Which LLM do I need?** Any API model works for answer generation. The prompt
+contract matters more than the model: answers only from your provided
+background, with an explicit "ask the human" escape for anything else.
+
+**Why does my script's input disappear at submit?** You are probably setting
+values from JavaScript, which skips the input events client-side validation
+listens for. Type and click like a user; the value then exists the way the page
+expects.
+
+**Why does my bot get blocked even though the code works?** Detection operates
+below your script: driver artifacts, headless tells, fingerprint and TLS
+inconsistencies. See the
+[invisible_playwright wiki](https://github.com/feder-cr/invisible_playwright/wiki)
+for the mechanism layer; correctness of your Python is not the question being
+asked.
+
+**How fast can I safely go?** Slower than the code allows. Jitter inside a
+form, minutes between applications, a daily cap you would defend out loud.
+Past that ceiling you are building a spam tool with extra steps, and the
+account it burns is yours.
+
+**Is there an open-source version already?** Yes -
+[AIHawk](https://github.com/feder-cr/AIHawk), which started as exactly this
+bot and is now a general web agent on a hardened Firefox. Reading its layout is
+a shortcut even if you then build your own.
+
+## Sources
+
+- The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), retrieved
+  2026-09-03, for the interface and headless commands, the library and MCP
+  layers, the license, and the agent's refusal to set form fields from
+  JavaScript.
+- [404 Media's October 2024
+  report](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/),
+  retrieved 2026-09-03, for what the original bot generation actually did in
+  the field: biographical fill, generated resumes, customized cover letters,
+  unattended volume.
+- This project's own engine documentation, linked throughout, for the
+  fingerprinting and detection mechanics summarized in the anti-bot section.
+
+**See also:** [getting an AI agent to fill out
+forms](ai-agent-fill-out-forms.md) for the form-reading approach in isolation,
+[automating job applications with
+Claude](automate-job-applications-with-claude.md) for the no-code version of
+this pipeline, [the open-source job application bot, and what it
+became](open-source-job-application-bot.md) for where the build-it-yourself
+road led once, and the
+[job application automation hub](guides-job-application-automation.md).
+
+---
+
+*Written by the maintainer of [AIHawk](https://github.com/feder-cr/AIHawk),
+which exists because someone built this exact Python project and then spent two
+years on the parts this page says are the actual work.*

--- a/docs/automate-job-applications-with-chatgpt.md
+++ b/docs/automate-job-applications-with-chatgpt.md
@@ -1,0 +1,197 @@
+---
+title: "Automating job applications with ChatGPT"
+description: "What OpenAI's agent products can and cannot do for application forms as of September 2026, where copy-paste ChatGPT is honestly the better tool, and where an agent with its own browser fits."
+parent: "Job Application Automation"
+nav_order: 2
+---
+
+
+# Automating job applications with ChatGPT
+
+"Automating job applications with ChatGPT" means two different things, and most
+advice mixes them up. One is copy-paste assistance: ChatGPT drafts your tailored
+resume bullets and answers, you do the clicking. That works today, on any plan,
+and for the writing itself it is excellent. The other is agentic automation: an
+OpenAI product driving a browser through the form for you. That second thing has
+existed in four different shapes in twenty months, three of which have already
+been shut down, so the honest version of this page has to start with a timeline.
+
+## What OpenAI's agent products are, as of September 2026
+
+The short history, because which advice applies depends on which month's product
+you read about:
+
+- **Operator** (announced January 2025) was the original: a research preview
+  for Pro subscribers in the US, running a virtual browser in the cloud that
+  could fill forms, place orders, and schedule appointments. It was deprecated
+  when ChatGPT agent launched and shut down on August 31, 2025.
+- **ChatGPT agent / agent mode** (July 2025) absorbed Operator's
+  browser-control into ChatGPT itself: pick agent mode, state the task, and a
+  hosted browser works through it.
+- **ChatGPT Atlas** (October 2025) was a full desktop browser with the agent
+  built in, launched for macOS. It shut down in August 2026, with OpenAI
+  folding browser-based agentic work back into ChatGPT.
+- **ChatGPT Work** (announced July 2026) is the current shape: an agent for
+  multi-step office tasks - documents, spreadsheets, research - with a built-in
+  browser in the desktop app, its usage metered against your plan. Around the
+  same time, per Wikipedia's Operator entry, the older agent mode was removed
+  from ChatGPT and users were pointed at ChatGPT Work and a cloud browser
+  feature.
+
+Two things follow from this churn. First, any tutorial about applying to jobs
+"with Operator" or "in Atlas" describes a product that no longer exists. Second,
+the through-line across all four shapes is the same: a browser OpenAI hosts,
+metered usage, and confirmation prompts before consequential actions. Those
+properties, not the product names, are what decide whether the flow fits.
+
+## Where a hosted agent fits application flows, and where it strains
+
+An application flow has a specific shape: log in to an account that is yours,
+move through a multi-step form, upload a resume file, answer questions that vary
+per posting, and do it again tomorrow without looking like a different person.
+Measured against that shape, a cloud-hosted agent has real friction:
+
+**The session is not really yours.** The browser runs on OpenAI's
+infrastructure. Logging your accounts into it is possible but means handing a
+hosted browser your credentials, and the session identity - cookies, IP,
+fingerprint - lives wherever the product runs, shared infrastructure that sites
+see a lot of. Application platforms are exactly the kind of logged-in,
+rate-limited surface where that matters; the general mechanics are covered in
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md).
+
+**Persistence is not the product's goal.** Applying is a campaign, not a task:
+the same identity, the same logins, across days. Hosted agent sessions are
+task-shaped, and each product transition above reset what carried over.
+
+**Metered usage meets a many-step flow.** A multi-step wizard is dozens of agent
+steps, and hosted-agent usage draws down plan quota. One application is fine.
+Volume is expensive in exactly the way it is with every agent, which is not a
+loss, because volume is the wrong goal anyway - more on that below.
+
+**File uploads and judgment calls.** A tailored resume has to exist as a file
+the hosted browser can reach, and questions about salary, work authorization, or
+self-identification need to stop the run and come back to you. Confirmation
+prompts help here; they are the product behaving correctly, not friction to
+engineer away.
+
+## Where plain ChatGPT is honestly the better tool
+
+For the writing, copy-paste ChatGPT remains hard to beat, and it has none of the
+problems above. Paste your background once, then per posting: paste the
+description, ask for the three bullets of your history most relevant to it, a
+tailored summary, and honest draft answers to the form's long-text questions.
+You click through the form yourself, in your own browser, with your own logins,
+at your own pace - which also means every answer passes through your hands
+before it is submitted.
+
+Keep the same grounding rule that applies to any model doing this work: answers
+come from your real history, and a question the model has no data for is a
+question for you, not an invitation to improvise. Tailoring which true things to
+emphasize is the legitimate craft here. Fabricated qualifications are not a
+gray area, and they surface at the worst possible time: in an interview.
+
+## Where an agent with its own browser fits
+
+The gap between those two options - full manual clicking versus a hosted agent
+that is not really yours - is where an open-source agent running on your own
+machine sits. [AIHawk](https://github.com/feder-cr/AIHawk) is one: the model
+reads the form and drafts the answers, but the browser is a real, patched
+Firefox running locally, with a persistent profile (`--profile-dir`) so logins
+survive restarts, a stable seeded identity (`--seed`) so you look like the same
+machine every day, and your own network exit. You run it either by adding its
+MCP browser to an assistant you already have, or as its own interface:
+
+```bash
+uvx aihawk ui --openrouter-key sk-or-...
+```
+
+That is chat on the left, the live browser on the right, so the watching-it-work
+property of the hosted agents is kept. The model comes from OpenRouter, and
+`--model` takes any OpenRouter model id, so this route is not an
+anti-OpenAI position - it is a different answer to where the browser lives and
+who holds the session. The Claude-side equivalent of this page is
+[automating job applications with Claude](automate-job-applications-with-claude.md).
+
+## The same honesty about pacing
+
+Whatever drives the browser, the volume math does not change, and this project
+is the case study: its original bulk-application bot got written up by 404 Media
+and TechCrunch in October 2024, with The Verge's headline framing the trend as
+job seekers learning to think like spammers. The details are on
+[the history page](open-source-job-application-bot.md), but the conclusion
+transfers whole: sprayed applications replicate errors at scale, read as
+generic, and put a machine signature on an account you presumably want to keep.
+A handful of applications per session, each reviewed before submission, is both
+the safer pattern and the one that actually gets responses.
+
+## Conclusion
+
+As of September 2026, OpenAI's agentic route runs through ChatGPT Work and its
+built-in browser, after Operator, agent mode, and Atlas were each retired in
+turn. A hosted agent can walk an application form, but the session, identity,
+and persistence living on shared infrastructure fit a campaign of logged-in
+applications poorly. Copy-paste ChatGPT is excellent for the writing and leaves
+every submission in your hands. An open-source agent with its own local browser
+covers the middle: automated form work, your machine, your identity, your pace.
+All three routes share one constraint that no product changes - applications
+are worth automating one at a time, not in bulk.
+
+## Short answers to the questions that lead here
+
+**Can ChatGPT apply to jobs for me?** ChatGPT can draft everything and, through
+OpenAI's current agent products, can drive a hosted browser through a form. The
+hosted session, metered usage, and confirmation stops make it fit one careful
+application at a time, not a pipeline.
+
+**What happened to Operator and Atlas?** Operator shut down August 31, 2025,
+absorbed into ChatGPT agent mode; the Atlas browser shut down in August 2026.
+Browser-based agentic work now lives in ChatGPT Work, announced July 2026.
+
+**Is copy-paste ChatGPT enough?** For the writing, usually yes, and it is the
+cheapest and least risky option: tailored bullets and drafted answers, with you
+doing the clicking in your own browser.
+
+**Why would I use an open-source agent instead?** The browser runs on your
+machine: persistent logins, a stable identity across days, your network exit,
+and no per-step draw on a hosted plan. The model still does the reading and
+drafting.
+
+**Can I use OpenAI models with AIHawk?** AIHawk's interface takes any OpenRouter
+model id via `--model`, so you choose the model independently of the browser.
+
+**Will any of this get my account flagged?** Volume and robotic pacing are the
+main self-inflicted risks on a logged-in account, whichever tool you use. Keep
+human pace and review each submission; for the detection layers underneath, see
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md).
+
+## Sources
+
+- [Wikipedia, "OpenAI Operator"](https://en.wikipedia.org/wiki/OpenAI_Operator),
+  retrieved 2026-09-03, for the January 2025 launch, the August 31, 2025
+  shutdown, the absorption into ChatGPT agent, and the 2026 removal of agent
+  mode.
+- [Wikipedia, "ChatGPT Atlas"](https://en.wikipedia.org/wiki/ChatGPT_Atlas),
+  retrieved 2026-09-03, for the October 21, 2025 launch and the August 2026
+  shutdown.
+- [PPC Land, "OpenAI kills Atlas browser, folds it into new ChatGPT Work
+  agent"](https://ppc.land/openai-kills-atlas-browser-folds-it-into-new-chatgpt-work-agent/),
+  retrieved 2026-09-03, for ChatGPT Work's July 2026 announcement, its built-in
+  browser, and its metered usage model.
+- The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), retrieved
+  2026-09-03, for the `uvx aihawk ui` interface, `--model`, `--seed`, and
+  `--profile-dir`.
+
+**See also:** [automating job applications with
+Claude](automate-job-applications-with-claude.md) for the MCP-based setup on the
+Claude side, [automating job applications in
+Python](automate-job-applications-python.md) if you would rather build the
+pipeline yourself, [what is an AI web agent?](ai-web-agent-explained.md) for the
+category this all sits in, and the
+[job application automation hub](guides-job-application-automation.md).
+
+---
+
+*Written by the maintainer of [AIHawk](https://github.com/feder-cr/AIHawk), an
+open-source web agent that started as a job-application bot. Three of the four
+OpenAI products this page describes shut down while it was a going concern,
+which is its own argument for tools you can run yourself.*

--- a/docs/automate-job-applications-with-claude.md
+++ b/docs/automate-job-applications-with-claude.md
@@ -1,0 +1,192 @@
+---
+title: "Automating job applications with Claude"
+description: "Claude Code or Claude Desktop plus an MCP browser gives you an agent that works through application forms while you watch - what that setup does well, what it costs, and the pacing that keeps it from hurting you."
+parent: "Job Application Automation"
+nav_order: 1
+---
+
+
+# Automating job applications with Claude
+
+The current, real answer to "can Claude apply to jobs for me" is: Claude plus an
+MCP browser can work through an application form in front of you, reading each
+question, drafting an answer from your background, and filling it in while you
+watch every step. That is genuinely useful. It is not a fire-and-forget pipeline
+that sprays hundreds of applications overnight, and the second half of this page
+is about why you do not want it to be.
+
+## The setup, honestly
+
+Claude brings the model; you add a browser it can drive. If you use Claude Code,
+the whole setup is one command, run once:
+
+```bash
+claude mcp add -s user stealth -- uvx invisible-playwright-mcp
+```
+
+Claude Desktop and Cursor take a JSON config block instead of a command; the
+block, and which file it goes in, are in the
+[server's README](https://github.com/feder-cr/invisible-playwright-mcp). The
+server exposes a patched Firefox over MCP - the same engine behind
+[AIHawk](https://github.com/feder-cr/AIHawk), which is where this wiki lives.
+
+One thing the first run will not warn you about: the browser is about a quarter
+of a gigabyte and is downloaded on the first request that needs a page, so your
+first instruction sits silent for a while. Fetch it ahead of time, in a terminal
+where you can watch the progress:
+
+```bash
+uvx invisible-playwright fetch
+```
+
+After that, you talk to Claude the way you already do. Give it your background
+first - paste your resume text, or point Claude Code at the file - then open a
+listings page or an application form and ask it to work through it. Everything
+it does appears as a visible tool call: navigate, read the page, type into a
+field, click. You are not trusting a black box; you are supervising an intern
+with a very fast reading speed.
+
+## What Claude is actually good at here
+
+**Reading a form nobody wrote a script for.** Application forms differ on every
+site: different field names, different steps, questions hidden behind dropdowns,
+a resume upload here and a text box asking you to retype the same history there.
+A traditional bot needs selectors written for each variant and breaks when the
+markup changes. Claude reads the rendered page like a person does, so an
+unfamiliar form is just another form.
+
+**Tailoring answers from your background to the question asked.** "Describe a
+project where you led a migration" gets a better answer from a model holding
+your actual history than from a paragraph you pasted into twenty forms. This is
+the honest version of tailoring: choosing which true things to emphasize for
+this role. It is not inventing qualifications, and you should say so in your
+instructions - tell Claude explicitly that every claim must come from the
+background you provided, and that missing information means asking you, not
+improvising.
+
+**Noticing what should stop the process.** A good agent run includes moments
+where Claude halts and asks: this form wants a salary expectation, this question
+is about work authorization, this checkbox is a legal attestation. Those are
+yours. A model that answers them for you is not saving you time, it is signing
+things in your name.
+
+## What it does badly
+
+**Cost per application.** A multi-step wizard means reading each step, reasoning
+about each field, and a tool call per interaction - dozens of model round trips
+for one submission, on your plan or API bill. For one thoughtful application
+that is fine. As a bulk strategy it is an expensive way to get a worse outcome
+than five careful applications would have gotten you.
+
+**Judgment calls it should not make alone.** Compensation, notice periods,
+relocation, visa status, disability and veteran self-identification, references.
+None of these belong to an agent. The workable pattern is: Claude fills the
+factual and narrative fields, then stops and lists everything it left blank and
+why, and you finish the pass yourself.
+
+**Anything it was not told.** A model asked a question it has no data for will
+sometimes produce a plausible answer anyway. That failure mode is exactly the
+one a job application cannot afford. Ground it: full background in, explicit
+"ask, never guess" instruction, and your own read of the filled form before
+anything is submitted.
+
+## The part the media coverage was about
+
+This project's own history is the clearest available evidence on volume, and it
+is worth being straight about. AIHawk started life as a bulk job-application
+bot. In October 2024, 404 Media's Jason Koebler
+[used it to apply to 17 jobs in one hour](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/),
+writing up a user who had let it run to 2,843 applications - the bot entered
+biographical details, generated resumes, wrote customized cover letters, and
+filed the paperwork on its own.
+[TechCrunch covered the same story](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/)
+and called the result a bizarre loop: applicants automating applications while,
+by the figure TechCrunch cited, 42 percent of companies were already using AI to
+screen them, humans increasingly absent from both sides. The Verge's same-day
+piece put the criticism in its headline: AI was enabling job seekers to think
+like spammers.
+
+The criticism was not wrong, and the applicant is who it lands on. Sprayed
+applications carry replicated mistakes at scale, answers that read as generic
+because they are, and a volume signature that platforms throttle and recruiters
+learn to discount. An account that submits forty applications an hour does not
+look like an eager candidate; it looks like what it is.
+
+So the etiquette section of this page is short and unambiguous. Keep a human
+pace: a handful of applications in a session, not a stream. Review every filled
+form before it is submitted - the AIHawk README's own rule is "do not submit
+anything a human has not read," and it applies doubly when Claude did the
+writing. Let quality per application be the metric, because it is the only one
+that ever paid the applicant.
+
+## Conclusion
+
+Claude Code or Claude Desktop plus `invisible-playwright-mcp` gives you an agent
+that can genuinely work an application form: read it, tailor honest answers from
+your background, fill it while you watch, and stop where your judgment is
+required. Used at human pace with a human review before every submit, that is a
+real assist. Used as a spray tool, it recreates the exact behavior this
+project's own press coverage documented the costs of. The setup takes one
+command; the discipline is the part you bring.
+
+## Short answers to the questions that lead here
+
+**Can Claude actually fill out a job application?** Yes. With an MCP browser
+attached, Claude reads the rendered form, types into fields, handles multi-step
+wizards, and shows you each action as it happens. You review and submit.
+
+**Does this work with Claude Desktop, or only Claude Code?** Both, and Cursor
+too. Claude Code takes the one-line `claude mcp add` command; the others take a
+JSON config block documented in the MCP server's README.
+
+**Will Claude write my cover letter and answers?** It will draft them from the
+background you give it, tailored to the posting. Keep it grounded: instruct it
+that every claim must come from your provided history and that gaps mean asking
+you, not inventing.
+
+**How many applications can I do this way?** Technically many; practically you
+should not. Each application costs real model usage, and bulk volume is the
+pattern that damaged applicants in this project's own history. A few careful,
+reviewed applications beat a spray.
+
+**Will the browser get blocked?** The engine is a Firefox patched to look and
+behave like a normal desktop browser, which addresses the fingerprint layer.
+Pacing, account behavior, and your network exit are still yours - see
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md).
+
+**Should Claude answer salary, visa, or self-identification questions?** No.
+Have it stop and list them for you. Those answers bind you; a model should not
+be producing them unsupervised.
+
+## Sources
+
+- The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), retrieved
+  2026-09-03, for the `claude mcp add` setup line, the engine download
+  behavior, and the "do not submit anything a human has not read" rule.
+- [404 Media, "I Applied to 2,843 Roles With an AI-Powered Job Application
+  Bot"](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/),
+  Jason Koebler, retrieved 2026-09-03.
+- [TechCrunch, "Someone claims to have used AI to apply to 2,843
+  jobs"](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/),
+  Kyle Wiggers, October 10 2024, retrieved 2026-09-03, including the 42 percent
+  AI-screening figure it cites.
+- The Verge's October 10 2024 piece is linked from the
+  [project README](https://github.com/feder-cr/AIHawk#readme); the site blocks
+  automated retrieval, so the "think like spammers" phrasing is quoted from its
+  headline as linked there.
+
+**See also:** [automating job applications with
+ChatGPT](automate-job-applications-with-chatgpt.md) for the other assistant's
+side of this, [automating job applications in
+Python](automate-job-applications-python.md) for the build-it-yourself route,
+[the open-source job application bot, and what it
+became](open-source-job-application-bot.md) for the full history this page
+compresses, and [getting an AI agent to fill out
+forms](ai-agent-fill-out-forms.md) for the form mechanics on their own.
+
+---
+
+*Written by the maintainer of [AIHawk](https://github.com/feder-cr/AIHawk),
+which began as the job-application bot in those 2024 headlines and grew into a
+general web agent. The browser and the agent are the easy part now; applying
+like a person is still the part that works.*

--- a/docs/guides-job-application-automation.md
+++ b/docs/guides-job-application-automation.md
@@ -1,0 +1,21 @@
+---
+title: "Job Application Automation"
+has_children: true
+nav_order: 4
+---
+
+# Job Application Automation
+
+AIHawk was born here: an AI agent that applied to jobs in bulk, covered by
+TechCrunch, Business Insider, Wired and The Verge along the way. The project
+has since become a general web agent, but the job-application use case is
+still real, still asked about, and still where much of this community started.
+
+One rule these pages keep, everywhere: no job board or company site is named.
+Naming who is being automated against turns a guide into a target list, so
+examples use generic forms and pages you serve yourself.
+
+- [Automating job applications with Claude](automate-job-applications-with-claude.md)
+- [Automating job applications with ChatGPT](automate-job-applications-with-chatgpt.md)
+- [Automating job applications in Python](automate-job-applications-python.md)
+- [The open-source job application bot, and what it became](open-source-job-application-bot.md)

--- a/docs/open-source-job-application-bot.md
+++ b/docs/open-source-job-application-bot.md
@@ -1,0 +1,186 @@
+---
+title: "The open-source job application bot, and what it became"
+description: "AIHawk's own history, told straight: the 2024 bulk-application bot, the 30,000 stars and the media wave, the spammers criticism and the fair answer to it, and why the project became a general web agent."
+parent: "Job Application Automation"
+nav_order: 4
+---
+
+
+# The open-source job application bot, and what it became
+
+If you searched for an open-source job application bot, this repository is
+probably one of the results, and it earned that placement the loud way: in 2024
+it was the bot in the headlines. This page is the project telling its own
+story, including the part where the criticism was substantially right - because
+what the project became only makes sense once you see what the original hit,
+and what it hit first was its own ceiling.
+
+## What the original bot was
+
+The project began as a Python bot that automated job applications end to end.
+Point it at listings, give it your history, and it did the rest: entered
+biographical details into forms, generated resumes, wrote customized cover
+letters per posting, checked the required boxes, and submitted - unattended, in
+volume. That description is not marketing memory; it is how
+[404 Media](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/)
+described what it watched the bot do.
+
+It spread fast because it sat on a real nerve. Application forms had grown long
+and repetitive, applicants were being screened by software, and here was
+software that screened back. The repository climbed to about 30,000 stars, and
+in October 2024 the press arrived.
+
+## The media wave, and what it actually said
+
+404 Media's Jason Koebler ran the bot himself and
+[applied to 17 jobs in one hour](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/),
+building the piece around a user who had let it run to 2,843 applications.
+[TechCrunch picked the story up the same day](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/)
+and named the uncomfortable context: by the figure it cited, 42 percent of
+companies were already using AI to screen applicants, so automated applications
+meeting automated screening formed what it called a bizarre loop, with humans
+increasingly absent from both ends of hiring. The Verge published its take the
+same day with the criticism in the headline: AI was enabling job seekers to
+think like spammers. The
+[project README's featured strip](https://github.com/feder-cr/AIHawk#readme)
+carries the full set - Business Insider, Semafor, Wired's Italian edition, and
+Vanity Fair Italy alongside those three.
+
+Thirty thousand stars and international coverage is the part a project brags
+about. The next section is the part that matters more.
+
+## The criticism deserved a straight answer
+
+The spammers framing was not a cheap shot. A bot whose value proposition is
+volume converges on spam mechanics no matter how it is built: the same answers
+fanned out everywhere, any error in your data replicated 2,843 times, cover
+letters that read generic because they are generated at a rate no one reviews.
+And the damage lands on the applicant first. Recruiters learn to discount what
+looks mass-produced; platforms throttle and flag accounts with machine-like
+volume; an interview earned by an application you never read is an interview
+you walk into unprepared. The loop TechCrunch described makes it worse at the
+system level - every escalation in application volume buys more automated
+screening, which everyone then has to out-volume.
+
+There was a second, quieter problem: the original bot was welded to the markup
+of the pages it automated. Selectors written for a specific flow break when the
+page changes, and pages change constantly - some of that is ordinary
+redesign, some of it is aimed. A tool built as a collection of site-specific
+scripts is in a maintenance race it cannot win, which is why this wiki's pages
+name no job platforms at all: the durable knowledge is the mechanics that are
+the same everywhere, not any one site's layout.
+
+So the project's answer to the criticism is not a defense of spray. It is
+agreement, followed by a change of direction: the metric that pays the
+applicant is quality per application, and the honest way to build for that is
+an agent that does one application well, with a human reviewing it, rather
+than a cannon that does thousands unread. The project's own README now states
+the rule in one line: do not submit anything a human has not read.
+
+## What it became, and why
+
+Strip the volume out of the original bot and ask what was actually valuable in
+it, and two parts survive. First, a model that can read any form: the LLM never
+cared that the form was a job application, and reading an unfamiliar page is
+precisely what site-specific scripts could not do. Second, a browser that holds
+up under inspection, because the anti-bot layer meets automation everywhere,
+not just on application flows.
+
+Those two parts are simply a general web agent, and that is what AIHawk is
+now: you say what you want in plain language, and it does it in a real browser
+- the pointer moves, keys are pressed, and it declines shortcuts a page could
+detect, like setting form fields from JavaScript. The browser is the part that
+went deepest: a Firefox patched at the C++ level so the browser itself, not a
+wrapper of overrides, looks and behaves like a normal desktop Firefox. That
+engine and its documentation live at
+[invisible_playwright](https://github.com/feder-cr/invisible_playwright), and
+what an agent in this category is at all is covered in
+[what is an AI web agent?](ai-web-agent-explained.md).
+
+There are two ways in, both current. If you already use an assistant that runs
+tools - Claude Code, Claude Desktop, Cursor - you add the browser to it as an
+MCP server, and your assistant brings the model. Otherwise `uvx aihawk ui`
+runs the project's own interface, chat beside a live browser view, with the
+model coming from an OpenRouter key you supply. The code is MIT-licensed as of
+September 2026; everything distributed earlier was and remains AGPL-3.0.
+
+Job applications did not disappear from the picture - this page's siblings
+cover doing them [with Claude](automate-job-applications-with-claude.md),
+[with ChatGPT](automate-job-applications-with-chatgpt.md), and
+[in Python](automate-job-applications-python.md). What disappeared is the
+unattended volume. The agent works through an application in front of you,
+drafts from your real history, and stops where your judgment is required.
+
+## Conclusion
+
+The open-source job application bot was real, enormous, and covered by half
+the tech press in a week, and the sharpest criticism it drew was right:
+volume-first automation hurts the people it claims to help, applicants
+included. What survived the criticism was not the bulk pipeline but the two
+hard parts inside it - a model that reads any form, and a browser built to
+withstand inspection - and those two parts, generalized, are AIHawk today: an
+open-source web agent that treats a job application as one task done well
+rather than thousands done blind.
+
+## Short answers to the questions that lead here
+
+**What was the original AIHawk?** A 2024 open-source Python bot that applied
+to jobs automatically: form filling, generated resumes, customized cover
+letters, unattended submission. It reached about 30,000 stars and was covered
+by 404 Media, TechCrunch, The Verge, Business Insider, Semafor, Wired's
+Italian edition, and Vanity Fair Italy.
+
+**Is the bulk-application bot still what this repository is?** No. The project
+is now a general web agent on a hardened browser. The job-application use case
+remains supported as supervised, one-at-a-time work, not unattended volume.
+
+**Was the "spammers" criticism fair?** Substantially, yes. Spray-and-pray
+replicates errors at scale, reads as generic, and triggers the throttling and
+discounting that hurt the applicant first. The project's answer is quality per
+application, not more spray.
+
+**Why did it stop being job-board-specific?** Site-specific scripts lose the
+maintenance race against changing pages, and a general agent that reads any
+form does not need them. That is also why no page on this wiki names a job
+platform.
+
+**Can I still use it to apply to jobs?** Yes - through an assistant you
+already have via MCP, or through its own interface. See
+[automating job applications with Claude](automate-job-applications-with-claude.md)
+for the concrete setup and the pacing rules that keep it useful.
+
+**What license is it under?** MIT for everything distributed from
+September 2, 2026; earlier distributions were AGPL-3.0 and stay under it.
+
+## Sources
+
+- [404 Media, "I Applied to 2,843 Roles With an AI-Powered Job Application
+  Bot"](https://www.404media.co/i-applied-to-2-843-roles-the-rise-of-ai-powered-job-application-bots/),
+  Jason Koebler, retrieved 2026-09-03, for the first-hand account of the
+  original bot's behavior and volume.
+- [TechCrunch, "Someone claims to have used AI to apply to 2,843
+  jobs"](https://techcrunch.com/2024/10/10/a-reporter-used-ai-to-apply-to-2843-jobs/),
+  Kyle Wiggers, October 10 2024, retrieved 2026-09-03, for the 42 percent
+  AI-screening figure and the automation-loop framing.
+- The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), retrieved
+  2026-09-03, for the featured-coverage list, the current two ways to run the
+  agent, the human-review rule, and the licensing dates.
+- The Verge's October 10 2024 piece is linked from that README; the site
+  blocks automated retrieval, so its framing is cited from the headline as
+  linked there.
+
+**See also:** the
+[job application automation hub](guides-job-application-automation.md) for the
+practical guides this history sits behind,
+[automating job applications in Python](automate-job-applications-python.md)
+for the road the original bot walked,
+[what is an AI web agent?](ai-web-agent-explained.md) for the category it
+moved into, and
+[why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md) for
+the layer that made the browser the hard part.
+
+---
+
+*Written by the maintainer of [AIHawk](https://github.com/feder-cr/AIHawk).
+The 2,843 applications in those headlines were sent by the old bot; the point
+of the new agent is that nobody should ever send that many again.*


### PR DESCRIPTION
Option 1 was headed "Claude Code, Claude Desktop or Cursor" and then gave a single command that only the first of the three can run. A Cursor reader arrived at a `claude mcp add` line with nothing telling them it was not for them.

Three commands now, verified against each vendor's own documentation: Claude Code, Codex and Gemini CLI. They do not agree on syntax - Gemini takes no `--` separator where the other two require it - so each is written out rather than described.

The heading no longer lists products, because a list of products goes stale: it asks the question a reader can answer, whether they already use an assistant that can run tools. The six clients that take a config file are named, pointing at the server's README where each file is written out, because it is a different file with a different top-level key for several of them.