### PR TITLE
Two verbs for the tools the server grew overnight

### DIFF
--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -385,7 +385,9 @@ const VERB = {
   browser_evaluate:['Evaluating','Evaluated'], browser_take_screenshot:['Capturing','Captured'],
   browser_select_option:['Choosing','Chose'],
   session_new_page:['Opening tab','Opened tab'],   session_select_page:['Switching tab','Switched tab'],
-  session_close_page:['Closing tab','Closed tab'], session_list_pages:['Listing tabs','Listed tabs']
+  session_close_page:['Closing tab','Closed tab'], session_list_pages:['Listing tabs','Listed tabs'],
+  session_start:['Starting browser','Started browser'],
+  session_status:['Checking session','Checked session']
 };
 const LEAD = /^(I will |I'll |I am |I'm |Let me |Now I will |Now I'll )/i;
 const LONG = 120;


### PR DESCRIPTION
## Summary

invisible-playwright-mcp 0.11.0 landed on the index tonight with two new tools, `session_start` and `session_status`, and `test_every_tool_the_server_offers_has_a_verb` went red on 5 of 6 matrix jobs doing exactly its job: without a verb, those steps would render as "Called <raw arguments>" in the step list. (The red surfaced on a docs-only PR that was merged on the green `gate` alone - the failure predates that PR and belongs to the dependency, not the docs.)

The `VERB` table gains the two entries: Starting/Started browser, Checking/Checked session.

## Test plan

- [x] `tests/test_every_tool_reads_as_english.py` run in a fresh venv against the real invisible-playwright-mcp 0.11.0: 3 passed - both directions, every offered tool has a verb and no verb names a tool that no longer exists

Generated with Claude Code
