### PR TITLE
The scheduled flows move to the library, and every published block was executed first

### DIFF
--- a/docs/agent-retry-loops-rate-limits.md
+++ b/docs/agent-retry-loops-rate-limits.md
@@ -90,17 +90,19 @@ again. The half that no product can supply is how often you run it.
 - **Mind the exit, not the browser count.** The unit a counter sees is requests per
   address and per account. Several agents behind one exit IP, each politely pacing
   itself, are one very busy client to the site.
-- **If you script it, budget it.** The assistant one-shot (`claude -p` with
-  AIHawk's browser attached over MCP) makes it easy to put an agent in a
-  script or cron job, which makes it easy to build an accidental refresh storm. Give
+- **If you script it, budget it.** A scheduled check on the engine (the
+  script pattern on
+  [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md))
+  makes it easy to put a browser run in cron, which makes it easy to build an
+  accidental refresh storm. Give
   the script a budget and backoff, because that is the layer that owns the schedule:
 
 ```python
 import subprocess, time
 
-def run_with_backoff(task, *, max_attempts=3):
+def run_with_backoff(check_cmd, *, max_attempts=3):
     for attempt in range(max_attempts):
-        r = subprocess.run(["claude", "-p", task],
+        r = subprocess.run(check_cmd,
                            capture_output=True, text=True)
         if r.returncode == 0:
             return r.stdout
@@ -108,8 +110,8 @@ def run_with_backoff(task, *, max_attempts=3):
     raise RuntimeError("giving up instead of hammering")
 ```
 
-The agent makes each visit look right; the script decides how many visits happen and
-when. They are separate jobs, and the second one cannot be delegated downward.
+The engine makes each visit look right; the script decides how many visits happen
+and when. They are separate jobs, and the second one cannot be delegated downward.
 
 ## What the browser fixes, and what it does not
 

--- a/docs/ai-agent-download-invoices.md
+++ b/docs/ai-agent-download-invoices.md
@@ -90,28 +90,24 @@ What runs well today, per portal:
    anything in the prompt travels through the model provider. The profile
    directory keeps the session.
 
-2. **Extract on a schedule.** With the login living in the profile, the
-   monthly run is one `do` command, and the flags that make a recurring run
-   stable are the same three
-   [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md)
-   establishes: `--profile-dir` (absolute path) so the session is found,
-   `--seed` so every visit is the same browser rather than a parade of new
-   devices, and the API key in `OPENROUTER_API_KEY` rather than on the
-   command line.
+2. **Extract on a rhythm, honestly.** Since aihawk 0.3.0 there is no headless
+   aihawk command to put in cron, and this page will not pretend a scheduler
+   is doing work a person starts. The monthly run is a five-minute ritual:
+   open the same session (the profile still holds the login), paste the same
+   instruction - "Find the most recent invoice. Reply with CSV only:
+   number,date,amount,due_date, one line, no commentary." - and append the
+   line to your ledger file. Same `--seed` and `--profile-dir` as step 1, so
+   every visit is the same returning browser rather than a parade of new
+   devices.
 
-   ```
-   23 7 3 * *  claude -p "Go to <portal URL>. Find the most recent invoice. \
-   Reply with CSV only: number,date,amount,due_date, one line, no \
-   commentary." >> $HOME/invoices/ledger.csv
-   ```
-
-   That is the assistant one-shot with AIHawk's browser attached over MCP
-   (since aihawk 0.3.0; the one-time setup, with `STEALTHFOX_SEED` and
-   `STEALTHFOX_PROFILE_DIR` on the registration, is on
-   [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md)), in cron
-   on the 3rd of each month, at an off-round minute for the
-   reasons the monitoring page gives. One portal per line, different seeds if
-   you want different identities per supplier.
+   If a portal of yours is stable enough that finding the newest invoice is
+   the same three clicks every month, that is no longer judgment work: the
+   engine behind AIHawk is on PyPI as a Python library with Playwright's API,
+   and a short script with your portal's selectors plus `profile_dir` makes
+   the run schedulable for real - the pattern, with an executed example, is
+   on [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md). This
+   page does not print a portal script because your portal's selectors are
+   yours; test it against your own portal before trusting it with money.
 
 3. **Verify like it is money, because it is.** Every number the agent returns
    is a model's reading of a page. Before a ledger line drives a payment,

--- a/docs/ai-agent-timing-signal.md
+++ b/docs/ai-agent-timing-signal.md
@@ -101,7 +101,7 @@ where the wins are:
   session ten seconds later confirms the verdict.
 
 If you are building your own harness above an agent loop - executing its actions
-yourself, or wrapping a one-shot assistant run in a script - you own the timing, and then the rule
+yourself, or scripting the engine directly through its Python library - you own the timing, and then the rule
 is: vary it, and make it depend on the step. A uniform delay is its own tell. A
 `sleep(1.0)` between every action just moves the cluster from "instant" to "exactly
 one second", and a tight cluster at one second is as machine-regular as a tight

--- a/docs/ai-agent-to-test-website.md
+++ b/docs/ai-agent-to-test-website.md
@@ -35,16 +35,13 @@ Run it through an editor client - [Cursor](running-aihawk-with-cursor.md) or
 [Cline](running-aihawk-with-cline.md), where the same assistant also has your
 code open - or from the terminal:
 
-```bash
-claude -p "Open http://localhost:3000 and try to register a new user
-with placeholder data. Report every field, every validation message, and
-whether registration succeeded."
-```
+> Open http://localhost:3000 and try to register a new user
+> with placeholder data. Report every field, every validation message, and
+> whether registration succeeded.
 
-(the one-shot assistant path, since aihawk 0.3.0). If you would rather watch,
-`uvx aihawk ui` runs the same task with the live page beside the chat, which
-for testing is worth having: seeing the agent hesitate on your form is itself
-a finding. Two properties of
+Typed into `uvx aihawk ui`, which runs the task with the live page beside the
+chat - and for testing the watching is worth having: seeing the agent
+hesitate on your form is itself a finding. Two properties of
 this browser matter specifically for testing. It fills forms through real key
 presses and clicks, refusing script injection, so your input handlers,
 keystroke validation and change events fire the way they fire for people. And

--- a/docs/ai-agent-web-research.md
+++ b/docs/ai-agent-web-research.md
@@ -82,15 +82,14 @@ synthesis while the browser does the driving, which suits research well: the
 conversation holds the accumulating picture, and you can steer mid-walk. Or
 scripted, one question per run:
 
-```bash
-claude -p "Go to https://books.toscrape.com/. Walk the first three pages
-of the catalog and report: how many books are priced above forty pounds, and
-the three most common price bands you observe. Ground every number in what
-the pages show; do not estimate."
-```
+> Go to https://books.toscrape.com/. Walk the first three pages
+> of the catalog and report: how many books are priced above forty pounds, and
+> the three most common price bands you observe. Ground every number in what
+> the pages show; do not estimate.
 
-(The one-shot assistant path, with AIHawk's browser attached over MCP - since
-aihawk 0.3.0 the aihawk command itself is interactive-only.)
+(Typed into `uvx aihawk ui`, or handed to your assistant with AIHawk's
+browser attached - research is judgment work, and since aihawk 0.3.0 the
+judgment paths are those two.)
 
 Prompt habits that separate usable research from confident noise:
 
@@ -142,8 +141,8 @@ sequential browser cannot match. It cannot log in as you, render
 interaction-gated content, or walk an archive in order. Different machine.
 
 **Can AIHawk do deep research?** It does the browser half well: driven
-reading of hard sources, through an MCP client where your assistant
-synthesizes, interactively or as scripted one-shots. It does not fan out
+reading of hard sources, in its own interface or through an MCP client where
+your assistant synthesizes. It does not fan out
 across twenty sources in parallel, and this page does not pretend otherwise.
 
 **How do I stop a research agent from making things up?** Demand quotes tied

--- a/docs/ai-apartment-hunting.md
+++ b/docs/ai-apartment-hunting.md
@@ -81,21 +81,17 @@ minutes is a bill and a signature.
 
 ## The workflow, concretely
 
-The repeatable single instruction runs through your assistant's one-shot
-mode with AIHawk's browser attached over MCP (since aihawk 0.3.0 the aihawk
-command itself is interactive-only; the one-time MCP setup is on
-[the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md)). A worked
-example, with the portal URL being whatever search-results page you have
-already set up by hand:
+Reading listings against criteria is judgment work, so it runs where the
+model is: `uvx aihawk ui`, or your assistant with AIHawk's browser attached.
+A worked instruction to paste, with the portal URL being whatever
+search-results page you have already set up by hand:
 
