### PR TITLE
Eleven audit findings closed: stale command references, a version that contradicted itself, and a model id made exact

### DIFF
--- a/articles/extracting-a-category-to-csv/README.md
+++ b/articles/extracting-a-category-to-csv/README.md
@@ -82,7 +82,7 @@ MCP sessions do; the browser's screenshots are the visual record.
 
 | Piece | Version |
 |---|---|
-| invisible-playwright-mcp | 0.3.0 |
+| invisible-playwright-mcp | 0.3.0 (the locally installed server that drove this run; releases have moved well past it, so your tool names may differ) |
 | invisible_playwright | 0.8.3 |
 | invisible_core | 26.17.0 |
 | Engine | firefox-26 |
@@ -94,7 +94,7 @@ changed.
 ## Reproducing it
 
 Attach the browser to your assistant (from the
-[README](../../README.md#1-you-already-use-claude-code-claude-desktop-or-cursor)):
+[README](../../README.md#1-you-already-use-an-assistant-that-can-run-tools)):
 
 ```bash
 claude mcp add -s user stealth -- uvx invisible-playwright-mcp

--- a/articles/web-research-audited/README.md
+++ b/articles/web-research-audited/README.md
@@ -93,7 +93,7 @@ rendered as images are where reading starts to drift. The honest conclusions:
 
 | Piece | Version |
 |---|---|
-| invisible-playwright-mcp | 0.3.0 |
+| invisible-playwright-mcp | 0.3.0 (the locally installed server that drove this run; releases have moved well past it, so your tool names may differ) |
 | invisible_playwright | 0.8.3 |
 | invisible_core | 26.17.0 |
 | Engine | firefox-26 |

--- a/docs/ai-agent-download-invoices.md
+++ b/docs/ai-agent-download-invoices.md
@@ -176,8 +176,8 @@ All retrieved 2026-09-03.
   the server's README, for the complete tool list this page's "no download
   tool" statement is checked against.
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README and
-  source in this repository, for `--profile-dir`, `--seed`, `--headed`, the
-  key-in-environment guidance and the answer-on-stdout behavior of `do`.
+  source in this repository, for `--profile-dir`, `--seed`, `--headed` and
+  the key-in-environment guidance.
 
 **See also:** [extracting data to a CSV](how-to-extract-data-to-csv-with-an-ai-agent.md),
 [getting website data into Google Sheets](website-data-to-google-sheets-ai-agent.md),

--- a/docs/ai-agent-web-research.md
+++ b/docs/ai-agent-web-research.md
@@ -170,7 +170,7 @@ All retrieved 2026-09-03.
   README.
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README and
   source in this repository, for the agent loop, the grounding line in its
-  system prompt, and the `do` command this page's examples use.
+  system prompt this page's cost notes describe.
 
 **See also:** [what is an AI web agent?](ai-web-agent-explained.md),
 [AI browser agents vs traditional scraping](ai-browser-agents-vs-traditional-scraping.md),

--- a/docs/ai-apartment-hunting.md
+++ b/docs/ai-apartment-hunting.md
@@ -162,9 +162,9 @@ on [the blocking page](why-does-my-ai-agent-get-blocked.md) before blaming
 any one of them. A sweep at scraper volume deserves the block, and this
 page is not the recipe for one.
 
-**Can it fill out rental application forms too?** The same way it works
-job forms: draft from your real information, stop at anything binding,
-human reviews and submits. See
+**Can it fill out rental application forms too?** Yes, with the same
+discipline as any form: draft from your real information, stop at anything
+binding, human reviews and submits. See
 [getting an AI agent to fill out forms](ai-agent-fill-out-forms.md).
 
 ## Sources

--- a/docs/aihawk-review.md
+++ b/docs/aihawk-review.md
@@ -24,8 +24,9 @@ AIHawk is an open-source AI web agent: you describe a task in plain
 language and it drives a real browser until the task is done. The
 repository sits at about 30,300 stars and 4,600 forks, has existed since
 August 2024, and is MIT licensed. The Python package `aihawk` is on PyPI
-at version 0.2.0, published 3 September 2026, requiring Python 3.11 or
-newer.
+at version 0.3.0, published 3 September 2026, requiring Python 3.11 or
+newer; the repository's main branch already carries 0.4.0, and the
+statements below that name a version say which one they describe.
 
 One factual line on where it came from, because the repository description
 still says it: the project was born as an AI web agent that applied to
@@ -207,7 +208,7 @@ the MCP route.
 ## Sources
 
 - The [AIHawk repository](https://github.com/feder-cr/AIHawk): README, LICENSE, `pyproject.toml` and `tests/test_key_isolation.py` read in the working tree on 2026-09-03; stars, forks, license and creation date read via the GitHub API the same day.
-- [`aihawk` on PyPI](https://pypi.org/project/aihawk/), version 0.2.0 metadata fetched via the PyPI JSON API 2026-09-03.
+- [`aihawk` on PyPI](https://pypi.org/project/aihawk/), version 0.3.0 metadata checked against the index 2026-09-04.
 - The relicense commit ("Relicense under MIT", dated 2026-09-02) in the repository history, and the README's license section stating the AGPL-3.0 boundary for earlier distributions, both read 2026-09-03.
 - For comparative claims about other tools, the pages linked above carry their own dated sources; none are repeated here.
 

--- a/docs/how-to-monitor-a-page-with-an-ai-agent.md
+++ b/docs/how-to-monitor-a-page-with-an-ai-agent.md
@@ -1,6 +1,6 @@
 ---
 title: "Monitoring a page for changes with an AI agent"
-description: "When a plain diff monitor is the right tool, when an agent's judgment earns its cost, how to schedule checks with the aihawk CLI, and what to store between runs."
+description: "When a plain diff monitor is the right tool, when an agent's judgment earns its cost, how to schedule the capture as a script on the same engine, and what to store between runs."
 parent: "Using the Agent"
 nav_order: 7
 ---

--- a/docs/is-openai-operator-still-available.md
+++ b/docs/is-openai-operator-still-available.md
@@ -62,8 +62,9 @@ through interfaces".
 
 **The computer-use API.** For developers, OpenAI's computer use tool in the
 Responses API drives a click-type-scroll loop over screenshots. It left its
-research-preview phase: the current guide documents it as a generally
-available tool (named `computer`) driven by current models such as `gpt-5.6`,
+research-preview phase: the current guide documents the tool (named
+`computer`) driven by the current model ids it lists (`gpt-5.6-sol` and
+`gpt-6-astra`, checked 2026-09-04),
 with a migration path from the old `computer-use-preview` model. It is a
 building block, not a product: you supply the browser or VM it acts on.
 

--- a/docs/website-data-to-google-sheets-ai-agent.md
+++ b/docs/website-data-to-google-sheets-ai-agent.md
@@ -69,9 +69,10 @@ sometimes and not others.
 Here is the fact this page exists to state plainly: AIHawk has no Google
 Sheets integration. Nothing in its source talks to a Google API, there is no
 credential to configure, and the agent has no file-writing tool at all. What
-the agent produces is its answer as text - in the interface, in the chat; from
-the command line, on stdout. That is not a gap waiting for a feature; it is
-the architecture: the agent extracts, and the spreadsheet imports.
+the agent produces is its answer as text in the interface's chat, and what
+the scheduled script produces is CSV on stdout. That is not a gap waiting
+for a feature; it is
+the architecture: the extraction produces text, and the spreadsheet imports.
 
 So the working pipeline has two short stages. First, extraction to CSV. For a
 one-off, the agent is the right tool and

--- a/docs/which-model-to-use-with-aihawk.md
+++ b/docs/which-model-to-use-with-aihawk.md
@@ -12,7 +12,7 @@ AIHawk brings the browser and you bring the model, from
 [OpenRouter](https://openrouter.ai) and nowhere else. If you set nothing, you get
 `z-ai/glm-4.6`: that is the default written into the source, and it sits at the
 cheap-and-capable end of the catalog rather than the flagship end. You override it
-with `--model` on either command, or the `AIHAWK_MODEL` environment variable, and
+with `--model` on `aihawk ui`, or the `AIHAWK_MODEL` environment variable, and
 any model id OpenRouter serves is legal. So the real question is not "which model
 does AIHawk support" - all of them - but which one is worth paying for on this
 kind of work, and that has a less obvious answer than the price sheet suggests.


### PR DESCRIPTION
## Summary

The corpus-wide editorial re-pass (three reviewers over all 49 pages plus both worked examples, one fact-checker over the volatile claims) reported eleven findings on this wiki; this PR closes them all.

- Stale command references the 0.3.0 alignment missed, all hiding in Sources sections and frontmatter: the invoices and web-research Sources still cited `do` in the present tense; the monitoring page's description still promised "schedule checks with the aihawk CLI"; the Sheets page's architecture paragraph still described a command line the package no longer has; the model page still said "--model on either command".
- The review page dated itself against PyPI 0.2.0 while describing 0.3.0/0.4.0 behavior; it now states 0.3.0 as the published version, names main as carrying 0.4.0, and version-stamps its behavioral claims.
- The apartment page's FAQ presented job-application forms as a current capability in passing; the sentence now stands without the banned theme.
- Fact-check catch: the Operator page cited `gpt-5.6` as a computer-use model id; OpenAI's guide lists `gpt-5.6-sol` and `gpt-6-astra` as the exact ids, now quoted and dated.
- Both worked examples: the README anchor updated to the heading the README actually has now, and the version tables state plainly that the recorded MCP server (0.3.0) is the locally installed one that drove the runs while releases have moved past it.

## Test plan

- [x] Content gate + selftest clean; english-only clean; forbidden-names clean on the range
- [x] Zero `aihawk do` / placeholder / keyless residue anywhere, verified by sweep
- [x] No page added or deleted; the live wiki's 0.4.0 sequencing is unaffected (docs merge, no dispatch until the release)

Generated with Claude Code
