### PR TITLE
A .env beside the command, and the floor that makes the verb table true

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,25 @@ quicker, because a page can tell the difference.
 - **`--host`, `--port`** `127.0.0.1` and `8765`. Changing the host
   exposes an interface that has no authentication.
 
+### A `.env` beside the command
+
+Rather than retyping the key and the binary path, put them in a `.env` in the
+directory you run from:
+
+```
+OPENROUTER_API_KEY=sk-or-...
+STEALTHFOX_BINARY=/path/to/firefox
+```
+
+It is read at startup, and on the way in it **never overrides** something
+already set, so the order is `--flag` > the environment > `.env` > the default.
+Only the directory you are in is read - there is no search upwards, so running
+from a subfolder cannot silently pick up a different key. The startup line names
+the variables it applied and never prints their values.
+
 Passing `--openrouter-key` puts the key in your shell history, and on Linux in
-the process list. `OPENROUTER_API_KEY` in the environment avoids both.
+the process list. `OPENROUTER_API_KEY` in the environment or in a `.env` avoids
+both.
 
 Either way it does not reach the browser process: it is removed from the
 environment the engine starts with, by name and by value, so a copy under a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,18 @@ dependencies = [
     # Set only after 0.10.0 is on the index, never before: a floor no published
     # version satisfies is a package nobody can install. publish.yml refuses
     # the release rather than trusting this comment to be read.
-    "invisible-playwright-mcp>=0.10.0",
+    # ⛔ 0.11.0, not 0.10.0, and the floor is what makes the pairing true.
+    # The VERB table below names session_start and session_status, and a
+    # table naming tools the server does not offer is exactly what
+    # test_the_table_names_no_tool_that_does_not_exist refuses. CI resolves
+    # this from the INDEX, not from a checkout, so the floor is the only
+    # thing that can say which server this interface goes with.
+    "invisible-playwright-mcp>=0.11.0",
     "mcp>=1.2",
+    # Declared rather than inherited. It arrives transitively through mcp today,
+    # and a transitive dependency is one somebody else can drop in a minor
+    # release without telling us.
+    "python-dotenv>=1",
     "openai>=1.30",
     "click>=8.1",
     # Declared even though `mcp` already pulls both in for streamable-http. This

--- a/src/aihawk/cli.py
+++ b/src/aihawk/cli.py
@@ -8,6 +8,49 @@ import click
 
 from .llm import BASE_URL, resolve_key, resolve_model
 
+#: The file read at startup, in the directory the command is run from.
+#:
+#: ⛔ CWD ONLY, not a search upwards. `find_dotenv` walks parent directories,
+#: which means running the command from a subfolder can silently pick up
+#: somebody else's file - a different key, a different browser - and nothing on
+#: screen says which one was used. One predictable location is worth more than
+#: the convenience.
+ENV_FILE = ".env"
+
+
+def load_env_file(directory=None) -> dict:
+    """Read `.env` from `directory` (default: the current one) into the process.
+
+    ⛔ IT NEVER OVERRIDES A VARIABLE THAT IS ALREADY SET, and that ordering is
+    the whole design. A variable exported in the shell is something the user
+    just did; a line in a file is something they did once, weeks ago. The recent
+    decision wins, so the precedence a reader can rely on is:
+
+        --flag  >  the environment  >  .env  >  the default
+
+    Returns what it actually applied, so the caller can say so rather than
+    leaving the user to guess whether the file was found at all.
+    """
+    from pathlib import Path
+
+    path = Path(directory or Path.cwd()) / ENV_FILE
+    if not path.is_file():
+        return {}
+
+    # dotenv rather than a hand-rolled parser: quoting, `export ` prefixes,
+    # comments and multi-line values are all things a hand-rolled one gets
+    # wrong on somebody else's machine, months later.
+    from dotenv import dotenv_values
+
+    applied = {}
+    for name, value in dotenv_values(path).items():
+        if value is None or name in os.environ:
+            continue
+        os.environ[name] = value
+        applied[name] = value
+    return applied
+
+
 BROWSER_OPTIONS = [
     click.option("--proxy", default=None, help="Proxy URL for the stealth browser."),
     click.option("--seed", type=int, default=None, help="Deterministic fingerprint seed."),
@@ -37,7 +80,16 @@ def main() -> None:
     Said here rather than only in the subcommand because this is the first page
     anybody reads, and a key requirement discovered from an error message is a
     key requirement discovered too late.
+
+    A `.env` in the directory you run from is read first, so the key and the
+    browser path can live in a file instead of a shell profile. It never
+    overrides something already in the environment.
     """
+    applied = load_env_file()
+    if applied:
+        # Names, never values: this line exists so a reader knows the file was
+        # found, and printing what was in it would put the key on the terminal.
+        click.echo("env      %s: %s" % (ENV_FILE, ", ".join(sorted(applied))))
 
 
 @main.command()

--- a/tests/test_env_file.py
+++ b/tests/test_env_file.py
@@ -1,0 +1,123 @@
+"""A `.env` beside the command, and the order that decides who wins.
+
+The key and the browser path are the two things nobody wants to retype, and a
+shell profile is a bad home for them: it is global, invisible from the project,
+and different on every machine. So a `.env` in the directory the command runs
+from is read at startup.
+
+Three properties carry the whole design, and each is a decision that could
+reasonably have gone the other way:
+
+  1. THE CURRENT DIRECTORY ONLY, never a walk upwards. `find_dotenv` searches
+     parent directories, so running from a subfolder can silently pick up
+     somebody else's file - a different key, a different browser - with nothing
+     on screen saying which one was used.
+  2. IT NEVER OVERRIDES what is already set. A variable exported in the shell is
+     something the user just did; a line in a file is something they did once,
+     weeks ago. So the precedence a reader can rely on is
+     `--flag > environment > .env > default`.
+  3. IT SAYS THE NAMES AND NEVER THE VALUES. The line exists so a reader knows
+     the file was found at all; printing what was in it would put the API key on
+     the terminal, and terminals get pasted into issues.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from aihawk import cli
+
+
+@pytest.fixture(autouse=True)
+def _clean_environment(monkeypatch):
+    for name in ("AIHAWK_TEST_KEY", "OPENROUTER_API_KEY", "STEALTHFOX_BINARY"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _write(directory, text):
+    (directory / cli.ENV_FILE).write_bytes(text.encode("utf-8"))
+
+
+def test_a_missing_file_is_not_an_error(tmp_path):
+    """Most runs have no `.env` at all, and that is the ordinary case rather
+    than a degraded one."""
+    assert cli.load_env_file(tmp_path) == {}
+
+
+def test_values_reach_the_process(tmp_path):
+    _write(tmp_path, "OPENROUTER_API_KEY=sk-from-file\nSTEALTHFOX_BINARY=C:/ff.exe\n")
+
+    applied = cli.load_env_file(tmp_path)
+
+    assert applied == {"OPENROUTER_API_KEY": "sk-from-file",
+                       "STEALTHFOX_BINARY": "C:/ff.exe"}
+    assert os.environ["OPENROUTER_API_KEY"] == "sk-from-file"
+
+
+def test_the_environment_wins_over_the_file(tmp_path, monkeypatch):
+    """⛔ The load-bearing one. Known-bad is `override=True`, which is what
+    `load_dotenv` does by default in plenty of projects: a stale line in a file
+    would then beat a key the user just exported, and the failure looks like the
+    key being wrong rather than the file being read."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-from-the-shell")
+    _write(tmp_path, "OPENROUTER_API_KEY=sk-from-file\n")
+
+    applied = cli.load_env_file(tmp_path)
+
+    assert os.environ["OPENROUTER_API_KEY"] == "sk-from-the-shell"
+    assert "OPENROUTER_API_KEY" not in applied, (
+        "the file reported applying a variable it did not set")
+
+
+def test_a_file_in_the_parent_directory_is_not_read(tmp_path):
+    """⛔ CWD only. A walk upwards means the same command behaves differently
+    depending on how deep you are, and picks up files nobody meant for it."""
+    _write(tmp_path, "OPENROUTER_API_KEY=sk-from-the-parent\n")
+    child = tmp_path / "project"
+    child.mkdir()
+
+    assert cli.load_env_file(child) == {}
+    assert "OPENROUTER_API_KEY" not in os.environ
+
+
+def test_quoting_and_export_prefixes_are_understood(tmp_path):
+    """The reason this uses dotenv rather than a split on '='. A hand-rolled
+    parser gets these wrong on somebody else's machine, months later."""
+    _write(tmp_path, 'export OPENROUTER_API_KEY="sk-quoted"\n'
+                     "# a comment\n"
+                     "STEALTHFOX_BINARY='C:/Program Files/ff.exe'\n")
+
+    applied = cli.load_env_file(tmp_path)
+
+    assert applied["OPENROUTER_API_KEY"] == "sk-quoted"
+    assert applied["STEALTHFOX_BINARY"] == "C:/Program Files/ff.exe"
+
+
+def test_what_is_printed_names_the_variable_and_never_its_value(tmp_path, monkeypatch,
+                                                                capsys):
+    """⛔ A terminal gets pasted into issues. The confirmation line has to be
+    enough to know the file was found and useless to anyone reading over a
+    shoulder."""
+    monkeypatch.chdir(tmp_path)
+    _write(tmp_path, "OPENROUTER_API_KEY=sk-do-not-print-me\n")
+
+    from click.testing import CliRunner
+
+    result = CliRunner().invoke(cli.main, ["--help"])
+
+    assert "sk-do-not-print-me" not in result.output, "the key was printed"
+
+
+def test_the_readme_tells_people_the_file_exists():
+    """A setting nobody can discover is a setting that does not exist. This is
+    the same defect the tool descriptions were audited for: the code was right
+    and the only text a user reads said nothing about it.
+    """
+    import pathlib
+
+    readme = pathlib.Path(__file__).resolve().parents[1] / "README.md"
+    text = readme.read_text(encoding="utf-8")
+
+    assert cli.ENV_FILE in text, "the README never mentions the .env file"
+    assert "OPENROUTER_API_KEY" in text


### PR DESCRIPTION
The key and the browser path are the two things nobody wants to retype, and a
shell profile is a bad home for them: global, invisible from the project, and
different on every machine. A `.env` in the directory the command runs from is
now read at startup.

Three decisions carry it. The current directory only, never a walk upwards, so
running from a subfolder cannot silently pick up somebody else's key with
nothing on screen saying which file was used. It never overrides what is already
set, so the order a reader can rely on is `--flag` > environment > `.env` >
default. And the startup line names the variables it applied and never their
values, because terminals get pasted into issues. `python-dotenv` is declared
rather than inherited through `mcp`: a transitive dependency is one somebody else
can drop in a minor release.

That work existed but shipped undiscoverable, with no tests and no mention in the
README. Seven tests now, including one that fails if the README stops explaining
it.

The dependency floor moves to `invisible-playwright-mcp>=0.11.0`, and that half
is not cosmetic. #1213 added verbs for `session_start` and `session_status`,
which only exist from 0.11.0; with the floor at 0.10.0 an install can resolve a
server offering neither, and `test_the_table_names_no_tool_that_does_not_exist`
refuses a table naming tools the server does not have. CI resolves that package
from the index rather than from a checkout, so the floor is the only place that
can say which server this interface goes with.

This branch originally carried its own verbs for those two tools. #1213 landed
the same thing first, so that half is dropped and main's wording is kept.
