### PR TITLE
The version gate asks whether the package moved, not whether the number is taken

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # The gate diffs the tree against the tag of the published
+          # version; a shallow clone has no tags and cannot tell.
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/tests/test_version_is_not_taken.py
+++ b/tests/test_version_is_not_taken.py
@@ -1,4 +1,5 @@
-"""The version a change proposes must not already be on the index.
+"""The version a change proposes must not already be on the index, unless
+nothing that ships has moved since it was published.
 
 ⛔ MEASURED 2026-09-04, AND NOTHING SAW IT. `aihawk 0.4.0` was published at
 23:47. Over the following hours main gained two more changes - verbs for the
@@ -25,9 +26,22 @@ somebody bumps, which is a normal resting state and not a defect, so a check
 that ran there would be red for a reason nobody can act on - and a gate that is
 red at rest is a gate people learn to skip.
 
-The trade this makes, stated rather than discovered: the first pull request
-after a release has to carry a version bump. That matches how this repository
-already works, since the change that earns a release is the change that bumps.
+⛔ AND "NEW CONTENT" MEANS WHAT THE INDEX SERVES, which the first version of
+this file got wrong on its first day. It refused every pull request whose
+version was published, and the first two after a release were the ledger the
+publish workflow opens by itself and the changelog entry for that release. A
+version bump on either would be a lie: nothing that ships had moved. The
+question the gate asks now is the one it always meant. Since the tag of the
+published version, has anything changed that goes into the wheel - the package
+tree the build backend names, or `pyproject.toml`? The ledger, the changelog,
+the tests, the workflows and the docs alter nothing anybody installs, so they
+pass without a bump; a change under the package does not.
+
+That needs the tag in the checkout, so the `version` CI job fetches the full
+history. A version that is on the index with no tag in the clone is refused
+outright rather than guessed at. The outcomes are free, taken-but-unmoved,
+taken-and-moved, and cannot-tell, and only the third is a defect while the
+fourth is a broken bench.
 
 Enabled by AIHAWK_CHECK_VERSION, which the `version` CI job sets itself, so it
 cannot silently skip the way it does in a local run.
@@ -35,6 +49,8 @@ cannot silently skip the way it does in a local run.
 from __future__ import annotations
 
 import os
+import pathlib
+import subprocess
 import urllib.error
 import urllib.request
 
@@ -42,19 +58,59 @@ import pytest
 
 PACKAGE = "aihawk"
 
+#: The tag that published the release BEFORE the current line of work. From it
+#: to here the package moved by definition, which makes it the live known-bad
+#: for the diff half: a check that has only ever said "unmoved" is not a check.
+PREVIOUS_RELEASE_TAG = "v0.5.0"
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
 pytestmark = pytest.mark.skipif(
     not os.environ.get("AIHAWK_CHECK_VERSION"),
     reason="set AIHAWK_CHECK_VERSION=1 to ask the index (one network call)",
 )
 
 
-def _declared_version() -> str:
-    import pathlib
+def _pyproject() -> dict:
     import tomllib
 
