### PR TITLE
The Home page links every page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,26 +5,78 @@ nav_order: 1
 
 # AIHawk Wiki
 
-AIHawk is an AI agent with a real browser: you say what you want in plain
-language, it goes and does it on the actual web. This wiki is the reading
-room around it - what an AI web agent is, how the tools in this space compare,
+AIHawk is an open-source AI browser agent: an AI agent with a real browser.
+You say what you want in plain language, and it autonomously browses, clicks,
+types and reads the actual web to get it done. This wiki is the reading room
+around it - what an AI web agent is, how the tools in this space compare,
 what to do when an agent gets blocked, and how to put an agent to work.
 
 The [README](https://github.com/feder-cr/AIHawk#readme) is the fastest way to
 run AIHawk. The pages here are for the questions that come before and after:
 which tool fits, why something failed, and what is actually happening
-underneath.
+underneath. Every page on this wiki is one link away from this one.
 
-## The guides
+## [Alternatives and Comparisons](guides-alternatives-and-comparisons.md)
 
-- **[Alternatives and Comparisons](guides-alternatives-and-comparisons.md)** -
-  the AI browser-agent landscape: OpenAI Operator and what replaced it,
-  browser-use, computer-use agents, and how the open-source options differ.
-- **[When the Agent Gets Blocked](guides-when-the-agent-gets-blocked.md)** -
-  challenge pages, rate limits, timing tells, and which of those the browser
-  can fix versus which are yours.
-- **[Using the Agent](guides-using-the-agent.md)** - task-shaped guides for
-  putting an agent to work.
+The AI browser-agent landscape: OpenAI Operator and what replaced it,
+browser-use, computer-use agents, and how the open-source options differ.
+
+- [What is an AI web agent?](ai-web-agent-explained.md)
+- [Choosing an AI browser agent](best-ai-browser-agent.md)
+- [Open-source AI browser agents](ai-browser-agent-open-source.md)
+- [Open-source computer-use agents](computer-use-agent-open-source.md)
+- [AI browser vs AI browser agent: which one do you want?](ai-browser-vs-ai-browser-agent.md)
+- [AI browser agents vs traditional scraping](ai-browser-agents-vs-traditional-scraping.md)
+- [Is OpenAI Operator still available?](is-openai-operator-still-available.md)
+- [OpenAI Operator alternatives](openai-operator-alternatives.md)
+- [Open-source Operator-style agents](openai-operator-open-source.md)
+- [OpenAI Operator vs Claude computer use](openai-operator-vs-claude-computer-use.md)
+- [Gemini computer use vs Claude computer use](gemini-computer-use-vs-claude-computer-use.md)
+- [Project Mariner is gone: what replaced it](project-mariner-is-gone.md)
+- [browser-use alternatives](browser-use-alternatives.md)
+- [Stagehand vs browser-use](stagehand-vs-browser-use.md)
+- [Skyvern alternatives](skyvern-alternatives.md)
+- [Manus alternatives](manus-alternatives.md)
+- [Firecrawl vs an AI browser agent](firecrawl-vs-ai-browser-agents.md)
+- [Browserbase alternatives](browserbase-alternatives.md)
+- [Cloud browser infrastructure for AI agents, explained](cloud-browser-infrastructure-for-ai-agents.md)
+- [AIHawk, reviewed honestly by its own wiki](aihawk-review.md)
+
+## [When the Agent Gets Blocked](guides-when-the-agent-gets-blocked.md)
+
+Challenge pages, rate limits, timing tells, and which of those the browser
+can fix versus which are yours.
+
+- [Why does my AI agent get blocked?](why-does-my-ai-agent-get-blocked.md)
+- [The timing signal AI agents give off](ai-agent-timing-signal.md)
+- [Agent retry loops trip rate limits, not fingerprints](agent-retry-loops-rate-limits.md)
+- [Claude computer use detected as a bot](claude-computer-use-detected-as-bot.md)
+- [browser-use getting blocked: what you can and cannot change](browser-use-getting-blocked.md)
+
+## [Using the Agent](guides-using-the-agent.md)
+
+Task-shaped guides for putting an AI agent to work on real websites.
+
+- [Getting an AI agent to fill out forms](ai-agent-fill-out-forms.md)
+- [Extracting data to a CSV with an AI agent](how-to-extract-data-to-csv-with-an-ai-agent.md)
+- [Getting website data into Google Sheets with an AI agent](website-data-to-google-sheets-ai-agent.md)
+- [Monitoring a page for changes with an AI agent](how-to-monitor-a-page-with-an-ai-agent.md)
+- [AI agents for web research](ai-agent-web-research.md)
+- [Using an AI agent to download invoices from portals](ai-agent-download-invoices.md)
+- [Using an AI agent to hunt for apartments](ai-apartment-hunting.md)
+- [Using an AI agent to test your own website](ai-agent-to-test-website.md)
+- [Posting to social media with an AI agent](posting-to-social-media-with-an-ai-agent.md)
+- [Posting to X with an AI agent](ai-agent-post-to-x.md)
+- [Posting to Facebook with an AI agent](post-to-facebook-with-an-ai-agent.md)
+- [Posting to Instagram with an AI agent](post-to-instagram-with-an-ai-agent.md)
+- [Automating LinkedIn posts: read this first](automating-linkedin-posts-read-this-first.md)
+- [Appointment bots: what they are and what an agent can legitimately do](appointment-bots-explained.md)
+- [Which model to use with AIHawk](which-model-to-use-with-aihawk.md)
+- [Browser problem or model problem?](browser-problem-or-model-problem.md)
+- [Running AIHawk's browser from Claude Code](running-aihawk-with-claude-code.md)
+- [Running AIHawk's browser from Claude Desktop](running-aihawk-with-claude-desktop.md)
+- [Running AIHawk's browser from Cursor](running-aihawk-with-cursor.md)
+- [Running AIHawk's browser from Cline](running-aihawk-with-cline.md)
 
 ## The layer underneath
 

--- a/scripts/build_wiki.py
+++ b/scripts/build_wiki.py
@@ -114,7 +114,9 @@ toplevel.sort(key=lambda x: int(x[1].get("nav_order", "999")))
 lines = ["### " + link("index"), ""]
 for slug, fm in toplevel:
     t = title_of(slug)
-    lines.append("**%s**" % t)
+    # The group header is a page too: bold AND a link, so the three hub pages
+    # are reachable from every wiki page instead of being named and unlinked.
+    lines.append("**%s**" % link(slug))
     for cs, cfm in children_of(t):
         if cfm.get("has_children") == "true":
             lines.append("- %s" % link(cs))


### PR DESCRIPTION
Home listed three hubs out of forty-nine pages; a wiki has no sitemap, so the root page is the sitemap. Now every page is one link from Home with its title as the anchor, the three hub pages are linked from the sidebar on every page, and the opening paragraph matches the README first line.