### PR TITLE
The wiki catches up with 0.3.0, and content gates make sure it stays caught up

### DIFF
--- a/.github/workflows/content-gates.yml
+++ b/.github/workflows/content-gates.yml
@@ -1,0 +1,25 @@
+name: content-gates
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # The gate proves itself on known-bad input before it judges anything.
+      - name: Gate selftest
+        run: python scripts/check_content.py --selftest
+      - name: Content gates
+        run: python scripts/check_content.py
+      - name: Wiki renders end to end
+        run: |
+          python scripts/build_wiki.py docs /tmp/wiki-out
+          test -f /tmp/wiki-out/_Sidebar.md
+          test -f /tmp/wiki-out/Home.md

--- a/docs/agent-retry-loops-rate-limits.md
+++ b/docs/agent-retry-loops-rate-limits.md
@@ -90,7 +90,8 @@ again. The half that no product can supply is how often you run it.
 - **Mind the exit, not the browser count.** The unit a counter sees is requests per
   address and per account. Several agents behind one exit IP, each politely pacing
   itself, are one very busy client to the site.
-- **If you script it, budget it.** `aihawk do` makes it easy to put an agent in a
+- **If you script it, budget it.** The assistant one-shot (`claude -p` with
+  AIHawk's browser attached over MCP) makes it easy to put an agent in a
   script or cron job, which makes it easy to build an accidental refresh storm. Give
   the script a budget and backoff, because that is the layer that owns the schedule:
 
@@ -99,7 +100,7 @@ import subprocess, time
 
 def run_with_backoff(task, *, max_attempts=3):
     for attempt in range(max_attempts):
-        r = subprocess.run(["uvx", "aihawk", "do", task],
+        r = subprocess.run(["claude", "-p", task],
                            capture_output=True, text=True)
         if r.returncode == 0:
             return r.stdout
@@ -155,8 +156,8 @@ re-issuing the same instruction immediately is still a retry loop, just with you
 it.
 
 **Where should backoff live?** In whatever decides when tasks run: your habits at
-the prompt, or the script wrapping `aihawk do`. No browser setting paces a loop that
-was told to try until it succeeds.
+the prompt, or the script wrapping the one-shot run. No browser setting paces a loop
+that was told to try until it succeeds.
 
 **Is a per-account quota a fingerprint problem?** No. A quota is counted against the
 account, not the browser, so a better fingerprint does nothing for it. Budget the

--- a/docs/ai-agent-download-invoices.md
+++ b/docs/ai-agent-download-invoices.md
@@ -100,13 +100,16 @@ What runs well today, per portal:
    command line.
 
    ```
-   23 7 3 * *  . $HOME/.hawk-env && uvx aihawk do "Go to <portal URL>. Find \
-   the most recent invoice. Reply with CSV only: number,date,amount,due_date, \
-   one line, no commentary." --seed 11 --profile-dir $HOME/.hawk-invoices \
-   >> $HOME/invoices/ledger.csv
+   23 7 3 * *  claude -p "Go to <portal URL>. Find the most recent invoice. \
+   Reply with CSV only: number,date,amount,due_date, one line, no \
+   commentary." >> $HOME/invoices/ledger.csv
    ```
 
-   That is cron on the 3rd of each month, at an off-round minute for the
+   That is the assistant one-shot with AIHawk's browser attached over MCP
+   (since aihawk 0.3.0; the one-time setup, with `STEALTHFOX_SEED` and
+   `STEALTHFOX_PROFILE_DIR` on the registration, is on
+   [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md)), in cron
+   on the 3rd of each month, at an off-round minute for the
    reasons the monitoring page gives. One portal per line, different seeds if
    you want different identities per supplier.
 

--- a/docs/ai-agent-timing-signal.md
+++ b/docs/ai-agent-timing-signal.md
@@ -101,7 +101,7 @@ where the wins are:
   session ten seconds later confirms the verdict.
 
 If you are building your own harness above an agent loop - executing its actions
-yourself, or wrapping `aihawk do` in a script - you own the timing, and then the rule
+yourself, or wrapping a one-shot assistant run in a script - you own the timing, and then the rule
 is: vary it, and make it depend on the step. A uniform delay is its own tell. A
 `sleep(1.0)` between every action just moves the cluster from "instant" to "exactly
 one second", and a tight cluster at one second is as machine-regular as a tight

--- a/docs/ai-agent-to-test-website.md
+++ b/docs/ai-agent-to-test-website.md
@@ -36,13 +36,15 @@ Run it through an editor client - [Cursor](running-aihawk-with-cursor.md) or
 code open - or from the terminal:
 
 ```bash
-uvx aihawk do "Open http://localhost:3000 and try to register a new user
+claude -p "Open http://localhost:3000 and try to register a new user
 with placeholder data. Report every field, every validation message, and
-whether registration succeeded." --headed
+whether registration succeeded."
 ```
 
-`--headed` gives you a window to watch, which for testing is worth having:
-seeing the agent hesitate on your form is itself a finding. Two properties of
+(the one-shot assistant path, since aihawk 0.3.0). If you would rather watch,
+`uvx aihawk ui` runs the same task with the live page beside the chat, which
+for testing is worth having: seeing the agent hesitate on your form is itself
+a finding. Two properties of
 this browser matter specifically for testing. It fills forms through real key
 presses and clicks, refusing script injection, so your input handlers,
 keystroke validation and change events fire the way they fire for people. And

--- a/docs/ai-agent-web-research.md
+++ b/docs/ai-agent-web-research.md
@@ -83,11 +83,14 @@ conversation holds the accumulating picture, and you can steer mid-walk. Or
 scripted, one question per run:
 
 ```bash
-uvx aihawk do "Go to https://books.toscrape.com/. Walk the first three pages
+claude -p "Go to https://books.toscrape.com/. Walk the first three pages
 of the catalog and report: how many books are priced above forty pounds, and
 the three most common price bands you observe. Ground every number in what
 the pages show; do not estimate."
 ```
+
+(The one-shot assistant path, with AIHawk's browser attached over MCP - since
+aihawk 0.3.0 the aihawk command itself is interactive-only.)
 
 Prompt habits that separate usable research from confident noise:
 
@@ -140,7 +143,7 @@ interaction-gated content, or walk an archive in order. Different machine.
 
 **Can AIHawk do deep research?** It does the browser half well: driven
 reading of hard sources, through an MCP client where your assistant
-synthesizes, or via `aihawk do` for scripted questions. It does not fan out
+synthesizes, interactively or as scripted one-shots. It does not fan out
 across twenty sources in parallel, and this page does not pretend otherwise.
 
 **How do I stop a research agent from making things up?** Demand quotes tied

--- a/docs/ai-apartment-hunting.md
+++ b/docs/ai-apartment-hunting.md
@@ -1,6 +1,6 @@
 ---
 title: "Using an AI agent to hunt for apartments"
-description: "What an agent genuinely does for an apartment search - read listings at volume, compare them against your criteria, watch for new ones - the workflow with uvx aihawk do, and the boundaries that keep the search from becoming scraping."
+description: "What an agent genuinely does for an apartment search - read listings at volume, compare them against your criteria, watch for new ones - the concrete workflow, and the boundaries that keep the search from becoming scraping."
 parent: "Using the Agent"
 nav_order: 10
 ---
@@ -81,18 +81,20 @@ minutes is a bill and a signature.
 
 ## The workflow, concretely
 
-AIHawk's headless entrypoint is built for repeatable single instructions
-(the README files it under "for scripts and cron"). A worked example, with
-the portal URL being whatever search-results page you have already set up
-by hand:
+The repeatable single instruction runs through your assistant's one-shot
+mode with AIHawk's browser attached over MCP (since aihawk 0.3.0 the aihawk
+command itself is interactive-only; the one-time MCP setup is on
+[the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md)). A worked
+example, with the portal URL being whatever search-results page you have
+already set up by hand:
 
 ```bash
-uvx aihawk do "Go to <your saved search URL>. Read the first 15 listings.
+claude -p "Go to <your saved search URL>. Read the first 15 listings.
 My criteria: max 1600/month, 2 rooms, pets allowed, available within 60
 days, no ground floor without outdoor space. For each listing output one
 line: title, price, rooms, floor, verdict FIT/NEAR/NO with the deciding
 reason. Read the listing text, do not trust the summary card. If a fact is
-not stated, write UNKNOWN, do not guess." --profile-dir ~/.hawk-flat
+not stated, write UNKNOWN, do not guess."
 ```
 
 The prompt carries the craft, and three parts of it matter more than the
@@ -104,9 +106,9 @@ that fills gaps optimistically is worse than none, because a wrong "pets
 allowed" costs you a viewing trip.
 
 For the recurring version, put that command in cron or Task Scheduler,
-redirect stdout to a dated file, and keep `--profile-dir` stable so the
-session persists between runs. Once a day, or twice in a genuinely fast
-market. For interactive sessions - "open the third FIT and tell me what
+redirect stdout to a dated file, and set `STEALTHFOX_PROFILE_DIR` on the MCP
+registration so the session persists between runs. Once a day, or twice in a
+genuinely fast market. For interactive sessions - "open the third FIT and tell me what
 the photos show about the kitchen" - `uvx aihawk ui` gives you the same
 agent beside a live browser view, and if you already use Claude Code or
 Claude Desktop, the same browser attaches to your assistant instead
@@ -172,8 +174,9 @@ human reviews and submits. See
 All retrieved 2026-09-03.
 
 - The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), for the
