### PR TITLE
fix: prevent duplicate SSE events at connect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.6.0"
+version = "0.6.1"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.9.1"
+version = "0.9.2"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -725,6 +725,10 @@ def build_app(link: Link, service: ChatService) -> Starlette:
 
     async def events(_request: Request) -> StreamingResponse:
         q = service.subscribe()
+        # Freeze the replay/live boundary while subscribing. StreamingResponse
+        # starts `stream` later, so taking this snapshot inside it would let an
+        # intervening event appear in both history and the listener's queue.
+        replay = list(service.history)
 
         async def stream() -> AsyncIterator[bytes]:
             try:
@@ -733,7 +737,7 @@ def build_app(link: Link, service: ChatService) -> Starlette:
                 # Flagged as replay so the page does not animate forty rows at
                 # once and does not start a stopwatch on work that finished
                 # before this listener existed.
-                for past in list(service.history):
+                for past in replay:
                     yield b"data: " + json.dumps({**past, "replay": True}).encode() + b"\n\n"
                 while True:
                     event = await q.get()

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -143,6 +143,38 @@ async def test_the_replay_flag_is_on_history_and_not_on_live_events():
     assert all(e["replay"] for e in replayed)
 
 
+async def test_an_event_after_subscription_is_delivered_once_as_live():
+    """The replay/live boundary is the instant the listener subscribes.
+
+    A StreamingResponse does not start its async generator when the endpoint
+    returns. An event emitted in that gap is already in both history and the
+    listener's queue, so taking the history snapshot inside the generator would
+    send it once as replay and then again as live.
+    """
+    svc = ChatService(FakeLink(), SilentBrain())
+    app = build_app(FakeLink(), svc)
+    route = [r for r in app.routes if r.path == "/chat/events"][0]
+
+    class Req:
+        query_params = {}
+
+    response = await route.endpoint(Req())
+    await svc.emit("said", "only once")
+    body = response.body_iterator
+
+    def payload(chunk):
+        return json.loads(chunk.removeprefix(b"data: ").strip())
+
+    assert payload(await anext(body))["kind"] == "model"
+    delivered = [payload(await anext(body))]
+    try:
+        delivered.append(payload(await asyncio.wait_for(anext(body), 0.1)))
+    except asyncio.TimeoutError:
+        pass
+
+    assert delivered == [{"kind": "said", "text": "only once"}]
+
+
 # --------------------------------------------------------------------------
 # stopping
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes: An event emitted after /chat/events subscribes but before its StreamingResponse body starts is sent once as replay and again as live, producing duplicate conversation rows.
- Root cause: The listener queue is registered when the endpoint runs, but the history snapshot is delayed until the response generator first iterates, so an intervening event enters both history and the already-subscribed queue.

## Regression evidence

- Before: `.venv/bin/python -m pytest -q tests/test_web_service.py::test_an_event_after_subscription_is_delivered_once_as_live` exited `1`

- After: `.venv/bin/python -m pytest -q tests/test_web_service.py::test_an_event_after_subscription_is_delivered_once_as_live` exited `0`

## Verification

- `.venv/bin/python -m pytest -q tests/test_web_service.py`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python scripts/check_english_only.py --selftest && .venv/bin/python scripts/check_english_only.py`
- `.venv/bin/python scripts/check_content.py --selftest && .venv/bin/python scripts/check_content.py`
- `AIHAWK_CHECK_VERSION=1 .venv/bin/python -m pytest -q tests/test_version_is_not_taken.py`
- `.venv/bin/python -m build --wheel; install the wheel in a clean virtual environment; run aihawk --help and import shipped modules`

## Scope

- 3 files changed, +38 / -2 lines