-```bash
-claude -p "Go to <your saved search URL>. Read the first 15 listings.
-My criteria: max 1600/month, 2 rooms, pets allowed, available within 60
-days, no ground floor without outdoor space. For each listing output one
-line: title, price, rooms, floor, verdict FIT/NEAR/NO with the deciding
-reason. Read the listing text, do not trust the summary card. If a fact is
-not stated, write UNKNOWN, do not guess."
-```
+> Go to `<your saved search URL>`. Read the first 15 listings.
+> My criteria: max 1600/month, 2 rooms, pets allowed, available within 60
+> days, no ground floor without outdoor space. For each listing output one
+> line: title, price, rooms, floor, verdict FIT/NEAR/NO with the deciding
+> reason. Read the listing text, do not trust the summary card. If a fact is
+> not stated, write UNKNOWN, do not guess.
 
 The prompt carries the craft, and three parts of it matter more than the
 rest. The criteria are explicit and closed - the agent judges against your
@@ -105,10 +101,12 @@ load-bearing: listings omit exactly the facts that matter, and an agent
 that fills gaps optimistically is worse than none, because a wrong "pets
 allowed" costs you a viewing trip.
 
-For the recurring version, put that command in cron or Task Scheduler,
-redirect stdout to a dated file, and set `STEALTHFOX_PROFILE_DIR` on the MCP
-registration so the session persists between runs. Once a day, or twice in a
-genuinely fast market. For interactive sessions - "open the third FIT and tell me what
+For the recurring half - "anything new today?" - split the work the way
+[the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md) does: a
+scheduled script on the same engine captures the listing count or the newest
+title each morning, and when that signal moves you bring the judgment prompt
+above to the agent. Once a day, or twice in a genuinely fast market. For
+interactive sessions - "open the third FIT and tell me what
 the photos show about the kitchen" - `uvx aihawk ui` gives you the same
 agent beside a live browser view, and if you already use Claude Code or
 Claude Desktop, the same browser attaches to your assistant instead