-  `uvx aihawk do` / `uvx aihawk ui` commands, the `--profile-dir` and
-  proxy behavior, and the scripts-and-cron framing.
+  `uvx aihawk ui` command, the MCP path for assistants, and the profile and
+  proxy behavior (updated for aihawk 0.3.0, which removed the `do`
+  subcommand).
 - [Rightmove's terms-of-use page](https://www.rightmove.co.uk/this-site/terms-of-use.html),
   for its stated prohibition on scraping its content, cited as the
   concrete example that listing portals restrict automated access.

--- a/docs/aihawk-review.md
+++ b/docs/aihawk-review.md
@@ -40,10 +40,11 @@ There are two ways to run it, and they share one browser:
   registers the browser as an MCP server in Claude Code, Claude Desktop or
   Cursor, and your assistant's model does the thinking.
 - **Standalone.** `uvx aihawk ui` serves a local page with chat on the
-  left and the live browser on the right; `uvx aihawk do "..."` runs one
-  task headlessly and prints the answer. Both take an
-  [OpenRouter](https://openrouter.ai) key, defaulting to `z-ai/glm-4.6`,
-  and both accept `--model` for anything OpenRouter serves.
+  left and the live browser on the right. It takes an
+  [OpenRouter](https://openrouter.ai) key, defaults to `z-ai/glm-4.6`,
+  and accepts `--model` for anything OpenRouter serves. Since 0.3.0 this
+  is the only aihawk entrypoint; headless one-shots run through the
+  assistant path above.
 
 The differentiating bet is the browser itself. Instead of driving a stock
 automation build over an automation protocol, AIHawk drives a Firefox
@@ -69,9 +70,10 @@ fails if that stops being true.
 
 **Operational features match real use.** `--proxy` takes HTTP or SOCKS5
 and the browser's timezone, locale and egress follow it; `--profile-dir`
-persists logins between runs; `--headed` shows the window; `do` slots
-into scripts and cron. The pieces you need to run it repeatedly are
-there, not left as exercises.
+persists logins between runs; `--headed` shows the window; and on the
+assistant path the same knobs ride the MCP registration as
+`STEALTHFOX_*` variables, which is what scripts and cron want. The
+pieces you need to run it repeatedly are there, not left as exercises.
 
 **It is genuinely open.** MIT license, the engine and its wrapper
 published as installable packages, and the agent code in this repository

--- a/docs/browser-problem-or-model-problem.md
+++ b/docs/browser-problem-or-model-problem.md
@@ -88,9 +88,9 @@ fine:
 
 ## The procedure
 
-1. **Read the failed transcript first.** Both the interface and `aihawk do`
-   ran the same loop; the interface shows each step, what was called, and what
-   came back. Most failures are legible there, and the split is often obvious:
+1. **Read the failed transcript first.** The interface shows each step, what
+   was called, and what came back; on the assistant path the same record is
+   your assistant's own conversation. Most failures are legible there, and the split is often obvious:
    a block page in a tool result is browser-side, a wrong click on a healthy
    page is model-side.
 2. **Replay the failing step in placeholder mode.** Restart the interface with

--- a/docs/how-to-extract-data-to-csv-with-an-ai-agent.md
+++ b/docs/how-to-extract-data-to-csv-with-an-ai-agent.md
@@ -22,8 +22,8 @@ on a page you serve yourself; the mechanics transfer, the risk does not.
 
 ## What you actually say
 
-A working instruction, typed into the AIHawk interface or passed to
-`uvx aihawk do`:
+A working instruction, typed into the AIHawk interface or handed to your
+assistant with AIHawk's browser attached:
 
 > Go to https://books.toscrape.com/. For each book on the first two pages,
 > extract the title and the price. Reply with CSV only: a header line
@@ -44,8 +44,9 @@ Four choices in there do most of the work:
 One mechanical fact, early: the agent has no file-writing
 tool. The browser tools navigate, read, click and type; the CSV materializes as
 the model's final answer, nothing else. From the interface you copy it out of
-the chat; from the command line, `uvx aihawk do "..." > books.csv` works
-because the answer is printed to stdout.
+the chat; from the command line, `claude -p "..." > books.csv` works (the
+one-shot assistant path, since aihawk 0.3.0) because the answer is printed
+to stdout.
 
 ## What happens underneath
 
@@ -186,7 +187,7 @@ All retrieved 2026-09-03.
   source in this repository: the loop, the 25-turn default, the 8,000-character
   tool-result clip and the reply ceiling are in
   [`src/aihawk/agent.py`](https://github.com/feder-cr/AIHawk/blob/main/src/aihawk/agent.py),
-  and the stdout behavior of `aihawk do` in
+  and the CLI surface in
   [`src/aihawk/cli.py`](https://github.com/feder-cr/AIHawk/blob/main/src/aihawk/cli.py).
 
 A complete worked run of this task shape, with the real transcript, the two

--- a/docs/how-to-monitor-a-page-with-an-ai-agent.md
+++ b/docs/how-to-monitor-a-page-with-an-ai-agent.md
@@ -67,20 +67,27 @@ session closed, cents per check on the default model and roughly a minute of
 wall clock. Daily is comfortable; every five minutes is a bill and, as covered
 below, a signature.
 
-## Scheduling it: the CLI exists, and this is what it does
+## Scheduling it: the one-shot shape, as of aihawk 0.3.0
 
-AIHawk has a headless entrypoint built for exactly this, and its README files
-it under "for scripts and cron":
+Since 0.3.0 AIHawk itself is interactive-only (`uvx aihawk ui`); the old `do`
+subcommand is gone. The one-shot shape did not disappear, it moved: your
+assistant's CLI runs a single instruction non-interactively, with AIHawk's
+browser attached over MCP. One-time setup, then the check itself:
 
 ```bash
-uvx aihawk do "Go to <your page>. Report the current title and price of the
-first listed item, one line, no commentary." --seed 7 --profile-dir ~/.hawk-mon
+claude mcp add -s user stealth -e STEALTHFOX_SEED=7 \
+  -e STEALTHFOX_PROFILE_DIR=$HOME/.hawk-mon -- uvx invisible-playwright-mcp
+
+claude -p "Go to <your page>. Report the current title and price of the
+first listed item, one line, no commentary."
 ```
 
-`do` runs one instruction in the stealth browser, prints the model's answer to
-stdout, and exits; the browser is opened for the run and closed after. That
-shape composes with cron, systemd timers, or Windows Task Scheduler the way any
-command does: redirect stdout to a dated file and you have a log of answers.
+`claude -p` runs one instruction, prints the answer to stdout, and exits; the
+browser session opens for the run and closes after. That shape composes with
+cron, systemd timers, or Windows Task Scheduler the way any command does:
+redirect stdout to a dated file and you have a log of answers. The seed and
+the persistent profile now live on the server registration (the `-e` lines)
+instead of per-run flags, which is where a scheduled job wants them anyway.
 
 Three flags matter for a recurring check:
 
@@ -98,12 +105,13 @@ Three flags matter for a recurring check:
 A real crontab line, deliberately not on the hour:
 
 ```
-17 8 * * *  . $HOME/.hawk-env && uvx aihawk do "..." >> $HOME/hawk-mon/$(date +\%F).txt 2>&1
+17 8 * * *  claude -p "..." >> $HOME/hawk-mon/$(date +\%F).txt 2>&1
 ```
 
-with the key exported from `~/.hawk-env`, readable only by you. The interface
-(`uvx aihawk ui`) has no scheduler; the recurring path is `do` plus whatever
-scheduler your system already has.
+No API key in the crontab: on the assistant path the model comes from the
+assistant's own login, and the browser needs no key at all. The interface
+(`uvx aihawk ui`) has no scheduler; the recurring path is the assistant
+one-shot plus whatever scheduler your system already has.
 
 ## What to store between runs
 
@@ -115,11 +123,11 @@ which means the memory of the monitor is yours to keep. Two files do it:
   feeds the last run's output back in:
 
   ```bash
-  uvx aihawk do "Here is what this page said on the last check:
+  claude -p "Here is what this page said on the last check:
   $(cat ~/hawk-mon/last.txt)
   Now go to <your page> and report only meaningful differences from that,
   or the exact word NOCHANGE if nothing that matters changed." \
-    --seed 7 --profile-dir ~/.hawk-mon | tee ~/hawk-mon/last.txt
+    | tee ~/hawk-mon/last.txt
   ```
 
   Asking for a sentinel word like `NOCHANGE` makes the no-op case scriptable:
@@ -165,7 +173,8 @@ remember that with `--seed` unset, every run was a different browser.
 ## Short answers to the questions that lead here
 
 **Can an AI agent monitor a website for changes?** Yes, mechanically: schedule
-`uvx aihawk do` with a prompt that carries the previous state and asks for
+a one-shot assistant run (`claude -p`, with AIHawk's browser attached over
+MCP) with a prompt that carries the previous state and asks for
 meaningful differences. Whether it should depends on the question: byte-level
 "did it change" belongs to a diff tool; "does the change matter" is the
 agent's case.
@@ -176,10 +185,10 @@ the check requires reading: meaningful-change questions, prose thresholds,
 summarized deltas.
 
 **How do I schedule AIHawk to check a page every day?** Cron (or any
-scheduler) plus `uvx aihawk do "..."` with `OPENROUTER_API_KEY` in the
-environment, `--seed` for a stable identity, `--profile-dir` for a persistent
-profile, and stdout redirected somewhere dated. There is no built-in scheduler;
-the CLI is the building block on purpose.
+scheduler) plus `claude -p "..."` with the stealth MCP server registered once,
+`STEALTHFOX_SEED` for a stable identity, `STEALTHFOX_PROFILE_DIR` for a
+persistent profile, and stdout redirected somewhere dated. There is no
+built-in scheduler; the one-shot run is the building block on purpose.
 
 **What does each check cost?** A browser session plus a short model
 conversation: cents on the default model, roughly a minute of wall clock. The
@@ -204,9 +213,11 @@ All retrieved 2026-09-03.
   the self-hosted diff-based monitor referenced as the plain-tool baseline,
   including its scheduling and notification features.
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README and
-  source in this repository: the `do` command, its "scripts and cron" framing,
-  the key-in-environment advice, and the one-shot open-run-close behavior in
-  [`src/aihawk/runner.py`](https://github.com/feder-cr/AIHawk/blob/main/src/aihawk/runner.py).
+  source in this repository: the interface entrypoint and the
+  open-run-close session behavior in
+  [`src/aihawk/runner.py`](https://github.com/feder-cr/AIHawk/blob/main/src/aihawk/runner.py),
+  and [invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp)
+  for the `STEALTHFOX_*` variables the scheduled path rides on.
 
 **See also:** [extracting data to a CSV](how-to-extract-data-to-csv-with-an-ai-agent.md),
 [agent retry loops and rate limits](agent-retry-loops-rate-limits.md),

--- a/docs/using-aihawk-without-an-api-key.md
+++ b/docs/using-aihawk-without-an-api-key.md
@@ -16,9 +16,11 @@ plainly: `model    none: literal commands only.` Everything else is the
 product - the same browser engine, the same tools, the same live view - which
 is exactly what makes the mode useful rather than decorative.
 
-The asymmetry with the other command is deliberate: `aihawk do` refuses to run
-without a key, because its whole job is a model producing an answer. The
-interface runs, because most of what it shows you does not need one.
+The interface runs keyless because most of what it shows you does not need a
+model. Producing answers is the model's half of the product - and if you want
+that half without buying a key, the assistant path covers it: since aihawk
+0.3.0 the browser attaches to Claude Code, Codex or Gemini CLI over MCP, and
+the assistant brings its own model.
 
 ## What actually runs
 
@@ -84,8 +86,9 @@ The boundary is the model, and everything on the model's side of it is absent:
   or notice that a click failed - noticing is a model behavior.
 - **No answers.** It shows you raw page text; it will not extract, summarize,
   compare, or conclude. Producing an answer is the paid half of the product.
-- **No `aihawk do`.** The headless command exists to print a model's answer,
-  so keyless it exits with the error naming the two ways to supply a key.
+- **No one-shot runs.** Since 0.3.0 aihawk has no headless subcommand at all;
+  the scripted path runs through an assistant CLI with the browser attached
+  over MCP, and there the key question moves to the assistant, not to aihawk.
 
 One cost survives keylessness: the engine itself. The browser, roughly a
 quarter of a gigabyte, downloads on the first command that needs a page, even

--- a/docs/website-data-to-google-sheets-ai-agent.md
+++ b/docs/website-data-to-google-sheets-ai-agent.md
@@ -80,10 +80,14 @@ columns, saying "CSV only, no commentary", bounding the scope. The one-line
 version:
 
 ```bash
-uvx aihawk do "Go to https://books.toscrape.com/. For each book on the first
+claude -p "Go to https://books.toscrape.com/. For each book on the first
 page, extract the title and the price. Reply with CSV only: header line
 title,price, one line per book, no commentary." > books.csv
 ```
+
+(That is the assistant CLI in one-shot mode with AIHawk's browser attached
+over MCP; since aihawk 0.3.0 that is the scripted path, and the one-time
+setup is on [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md).)
 
 Second, the import, which is Google's half and needs no agent:
 
@@ -94,10 +98,9 @@ Second, the import, which is Google's half and needs no agent:
   host, a paste service with raw URLs, your own server - one cell of
   `IMPORTDATA("https://your-host/books.csv")` makes the sheet re-read it.
   Combine that with a scheduled extraction and the sheet updates itself: cron
-  runs `aihawk do` and drops the file, `IMPORTDATA` picks it up. The
-  scheduling half, including the flags that keep a recurring run stable and
-  where the API key should live, is on
-  [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md); it
+  runs the one-shot and drops the file, `IMPORTDATA` picks it up. The
+  scheduling half, including the settings that keep a recurring run stable, is
+  on [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md); it
   transfers unchanged.
 
 Resist the urge to have the agent drive the Google Sheets web interface and
@@ -148,7 +151,7 @@ page, served HTML, table or list shape. Free and self-refreshing beats cents
 and a model every time the mechanical tool can reach.
 
 **How do I make the sheet update on a schedule?** Schedule the extraction
-(cron plus `uvx aihawk do`, per [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md)),
+(cron plus a one-shot assistant run, per [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md)),
 write the CSV to a web-served location, and point `IMPORTDATA` at it. The
 sheet re-fetches; nothing touches the sheet directly.
 
@@ -175,7 +178,7 @@ All retrieved 2026-09-03.
   the template class recommended for recurring mechanical work.
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README and
   source in this repository, for the no-file-tool, answer-on-stdout
-  architecture of `aihawk do`.
+  architecture of the agent loop.
 
 **See also:** [extracting data to a CSV](how-to-extract-data-to-csv-with-an-ai-agent.md),
 [monitoring a page for changes](how-to-monitor-a-page-with-an-ai-agent.md),

--- a/docs/which-model-to-use-with-aihawk.md
+++ b/docs/which-model-to-use-with-aihawk.md
@@ -19,8 +19,8 @@ kind of work, and that has a less obvious answer than the price sheet suggests.
 
 ## How AIHawk actually spends the model
 
-Worth knowing before choosing, because the loop's shape decides the bill. Both
-`aihawk do` and the interface run the same loop: the model receives the task and
+Worth knowing before choosing, because the loop's shape decides the bill. The
+interface runs one fixed loop: the model receives the task and
 the browser tools, replies with one thought and usually one tool call, the tool
 runs, the result goes into the transcript, and the model is called again. In the
 current source the loop is capped at 25 turns per instruction, each reply is

--- a/scripts/check_content.py
+++ b/scripts/check_content.py
@@ -1,0 +1,238 @@
+"""Content gates for this repository's published surface.
+
+Four checks over docs/, articles/, assets/ and the README, each born from a
+real incident rather than a hypothetical:
+
+  1. Banned-topic scan. Pages on retired topics must not come back; a stale
+     branch once squash-merged five of them straight onto main. Historical
+     one-line mentions are pinned in an explicit allowance table.
+  2. Dash and invisible-Unicode scan. No em/en dashes, and none of the
+     invisible or formatting codepoints that text pipelines can smuggle in
+     (zero-width, bidi controls, variation selectors, tag block).
+  3. CLI-surface scan. Every `aihawk <subcommand>` a page teaches must exist
+     in src/aihawk/cli.py. A release once removed a subcommand while 13 wiki
+     pages still taught it.
+  4. Internal links. Every `](page.md)` in docs/ must point at a page that
+     exists, and image assets must carry no metadata chunks.
+
+Run: python scripts/check_content.py            (from the repo root)
+     python scripts/check_content.py --selftest (prove the gate on known-bad)
+
+Exit 0 clean, 1 findings, 2 usage error.
+"""
+
+import argparse
+import re
+import struct
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+BANNED_TERMS = [
+    "job application", "job-application", "job applications",
+    "apply to jobs", "job board", "cover letter", "job hunt", "job search",
+]
+
+# Path suffix -> max total banned-term hits allowed there, with the reason.
+# A historical one-liner is allowed; a page ABOUT the topic is not.
+ALLOWED_MENTIONS = {
+    "docs/ai-browser-agent-open-source.md": 1,   # one line of project history
+    "docs/openai-operator-open-source.md": 1,    # one line of project history
+    "README.md": 1,                              # press-coverage link
+}
+
+INVISIBLE = {
+    0x00A0, 0x00AD, 0x034F, 0x061C, 0x115F, 0x1160, 0x17B4, 0x17B5, 0x180E,
+    0x200B, 0x200C, 0x200D, 0x200E, 0x200F, 0x202F, 0x205F, 0x2060, 0x2061,
+    0x2062, 0x2063, 0x2064, 0x3164, 0xFEFF, 0xFFA0, 0xFFF9, 0xFFFA, 0xFFFB,
+}
+INVISIBLE_RANGES = [(0x2000, 0x200A), (0x202A, 0x202E), (0x2066, 0x2069),
+                    (0xFE00, 0xFE0F), (0xE0000, 0xE007F), (0xE0100, 0xE01EF)]
+
+PNG_OK = {b"IHDR", b"PLTE", b"IDAT", b"IEND", b"tRNS", b"gAMA", b"cHRM",
+          b"sRGB", b"iCCP", b"sBIT", b"bKGD", b"hIST", b"pHYs", b"sPLT",
+          b"tIME", b"acTL", b"fcTL", b"fdAT"}
+
+# `aihawk <token>` counts as a command reference only in code-shaped contexts:
+# after `uvx `, inside backticks, or in a quoted argv list.
+CMD_RE = re.compile(r"(?:uvx\s+|[\"'`])aihawk[\"',\s]+([a-z][a-z-]*)")
+
+
+def cli_commands(cli_path):
+    """Subcommands actually declared in cli.py (click's @main.command())."""
+    src = cli_path.read_text(encoding="utf-8")
+    cmds = set()
+    # Non-greedy across the option decorators (which span multiple lines)
+    # to the def that carries the command's name.
+    for m in re.finditer(r"@main\.command\(\)[\s\S]*?def\s+(\w+)", src):
+        cmds.add(m.group(1).replace("_", "-"))
+    return cmds
+
+
+def content_files(root):
+    files = []
+    for base in ("docs", "articles"):
+        files.extend(sorted((root / base).rglob("*.md")))
+    if (root / "README.md").exists():
+        files.append(root / "README.md")
+    return files
+
+
+def check_tree(root):
+    findings = []
+    valid = cli_commands(root / "src" / "aihawk" / "cli.py") \
+        if (root / "src" / "aihawk" / "cli.py").exists() else None
+
+    docs_names = {f.stem for f in (root / "docs").glob("*.md")} | {"Home"}
+
+    for f in content_files(root):
+        rel = f.relative_to(root).as_posix()
+        raw = f.read_bytes()
+        text = raw.decode("utf-8", errors="replace")
+        low = text.lower()
+
+        hits = sum(low.count(t) for t in BANNED_TERMS)
+        allowed = ALLOWED_MENTIONS.get(rel, 0)
+        if hits > allowed:
+            findings.append("%s: %d banned-topic mention(s), %d allowed"
+                            % (rel, hits, allowed))
+
+        for tell, name in ((b"\xe2\x80\x94", "em-dash"),
+                           (b"\xe2\x80\x93", "en-dash")):
+            if tell in raw:
+                findings.append("%s: %s x%d" % (rel, name, raw.count(tell)))
+
+        for ch in set(text):
+            cp = ord(ch)
+            if cp in INVISIBLE or any(lo <= cp <= hi
+                                      for lo, hi in INVISIBLE_RANGES):
+                findings.append("%s: invisible codepoint U+%04X" % (rel, cp))
+
+        if valid is not None:
+            for m in CMD_RE.finditer(text):
+                token = m.group(1)
+                if token not in valid:
+                    findings.append(
+                        "%s: teaches `aihawk %s`, which cli.py does not "
+                        "define (valid: %s)"
+                        % (rel, token, ", ".join(sorted(valid))))
+
+        if f.parent == root / "docs":
+            for m in re.finditer(r"\]\(([^)#\s]+?)\.md(#[^)]*)?\)", text):
+                target = m.group(1)
+                if "/" not in target and ":" not in target \
+                        and target not in docs_names:
+                    findings.append("%s: dead link -> %s.md" % (rel, target))
+
+    for img in sorted((root / "assets").glob("*.png")) if (root / "assets").exists() else []:
+        raw = img.read_bytes()
+        if raw[:8] != b"\x89PNG\r\n\x1a\n":
+            findings.append("%s: not a PNG" % img.name)
+            continue
+        off = 8
+        while off + 8 <= len(raw):
+            (length,) = struct.unpack(">I", raw[off:off + 4])
+            ctype = raw[off + 4:off + 8]
+            if ctype not in PNG_OK:
+                findings.append("assets/%s: metadata chunk %s"
+                                % (img.name, ctype.decode("latin1")))
+            if ctype == b"IEND":
+                break
+            off += 8 + length + 4
+
+    return findings
+
+
+def selftest():
+    import tempfile
+    failures = []
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        (root / "docs").mkdir()
+        (root / "articles").mkdir()
+        (root / "assets").mkdir()
+        (root / "src" / "aihawk").mkdir(parents=True)
+        # Mirrors the real file's shape: multi-line option decorators
+        # between the command decorator and the def.
+        (root / "src" / "aihawk" / "cli.py").write_bytes(
+            b"@main.command()\n"
+            b'@click.option("--model", default=None,\n'
+            b'              help="Model id.")\n'
+            b"def ui(model):\n    pass\n")
+
+        bad = {
+            "banned topic": ("docs/spam.md",
+                             b"How to automate your job application flow\n"),
+            "em-dash": ("docs/dash.md", "text — more\n".encode()),
+            "invisible codepoint": ("docs/zw.md",
+                                    "wor​d\n".encode("utf-8")),
+            "removed command": ("docs/old.md",
+                                b'run `uvx aihawk do "task"` daily\n'),
+            "argv-list command": ("docs/argv.md",
+                                  b'subprocess.run(["uvx", "aihawk", "do"])\n'),
+            "dead link": ("docs/link.md", b"see [x](missing-page.md)\n"),
+        }
+        for label, (rel, content) in bad.items():
+            p = root / rel
+            p.write_bytes(content)
+            if not check_tree(root):
+                failures.append("mutation not seen: " + label)
+            p.unlink()
+
+        import zlib
+        def chunk(ctype, data):
+            return (struct.pack(">I", len(data)) + ctype + data +
+                    struct.pack(">I", zlib.crc32(ctype + data) & 0xFFFFFFFF))
+        png = (b"\x89PNG\r\n\x1a\n"
+               + chunk(b"IHDR", struct.pack(">IIBBBBB", 1, 1, 8, 0, 0, 0, 0))
+               + chunk(b"iTXt", b"XML:com.adobe.xmp\x00\x00\x00\x00\x00x")
+               + chunk(b"IDAT", zlib.compress(b"\x00\x00"))
+               + chunk(b"IEND", b""))
+        (root / "assets" / "meta.png").write_bytes(png)
+        if not check_tree(root):
+            failures.append("mutation not seen: png metadata chunk")
+        (root / "assets" / "meta.png").unlink()
+
+        good = {
+            "clean page": ("docs/fine.md",
+                           b"plain page, `uvx aihawk ui`, a - dash\n"),
+            "allowed history line": ("docs/ai-browser-agent-open-source.md",
+                                     b"it began as a job-application bot\n"),
+            "prose verb": ("docs/verb.md",
+                           b"what can AIHawk do for research\n"),
+        }
+        for label, (rel, content) in good.items():
+            p = root / rel
+            p.write_bytes(content)
+            got = check_tree(root)
+            if got:
+                failures.append("false positive on %s: %s" % (label, got))
+            p.unlink()
+
+    if failures:
+        for f in failures:
+            print("SELFTEST FAIL: " + f)
+        return 1
+    print("selftest: 7 mutations caught, 3 clean cases pass")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--selftest", action="store_true")
+    args = ap.parse_args()
+    if args.selftest:
+        sys.exit(selftest())
+    findings = check_tree(ROOT)
+    if findings:
+        for line in findings:
+            print("[content] " + line)
+        print("[content] %d finding(s)" % len(findings))
+        sys.exit(1)
+    print("[content] clean")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Two coupled changes, shipped together so the new gate's first run proves green on the tree it will guard.

**Commit 1 - the 0.3.0 alignment.** Release 0.3.0 removed the `do` subcommand; thirteen wiki pages (27 references) still taught it, so every copy-pasted example errored from the moment 0.3.0 hit the index. Each page now teaches the two entrypoints that exist: `uvx aihawk ui` interactively, and the assistant CLI in one-shot mode (`claude -p`) with the browser attached over MCP - where the seed, profile and proxy ride the server registration as `STEALTHFOX_*` variables, which is what cron wants anyway. Version-bound claims are stamped "since aihawk 0.3.0".

**Commit 2 - content gates in CI.** `scripts/check_content.py`, wired as the `gate` job on every PR and push to main: banned-topic scan with a pinned allowance for the two historical one-liners, em/en-dash and invisible-Unicode scan, a CLI-surface check that parses `src/aihawk/cli.py` and refuses any page teaching a subcommand that does not exist, dead-link detection in docs/, and a PNG metadata-chunk check on assets/. The gate runs its own selftest (7 known-bad mutations, 3 clean cases) before judging anything, on every CI run. Both of this week's incidents - five pages riding back in on a stale branch, and the wiki teaching a removed command - would have turned this job red.

## Test plan

- [x] `check_content.py --selftest`: 7 mutations caught, 3 clean cases pass (including the multi-line-decorator shape of the real cli.py, which the first selftest missed and this one guards)
- [x] `check_content.py` on this tree: clean; CLI extraction from the real cli.py yields exactly `{ui}`
- [x] Zero `aihawk do` residue in prose, backticks and argv-list form; dash and invisible-Unicode scans clean
- [x] build_wiki renders 50 pages + sidebar; all internal links resolve

Generated with Claude Code
