### PR TITLE
The first sentence now says who it is about

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img alt="AIHawk" src="https://raw.githubusercontent.com/feder-cr/AIHawk/main/assets/aihawk-logo-light.png" width="380">
 </picture>
 
-**An AI agent with a real browser. You say what you want in plain language, it goes and does it on the actual web.**
+**AIHawk is an AI agent with a real browser. You say what you want in plain language, and it goes and does it on the actual web.**
 
 <sub>FEATURED IN</sub><br>
 [**Business Insider**](https://www.businessinsider.com/aihawk-applies-jobs-for-you-linkedin-risks-inaccuracies-mistakes-2024-11) ·


### PR DESCRIPTION
One word and one comma: the bold opening line becomes definitional ("AIHawk is an AI agent with a real browser...") because Google builds long-tail snippets from a page's first sentence, and the current one never names the project. Pairs with today's About refresh: category-first description, the website field now pointing at the wiki, and the topics rebuilt on the ai-agent vertical (ai, ai-agents, browser-agent, llm, mcp...) instead of the engine's scraping/fingerprinting set.

Content gate and english-only clean; claim scanner clean on the new metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