-    root = pathlib.Path(__file__).resolve().parents[1]
-    data = tomllib.loads((root / "pyproject.toml").read_text(encoding="utf-8"))
-    return data["project"]["version"]
+    return tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+
+
+def _declared_version() -> str:
+    return _pyproject()["project"]["version"]
+
+
+def _shipped_roots() -> tuple[str, ...]:
+    """What the wheel carries, read from where the build backend declares it
+    rather than typed here, so a moved package moves the gate with it."""
+    packages = _pyproject()["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"]
+    return tuple(p.rstrip("/") + "/" for p in packages) + ("pyproject.toml",)
+
+
+def _shipped(paths) -> list[str]:
+    """The subset of `paths` that goes into the wheel.
+
+    Pure on purpose: the known-bad below feeds it a list, no repository needed.
+    """
+    roots = _shipped_roots()
+    return [p for p in paths if any(p == r or p.startswith(r) for r in roots)]
+
+
+def _changed_since(tag: str):
+    """Every path that differs between `tag` and the tree, or None when git
+    cannot say: the tag is not in this checkout, or this is not a checkout.
+
+    ⛔ None is not an empty list. An absent tag scored as "nothing changed"
+    would pass exactly the case this file exists to refuse.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", tag],
+            cwd=ROOT, capture_output=True, text=True, check=True).stdout
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    return [line.strip() for line in out.splitlines() if line.strip()]
 
 
 def _on_the_index(version: str):
@@ -82,21 +138,33 @@ def test_the_declared_version_is_not_already_published():
 
     if present is None:
         pytest.skip("the index did not answer; neither present nor absent")
+    if not present:
+        return
 
-    assert not present, (
-        "pyproject declares %s and the index already serves it, so a release "
-        "from here publishes nothing: publish.yml sees the version, reports "
-        "'already on the index. No-op, not a failure', and everything below it "
-        "is skipped. Bump the version." % version)
+    changed = _changed_since("v" + version)
+    if changed is None:
+        pytest.fail(
+            "pyproject declares %s and the index already serves it, but the tag "
+            "v%s is not in this checkout, so whether the package moved since "
+            "cannot be told. Fetch the tags: the version job checks out with "
+            "fetch-depth 0 for this reason." % (version, version))
+
+    moved = _shipped(changed)
+    assert not moved, (
+        "pyproject declares %s, the index already serves it, and %d file(s) "
+        "that go into the wheel changed since v%s: %s. A release from here "
+        "publishes nothing: publish.yml sees the version, reports 'already on "
+        "the index. No-op, not a failure', and everything below it is skipped. "
+        "Bump the version." % (version, len(moved), version, ", ".join(moved[:8])))
 
 
 def test_the_check_can_tell_a_taken_version_from_a_free_one():
     """⛔ The known-bad input, run against the live index rather than a mock.
 
-    A check that has only ever said "free" is not a check. `0.1.0` was published
-    on 2026-09-02 and is not coming back, so it is a stable stand-in for the
-    thing this gate must catch, and a version far past anything real stands in
-    for the state it must allow.
+    A check that has only ever said "free" is not a check. `0.1.0` was
+    published and is not coming back, so it is a stable stand-in for the thing
+    this gate must catch, and a version far past anything real stands in for
+    the state it must allow.
     """
     taken = _on_the_index("0.1.0")
     free = _on_the_index("99.99.99")
@@ -106,3 +174,34 @@ def test_the_check_can_tell_a_taken_version_from_a_free_one():
 
     assert taken is True, "the check cannot see a version that IS published"
     assert free is False, "the check calls an unpublished version taken"
+
+
+def test_the_check_can_tell_a_shipped_change_from_one_that_does_not_ship():
+    """⛔ The known-bad for the diff half, with no repository involved.
+
+    The ledger, the changelog, a test, a workflow and a doc must not count. A
+    file under the package and `pyproject.toml` must. And a sibling of the
+    package whose name merely starts the same way must not.
+    """
+    package = _shipped_roots()[0]
+    quiet = [
+        "PUBLISHED.json", "CHANGELOG.md", "README.md", "docs/index.md",
+        "tests/test_version_is_not_taken.py", ".github/workflows/ci.yml",
+        package.rstrip("/") + "_notes.md",
+    ]
+    loud = [package + "__init__.py", package + "deep/inside.py", "pyproject.toml"]
+
+    assert _shipped(quiet) == []
+    assert _shipped(quiet + loud) == loud
+
+
+def test_the_diff_half_sees_a_release_that_did_move_the_package():
+    """The live known-bad: from the previous release's tag to here the package
+    moved, so the shipped set is non-empty. Skipped, not passed, when the tag
+    is not in this clone."""
+    changed = _changed_since(PREVIOUS_RELEASE_TAG)
+    if changed is None:
+        pytest.skip("%s is not in this checkout" % PREVIOUS_RELEASE_TAG)
+    assert _shipped(changed), (
+        "no shipped file differs from %s, so the diff half sees nothing"
+        % PREVIOUS_RELEASE_TAG)


### PR DESCRIPTION
On its first day the version gate refused every pull request that follows a release without a bump, including the ones that cannot carry one. The question it asks now is the one it always meant: since the tag of the published version, has anything that goes into the wheel changed? If not, the pull request passes without a bump. If the package tree or `pyproject.toml` moved, it is refused as before, naming the files.

The version job fetches the full history so the tag is there to diff against, and a taken version with no tag in the clone is refused rather than guessed at.

Known-bad inputs: a pure classifier fed the files that must not count (ledger, changelog, a test, a workflow, a same-prefix sibling of the package) and the ones that must, plus the previous release's tag, from which the package moved by definition. Checked locally too: a comment appended under the package turns the gate red with the message naming the file.