### PR TITLE
Nobody writes -s user, and the long form needs no explaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ about how you work.
 **Claude Code:**
 
 ```bash
-claude mcp add -s user stealth -- uvx invisible-playwright-mcp
+claude mcp add --scope user stealth -- uvx invisible-playwright-mcp
 ```
 
 **Codex:**
@@ -44,7 +44,7 @@ codex mcp add stealth -- uvx invisible-playwright-mcp
 **Gemini CLI:**
 
 ```bash
-gemini mcp add -s user stealth uvx invisible-playwright-mcp
+gemini mcp add --scope user stealth uvx invisible-playwright-mcp
 ```
 
 Then ask your assistant, in the window you already have open:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.5.0"
+version = "0.6.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
Surveyed twelve well-known MCP servers on their official sources, quoting each
install line verbatim and verifying every quote against the page it came from.

**Four document a scope flag, and every one writes it in full**: Context7, Chrome
DevTools MCP, Serena, Supabase. So does the example in Claude Code's own
documentation. Zero use the short form.

The split is not "people skip the scope". It tracks what the server is:

| Server | scope | how it is added |
|---|---|---|
| Chrome DevTools MCP | `--scope user` | local process, `npx` |
| Serena | `--scope user` | local process |
| Context7 | `--scope user` | local process, `npx` |
| Supabase | `--scope project` | hosted, but per-repo |
| Sentry, Stripe, Linear, Notion, Exa, Firecrawl, Browserbase | none | hosted, `--transport http https://mcp.<vendor>.com/...` |

The seven with no flag are vendor services added as a URL. The ones that launch a
local process for general use carry `--scope user`, and the nearest comparable to
this package sits on that side:

```bash
claude mcp add chrome-devtools --scope user npx chrome-devtools-mcp@latest
```

Playwright MCP is the counter-example in the same category and omits it.

The behaviour does not change. `--scope user` says what it does; `-s user` has to
be looked up, and it sits on the line where somebody is installing this for the
first time.