--- a/docs/aihawk-review.md
+++ b/docs/aihawk-review.md
@@ -70,10 +70,11 @@ fails if that stops being true.
 
 **Operational features match real use.** `--proxy` takes HTTP or SOCKS5
 and the browser's timezone, locale and egress follow it; `--profile-dir`
-persists logins between runs; `--headed` shows the window; and on the
+persists logins between runs; `--headed` shows the window; on the
 assistant path the same knobs ride the MCP registration as
-`STEALTHFOX_*` variables, which is what scripts and cron want. The
-pieces you need to run it repeatedly are there, not left as exercises.
+`STEALTHFOX_*` variables; and for scheduled work the engine itself is a
+Python library with Playwright's API. The pieces you need to run it
+repeatedly are there, not left as exercises.
 
 **It is genuinely open.** MIT license, the engine and its wrapper
 published as installable packages, and the agent code in this repository

--- a/docs/how-to-extract-data-to-csv-with-an-ai-agent.md
+++ b/docs/how-to-extract-data-to-csv-with-an-ai-agent.md
@@ -44,9 +44,10 @@ Four choices in there do most of the work:
 One mechanical fact, early: the agent has no file-writing
 tool. The browser tools navigate, read, click and type; the CSV materializes as
 the model's final answer, nothing else. From the interface you copy it out of
