### PR TITLE
The open-source trio declares its own split

### DIFF
--- a/docs/ai-browser-agent-open-source.md
+++ b/docs/ai-browser-agent-open-source.md
@@ -201,8 +201,11 @@ repository page on that date.
 
 **See also:** [open-source computer-use agents](computer-use-agent-open-source.md),
 [what is an AI web agent?](ai-web-agent-explained.md),
-[choosing an AI browser agent](best-ai-browser-agent.md), and
-[browser-use alternatives](browser-use-alternatives.md).
+[choosing an AI browser agent](best-ai-browser-agent.md),
+[browser-use alternatives](browser-use-alternatives.md), and - if you landed
+here from Operator's shutdown -
+[open-source Operator-style agents](openai-operator-open-source.md), which
+frames the overlapping repos by what Operator specifically did.
 
 ---
 

--- a/docs/openai-operator-open-source.md
+++ b/docs/openai-operator-open-source.md
@@ -165,6 +165,8 @@ direction is clear.
 
 **See also:** [OpenAI Operator alternatives](openai-operator-alternatives.md)
 for the hosted options next to these,
+[open-source AI browser agents](ai-browser-agent-open-source.md) for the same
+space compared without the Operator frame,
 [browser-use alternatives](browser-use-alternatives.md) for the leader's
 trade-offs in detail, and
 [Choosing an AI browser agent](best-ai-browser-agent.md) for the decision


### PR DESCRIPTION
The Operator/open-source trio was already split by intent in its descriptions (full landscape / Operator-framed subset / generic OSS comparison), but the third page linked neither sibling. The two links that declare the split to readers and crawlers are now in, both directions. Content gate and english-only clean.

Generated with Claude Code