### PR TITLE
The wiki was still teaching the short flag

### DIFF
--- a/docs/aihawk-review.md
+++ b/docs/aihawk-review.md
@@ -37,7 +37,7 @@ wiki documents; that earlier use is not covered here.
 There are two ways to run it, and they share one browser:
 
 - **Inside an assistant you already use.** One command
-  (`claude mcp add -s user stealth -- uvx invisible-playwright-mcp`)
+  (`claude mcp add --scope user stealth -- uvx invisible-playwright-mcp`)
   registers the browser as an MCP server in Claude Code, Claude Desktop or
   Cursor, and your assistant's model does the thinking.
 - **Standalone.** `uvx aihawk ui` serves a local page with chat on the

--- a/docs/claude-computer-use-detected-as-bot.md
+++ b/docs/claude-computer-use-detected-as-bot.md
@@ -100,7 +100,7 @@ them. This is the general agent-timing problem, and it has
    screenshotting a whole desktop, Claude Code, Claude Desktop or Cursor can drive a
    Firefox patched at the C++ level as a set of tools, via
    [invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp) -
-   one line for Claude Code: `claude mcp add -s user stealth -- uvx
+   one line for Claude Code: `claude mcp add --scope user stealth -- uvx
    invisible-playwright-mcp`. Disclosure: that server and this wiki have the same
    maintainer, and it is the route [AIHawk](https://github.com/feder-cr/AIHawk)
    itself uses. For staying with the screenshot loop instead, the engine wiki shows

--- a/docs/running-aihawk-with-claude-code.md
+++ b/docs/running-aihawk-with-claude-code.md
@@ -31,10 +31,10 @@ engine build for it was `firefox-20` - and [uv](https://docs.astral.sh/uv/),
 because the command runs the server with `uvx`. Then, once:
 
 ```bash
-claude mcp add -s user stealth -- uvx invisible-playwright-mcp
+claude mcp add --scope user stealth -- uvx invisible-playwright-mcp
 ```
 
-Reading it left to right: `-s user` registers the server at user scope, so it
+Reading it left to right: `--scope user` registers the server at user scope, so it
 is available in every project rather than only the directory you happened to be
 in; `stealth` is the name it appears under; everything after `--` is the
 command Claude Code will run to start the server, and `uvx` fetches and runs
@@ -128,7 +128,7 @@ results, and short steps keep its context small and its mistakes cheap.
 ## Short answers to the questions that lead here
 
 **How do I add AIHawk's browser to Claude Code?**
-`claude mcp add -s user stealth -- uvx invisible-playwright-mcp`, once, with uv
+`claude mcp add --scope user stealth -- uvx invisible-playwright-mcp`, once, with uv
 installed. New sessions then have the browser tools in `/mcp`.
 
 **Do I need an OpenRouter key for this?** No. The key is only for AIHawk's own


### PR DESCRIPTION
Five occurrences of `-s user` across three docs pages, which the published wiki renders verbatim. The READMEs moved to `--scope user` after a survey of twelve well-known MCP servers: everyone who documents a scope flag writes it in full, including Claude Code's own documentation, and nobody uses the short form.

These pages are the wiki's **source** - `publish-wiki.yml` rebuilds the wiki from `docs/` on every published release - so editing the wiki directly would have been wiped on the next release. Fixed here, and the wiki follows on its own.

One of the five is prose rather than a command: "Reading it left to right, `--scope user` registers the server at user scope", which is the sentence that makes the long form worth having.