-the chat; from the command line, `claude -p "..." > books.csv` works (the
-one-shot assistant path, since aihawk 0.3.0) because the answer is printed
-to stdout.
+the chat. For the RECURRING extraction, where the selectors are stable and
+no judgment is involved, the honest tool is a script on the same engine -
+[the Google Sheets page](website-data-to-google-sheets-ai-agent.md) carries
+one, executed, that prints CSV to stdout.
 
 ## What happens underneath
 

--- a/docs/how-to-monitor-a-page-with-an-ai-agent.md
+++ b/docs/how-to-monitor-a-page-with-an-ai-agent.md
@@ -61,82 +61,81 @@ Three shapes of monitoring genuinely need the model:
   bullets, ignoring cosmetics." The output is an editorial judgment, which is
   exactly what you cannot script.
 
-Be honest about the price even here: every check is a fresh agent run. On
-AIHawk that means a browser session opened, a handful of model turns, and the
-session closed, cents per check on the default model and roughly a minute of
-wall clock. Daily is comfortable; every five minutes is a bill and, as covered
-below, a signature.
+Be honest about the price even here: every judgment is a fresh agent session -
+a browser opened, a handful of model turns, cents on the default model and
+roughly a minute of wall clock. Daily is comfortable; every five minutes is a
+bill and, as covered below, a signature. The scheduled capture itself, as the
+next section shows, costs no model at all.
 
-## Scheduling it: the one-shot shape, as of aihawk 0.3.0
+## Scheduling it: a script, as of aihawk 0.3.0
 
-Since 0.3.0 AIHawk itself is interactive-only (`uvx aihawk ui`); the old `do`
-subcommand is gone. The one-shot shape did not disappear, it moved: your
-assistant's CLI runs a single instruction non-interactively, with AIHawk's
-browser attached over MCP. One-time setup, then the check itself:
+Since 0.3.0 AIHawk itself is interactive-only (`uvx aihawk ui`): there is no
+headless subcommand to put in cron anymore. That is less of a loss than it
+sounds, because the scheduled half of monitoring is deliberately mechanical -
+fetch the page, extract one signal, save it - and mechanical work belongs in
+code, not in model turns. The same stealth engine AIHawk drives is on PyPI as
+a Python library with Playwright's API, so the check is a short script. This
+one runs as shown, against the public scraping sandbox:
 
-```bash
-claude mcp add -s user stealth -e STEALTHFOX_SEED=7 \
-  -e STEALTHFOX_PROFILE_DIR=$HOME/.hawk-mon -- uvx invisible-playwright-mcp
+```python
+# check_page.py - fetch one signal from the watched page
+from invisible_playwright import InvisiblePlaywright
 
