### PR TITLE
The opening line names the thing a search calls it

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img alt="AIHawk" src="https://raw.githubusercontent.com/feder-cr/AIHawk/main/assets/aihawk-logo-light.png" width="380">
 </picture>
 
-**AIHawk is an open-source AI browser agent: an AI agent with a real browser. You say what you want in plain language, and it autonomously browses, clicks, types and reads the actual web to get it done.**
+**AIHawk is an open-source AI browser agent: an autonomous web agent with a real browser. You say what you want in plain language, and it browses, clicks, types and reads the actual web to get it done.**
 
 <sub>FEATURED IN</sub><br>
 [**Business Insider**](https://www.businessinsider.com/aihawk-applies-jobs-for-you-linkedin-risks-inaccuracies-mistakes-2024-11) ·

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,9 +5,7 @@ nav_order: 1
 
 # AIHawk Wiki
 
-AIHawk is an open-source AI browser agent: an AI agent with a real browser.
-You say what you want in plain language, and it autonomously browses, clicks,
-types and reads the actual web to get it done. This wiki is the reading room
+AIHawk is an open-source AI browser agent: an autonomous web agent with a real browser. You say what you want in plain language, and it browses, clicks, types and reads the actual web to get it done. This wiki is the reading room
 around it - what an AI web agent is, how the tools in this space compare,
 what to do when an agent gets blocked, and how to put an agent to work.
 


### PR DESCRIPTION
One noun phrase changes in the opening line, in the README and the wiki Home together: an autonomous web agent, where it said an AI agent. Same meaning, same sentence shape, and the phrasing people actually search now sits in the snippet zone. The About description moved to the matching wording the same evening.