### PR TITLE
Two pages from the same wave opened with the same five words

### DIFF
--- a/docs/ai-browser-agent-local-llm.md
+++ b/docs/ai-browser-agent-local-llm.md
@@ -1,12 +1,12 @@
 ---
-title: "Run an AI browser agent with a local LLM"
+title: "AI browser agent with a local LLM: what changes"
 description: "AIHawk's interface only calls OpenRouter. How to attach this browser to a client running a local model, and why privacy, not capability, is the real payoff."
 parent: "Using the Agent"
 nav_order: 25
 ---
 
 
-# Run an AI browser agent with a local LLM
+# AI browser agent with a local LLM: what changes
 
 A local model changes exactly one thing about this browser: where the model runs.
 AIHawk's own interface only ever calls OpenRouter, there is no local-model flag. To
@@ -129,7 +129,7 @@ reliably here.
 step with no model against the library: if it reproduces, the browser side is at
 fault regardless of any model; if not, the model was the variable.
 
-**See also:** [Which model to use with AIHawk](which-model-to-use-with-aihawk.md),
+**See also:** [running an agent unattended on a schedule](run-ai-agent-on-a-schedule.md) for the other half of the running question, [Which model to use with AIHawk](which-model-to-use-with-aihawk.md),
 [Browser problem or model problem?](browser-problem-or-model-problem.md), and
 [Running AIHawk's browser from Claude Code](running-aihawk-with-claude-code.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ Task-shaped guides for putting an AI agent to work on real websites.
 - [Build a lead list with an AI browser agent](ai-agent-lead-list.md)
 - [Move data between two web apps with an AI agent](move-data-between-web-apps-with-an-ai-agent.md)
 - [Run an AI browser agent on a schedule](run-ai-agent-on-a-schedule.md)
-- [Run an AI browser agent with a local LLM](ai-browser-agent-local-llm.md)
+- [AI browser agent with a local LLM: what changes](ai-browser-agent-local-llm.md)
 - [Should you log your AI agent into your accounts?](should-you-log-your-ai-agent-into-accounts.md)
 - [Which model to use with AIHawk](which-model-to-use-with-aihawk.md)
 - [Browser problem or model problem?](browser-problem-or-model-problem.md)

--- a/docs/run-ai-agent-on-a-schedule.md
+++ b/docs/run-ai-agent-on-a-schedule.md
@@ -138,7 +138,7 @@ hand, the model was the variable.
 read by a human on some cadence, somewhere you already look rather than a new place
 invented just for this.
 
-**See also:** [Monitoring a page for changes with an AI agent](how-to-monitor-a-page-with-an-ai-agent.md),
+**See also:** [running the agent on a local model](ai-browser-agent-local-llm.md) if the token bill is what pushed you here, [Monitoring a page for changes with an AI agent](how-to-monitor-a-page-with-an-ai-agent.md),
 [Browser problem or model problem?](browser-problem-or-model-problem.md), and
 [Which model to use with AIHawk](which-model-to-use-with-aihawk.md).
 


### PR DESCRIPTION
A cannibalization pass over both wikis (498 pages, positions read from the 4 September round) flagged one pair from yesterday: the local-model page and the scheduling page both opened with Run an AI browser agent. Different questions, twin titles. The local-model page takes the phrasing its own query uses, and the pair now cross-links so the split is declared.