-claude -p "Go to <your page>. Report the current title and price of the
-first listed item, one line, no commentary."
+with InvisiblePlaywright(seed=7) as browser:
+    page = browser.new_page()
+    page.goto("https://books.toscrape.com/", wait_until="domcontentloaded")
+    first = page.locator("article.product_pod").first
+    title = first.locator("h3 a").get_attribute("title")
+    price = first.locator(".price_color").inner_text()
+    print(f"{title} | {price}")
 ```
 
-`claude -p` runs one instruction, prints the answer to stdout, and exits; the
-browser session opens for the run and closes after. That shape composes with
-cron, systemd timers, or Windows Task Scheduler the way any command does:
-redirect stdout to a dated file and you have a log of answers. The seed and
-the persistent profile now live on the server registration (the `-e` lines)
-instead of per-run flags, which is where a scheduled job wants them anyway.
+Executed on 2026-09-03 it prints exactly `A Light in the Attic | £51.77`.
+`pip install invisible-playwright` is the only setup; swap the URL and the two
+selectors for your page's. Three details matter for a recurring check:
 
-Three flags matter for a recurring check:
-
-- **`--seed`** pins the browser identity. Same seed, same fingerprint, every
+- **`seed=7`** pins the browser identity. Same seed, same fingerprint, every
   run; without it each check arrives as a new device, which is not what a
   returning reader looks like.
-- **`--profile-dir`** keeps a persistent profile, so cookies and any login
-  survive between runs. Use an absolute path; a relative one resolves from
-  wherever cron happened to start the command.
-- **The key comes from the environment.** `do` requires an OpenRouter key, and
-  `OPENROUTER_API_KEY` in the environment beats `--openrouter-key` on a
-  schedule twice over: the flag lands in shell history and, on Linux, in the
-  process list for every user on the machine.
+- **`profile_dir="..."`** (a second keyword argument) keeps a persistent
+  profile, so cookies and any login survive between runs. Use an absolute
+  path; a relative one resolves from wherever cron happened to start.
+- **No model, no key, anywhere in the scheduled path.** The script reads one
+  signal; judging what it means is the model's half, and it does not belong
+  in the crontab.
 
 A real crontab line, deliberately not on the hour:
 
 ```
-17 8 * * *  claude -p "..." >> $HOME/hawk-mon/$(date +\%F).txt 2>&1
+17 8 * * *  python $HOME/hawk-mon/check_page.py >> $HOME/hawk-mon/$(date +\%F).txt 2>&1
 ```
 
-No API key in the crontab: on the assistant path the model comes from the
-assistant's own login, and the browser needs no key at all. The interface
-(`uvx aihawk ui`) has no scheduler; the recurring path is the assistant
-one-shot plus whatever scheduler your system already has.
+The interface (`uvx aihawk ui`) has no scheduler; the recurring path is this
+script plus whatever scheduler your system already has.
 
 ## What to store between runs
 
-Each `do` run is a one-shot conversation: nothing carries over on its own,
-which means the memory of the monitor is yours to keep. Two files do it:
+Each run prints one line and exits: nothing carries over on its own, which
+means the memory of the monitor is yours to keep. Two files do it:
 
-- **The previous answer.** "What changed" only means something against a
-  baseline, and the baseline has to travel in the prompt. The workable pattern
-  feeds the last run's output back in:
+- **The previous signal.** "Did it change" is a comparison, and with the
+  signal in a file the comparison is a diff, not a model call:
 
   ```bash
