### PR TITLE
A checkout should gate itself, and these two never did

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,13 @@ aihawk = "aihawk.cli:main"
 packages = ["src/aihawk"]
 
 [tool.pytest.ini_options]
+# ⛔ SO A CHECKOUT GATES ITSELF. Without this, pytest imports whatever the
+# interpreter's installation points at, which is not necessarily this tree:
+# measured 2026-08-29 on a sibling package, an editable install resolved to a
+# SECOND working copy of the same repository on an older branch, so a fix just
+# written did not move the test exercising it. Resolved against this
+# pyproject.toml, so every checkout points at itself.
+pythonpath = ["src"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 # `ui` tests launch a real browser through a real MCP server. They are slow,


### PR DESCRIPTION
`pytest` imports whatever the interpreter's installation points at, which is not
necessarily the tree you are standing in.

Measured 2026-08-29 on a sibling package: an editable install resolved to a
**second working copy of the same repository** on an older branch, so a fix just
written did not move the test that exercised it, because the code under test was
somewhere else. The cost was low by luck: the copies differed by a whole
subpackage, so collection exploded instead of running green on code nobody had
written there.

The remedy then was `pythonpath = ["src"]` in the pytest config, resolved against
`pyproject.toml` so every checkout points at itself. It went to the two packages
that existed at the time, `invisible_playwright` and `invisible_core`. The two
newer ones never got it, and this is the second of them.

**Measured here rather than assumed.** With the package installed non-editable
in a venv, and pytest run from this checkout:

```
before   C:\tmp\venv_albero\Lib\site-packages\aihawk\__init__.py
after    C:\src\...\release\aihawk\src\aihawk\__init__.py
```

136 tests pass either way, which is exactly the problem this closes: a suite can
be green against the wrong tree and nothing says so.