-  claude -p "Here is what this page said on the last check:
-  $(cat ~/hawk-mon/last.txt)
-  Now go to <your page> and report only meaningful differences from that,
-  or the exact word NOCHANGE if nothing that matters changed." \
-    | tee ~/hawk-mon/last.txt
+  python check_page.py > today.txt
+  diff -q last.txt today.txt || echo "changed - go look"
+  mv today.txt last.txt
   ```
 
-  Asking for a sentinel word like `NOCHANGE` makes the no-op case scriptable:
-  grep for it and only notify when it is absent.
+  The exit code of `diff` is the sentinel: zero means quiet, non-zero means
+  something moved. No model can misread a byte comparison.
 
-- **The dated archive.** Keep every answer with its timestamp. When the agent
-  claims a change, the archive is how you check whether it is real or a
-  misreading, and misreadings happen: the model is a stochastic reader, and a
-  monitor that alerts falsely gets ignored precisely when it is finally right.
+- **The dated archive.** Keep every line with its timestamp. When the diff
+  fires and the question becomes "does this change MATTER", that is the
+  judgment half - open `uvx aihawk ui` (or your assistant with this browser
+  attached) and ask exactly that, with the two saved lines pasted in. The
+  agent earns its per-session cost only on the days something actually moved,
+  which is the whole economics of the hybrid this page keeps arguing for.
 
 The strongest architecture is the two-stage hybrid: let the cheap diff monitor
 watch constantly, and run the agent only when the diff fires, to judge whether
@@ -172,12 +171,11 @@ remember that with `--seed` unset, every run was a different browser.
 
 ## Short answers to the questions that lead here
 
-**Can an AI agent monitor a website for changes?** Yes, mechanically: schedule
-a one-shot assistant run (`claude -p`, with AIHawk's browser attached over
-MCP) with a prompt that carries the previous state and asks for
-meaningful differences. Whether it should depends on the question: byte-level
-"did it change" belongs to a diff tool; "does the change matter" is the
-agent's case.
+**Can an AI agent monitor a website for changes?** The watching half is a
+scheduled script on the same stealth engine; the judging half is the agent,
+invoked when the script's diff fires. Whether the agent belongs in the loop
+at all depends on the question: byte-level "did it change" belongs to a diff
+tool; "does the change matter" is the agent's case.
 
 **Is an LLM agent overkill for change detection?** For plain change detection,
 yes, by orders of magnitude on cost and latency. It stops being overkill when
@@ -185,19 +183,20 @@ the check requires reading: meaningful-change questions, prose thresholds,
 summarized deltas.
 
 **How do I schedule AIHawk to check a page every day?** Cron (or any
-scheduler) plus `claude -p "..."` with the stealth MCP server registered once,
-`STEALTHFOX_SEED` for a stable identity, `STEALTHFOX_PROFILE_DIR` for a
-persistent profile, and stdout redirected somewhere dated. There is no
-built-in scheduler; the one-shot run is the building block on purpose.
+scheduler) plus the `check_page.py` script above on the same engine: `seed`
+for a stable identity, `profile_dir` for a persistent profile, and stdout
+redirected somewhere dated. There is no built-in scheduler; a script that
+prints one line is the building block on purpose.
 
-**What does each check cost?** A browser session plus a short model
-conversation: cents on the default model, roughly a minute of wall clock. The
-hybrid pattern, diff tool always on, agent only on diff-fire, keeps the model
-bill proportional to actual changes.
+**What does each check cost?** The scheduled script costs no model tokens at
+all: a browser session and a few seconds. The model bill starts only when a
+diff fires and you ask the agent whether the change matters, which keeps that
+bill proportional to actual changes - the whole point of the hybrid.
 
 **How does the agent know what changed since last time?** It does not, unless
-you tell it. Runs share nothing; store the previous answer and feed it back in
-the next prompt as the baseline to compare against.
+you tell it. Runs share nothing; the script stores each signal to a file, and
+when you bring the question to the agent you paste the before and after in as
+the baseline to compare against.
 
 **Will a site notice a scheduled agent?** It can: a metronomic schedule is a
 tell independent of the browser, and the browser's own realism does not cover
@@ -215,9 +214,11 @@ All retrieved 2026-09-03.
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README and
   source in this repository: the interface entrypoint and the
   open-run-close session behavior in
-  [`src/aihawk/runner.py`](https://github.com/feder-cr/AIHawk/blob/main/src/aihawk/runner.py),
-  and [invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp)
-  for the `STEALTHFOX_*` variables the scheduled path rides on.
+  [`src/aihawk/runner.py`](https://github.com/feder-cr/AIHawk/blob/main/src/aihawk/runner.py).
+- [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
+  the engine as a Python library, whose Playwright API the scheduled script
+  uses; the script above was executed against books.toscrape.com on
+  2026-09-03 and printed the line quoted.
 
 **See also:** [extracting data to a CSV](how-to-extract-data-to-csv-with-an-ai-agent.md),
 [agent retry loops and rate limits](agent-retry-loops-rate-limits.md),

--- a/docs/website-data-to-google-sheets-ai-agent.md
+++ b/docs/website-data-to-google-sheets-ai-agent.md
@@ -73,21 +73,35 @@ the agent produces is its answer as text - in the interface, in the chat; from
 the command line, on stdout. That is not a gap waiting for a feature; it is
 the architecture: the agent extracts, and the spreadsheet imports.
 
-So the working pipeline has two short stages. First, extraction to CSV, which
-[has its own page](how-to-extract-data-to-csv-with-an-ai-agent.md) covering
-the prompt patterns, the cost curve and the failure modes - naming your
-columns, saying "CSV only, no commentary", bounding the scope. The one-line
-version:
+So the working pipeline has two short stages. First, extraction to CSV. For a
+one-off, the agent is the right tool and
+[the CSV page](how-to-extract-data-to-csv-with-an-ai-agent.md) covers the
+prompt patterns, the cost curve and the failure modes. For the RECURRING
+version this page is about, the extraction is better off as a script on the
+same engine, because the selectors are stable and a model re-deciding them
+every morning is cost without judgment:
 
-```bash
-claude -p "Go to https://books.toscrape.com/. For each book on the first
-page, extract the title and the price. Reply with CSV only: header line
-title,price, one line per book, no commentary." > books.csv
+```python
+# extract_books.py - the watched listing to CSV on stdout
+from invisible_playwright import InvisiblePlaywright
+
+with InvisiblePlaywright(seed=7) as browser:
+    page = browser.new_page()
+    page.goto("https://books.toscrape.com/", wait_until="domcontentloaded")
+    print("title,price_gbp")
+    for card in page.locator("article.product_pod").all():
+        title = card.locator("h3 a").get_attribute("title").replace('"', '""')
+        price = card.locator(".price_color").inner_text().lstrip("£")
+        print(f'"{title}",{price}')
 ```
 
-(That is the assistant CLI in one-shot mode with AIHawk's browser attached
-over MCP; since aihawk 0.3.0 that is the scripted path, and the one-time
-setup is on [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md).)
+Since aihawk 0.3.0 there is no headless aihawk command, and a recurring
+extraction with stable selectors does not want one: it is mechanical work, and
+the same stealth engine AIHawk drives is on PyPI as a plain Python library
+(`pip install invisible-playwright`) with Playwright's API. Executed on
+2026-09-03, `python extract_books.py > books.csv` produced a header plus
+twenty rows, starting `"A Light in the Attic",51.77`. No model and no API key
+are involved anywhere in this path.
 
 Second, the import, which is Google's half and needs no agent:
 
@@ -98,7 +112,7 @@ Second, the import, which is Google's half and needs no agent:
   host, a paste service with raw URLs, your own server - one cell of
   `IMPORTDATA("https://your-host/books.csv")` makes the sheet re-read it.
   Combine that with a scheduled extraction and the sheet updates itself: cron
-  runs the one-shot and drops the file, `IMPORTDATA` picks it up. The
+  runs the script and drops the file, `IMPORTDATA` picks it up. The
   scheduling half, including the settings that keep a recurring run stable, is
   on [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md); it
   transfers unchanged.
@@ -151,7 +165,7 @@ page, served HTML, table or list shape. Free and self-refreshing beats cents
 and a model every time the mechanical tool can reach.
 
 **How do I make the sheet update on a schedule?** Schedule the extraction
-(cron plus a one-shot assistant run, per [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md)),
+(cron plus the script above, per [the monitoring page](how-to-monitor-a-page-with-an-ai-agent.md)),
 write the CSV to a web-served location, and point `IMPORTDATA` at it. The
 sheet re-fetches; nothing touches the sheet directly.
 

--- a/scripts/check_content.py
+++ b/scripts/check_content.py
@@ -164,9 +164,9 @@ def selftest():
         bad = {
             "banned topic": ("docs/spam.md",
                              b"How to automate your job application flow\n"),
-            "em-dash": ("docs/dash.md", "text — more\n".encode()),
+            "em-dash": ("docs/dash.md", "text \u2014 more\n".encode()),
             "invisible codepoint": ("docs/zw.md",
-                                    "wor​d\n".encode("utf-8")),
+                                    "wor\u200bd\n".encode("utf-8")),
             "removed command": ("docs/old.md",
                                 b'run `uvx aihawk do "task"` daily\n'),
             "argv-list command": ("docs/argv.md",


### PR DESCRIPTION
## Summary

The 0.3.0 alignment shipped earlier tonight (#1205) replaced `aihawk do` with one-shot assistant runs (`claude -p`) in the scheduled flows. This PR is the correction of that correction, driven by execution instead of assumption: every code block published here was run first, and the runs changed the decisions.

## What was executed, and what it proved

- `pip install aihawk==0.3.0; aihawk do x` in a fresh venv: `Error: No such command 'do'.` One command remains (`ui`), and its keyless placeholder mode still exists in the 0.3.0 source with exactly the commands the without-a-key page lists.
- `claude -p "Go to books.toscrape.com... tagline"` with the stealth MCP server registered: printed the right answer - and the event transcript showed the tool used was **WebFetch, not the stealth browser**. The right answer, from the wrong instrument. With `--allowedTools "mcp__stealth__*"` alone: still WebFetch. Only with `--disallowedTools "WebFetch,WebSearch"` added did the transcript show real `browser_navigate`/`browser_read_text` calls and the `STEALTHFOX_PROFILE_DIR` profile appear on disk (65 entries). So the `claude -p` recipes published in #1205 did not do what their pages promised, even when they printed correct output.
- The library path, executed verbatim as now published: `check_page.py` printed `A Light in the Attic | £51.77`; `extract_books.py > books.csv` produced a header plus twenty correctly quoted rows. No model, no key, deterministic.

## The decision, page by page (the five built on `do`)

- **how-to-monitor-a-page**: rewritten on the library (option 3). The scheduled half of monitoring is mechanical by the page's own argument, so the cron block is now the executed `check_page.py` plus a plain `diff`; the judgment half ("does the change matter") moves explicitly to an interactive session, which is the page's hybrid thesis made concrete. Title promise intact. Also removed a leftover `do`-era flags block (`--seed`/`--profile-dir`/`OPENROUTER_API_KEY`) that #1205 missed.
- **website-data-to-google-sheets**: library (option 3). Recurring extraction with stable selectors is cost without judgment on a model; the executed extraction script now feeds the unchanged `IMPORTDATA` half. Title promise intact.
- **ai-apartment-hunting**: interactive agent for the judgment core (the worked prompt survives verbatim, now typed into `aihawk ui` or the attached assistant); the recurring "anything new today" defers to the monitoring page's script-plus-judgment split. No cron block left.
- **ai-agent-download-invoices**: honest restructure. The monthly run is a five-minute interactive ritual on the persistent profile; for a portal stable enough to be three identical clicks, the library path is named in prose with a pointer to the executed pattern - no portal script is printed, because your portal's selectors are yours and an untested block next to money is the worst kind of paste.
- **ai-agent-web-research**: the scripted-question block becomes the same instruction as an interactive prompt; research is judgment work and never belonged in cron. Title promise intact.

Also aligned: test-website (interactive, watch the run), the CSV page (recurring case now points at the executed script), retry-loops (the budget wrapper wraps a generic check command instead of `claude -p`), timing-signal, and the review page. The without-a-key page's command list was verified against the 0.3.0 placeholder source and stands.

`scripts/check_content.py` gains nothing new in coverage, but its two known-bad fixtures now spell their em-dash and zero-width space as `\u` escapes, so the gate's own source is clean under the invisible-codepoint scan it performs.

## Links and gates

No page was deleted, so no inbound links broke; all internal links resolve and the wiki renders 50 pages + sidebar from this tree. Content gate selftest and scan clean, english-only clean (run after `git add`), forbidden-names clean on the pushed range (95 files + the commit message), zero em/en dashes, zero invisible codepoints.

Generated with Claude Code
