### PR TITLE
The browser is on disk before the interface serves anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,15 +90,10 @@ over MCP, exactly as your assistant would.
 (x86_64 or arm64)**. macOS is not supported: the last engine build for it was
 `firefox-20`.
 
-**The browser is a separate download of about 250 MB**, and it does not arrive
-with the package. It arrives on the first instruction that needs a page, so
-that instruction sits there for a while and a slow connection can fail with an
-error that never mentions a download. Get it over with first, where you can
-watch it:
-
-```bash
-invisible-playwright fetch
-```
+**The browser is a separate download of about 250 MB** that happens by itself
+the first time either way starts: the server fetches it as soon as your
+assistant launches it, and `aihawk ui` shows it coming down before it opens
+the port. Nothing to run.
 
 If your assistant reports that it cannot find `invisible-playwright-mcp`, pip
 put the script somewhere your PATH does not reach; register

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.6.0"
+version = "0.7.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -42,7 +42,12 @@ dependencies = [
     # test_the_table_names_no_tool_that_does_not_exist refuses. CI resolves
     # this from the INDEX, not from a checkout, so the floor is the only
     # thing that can say which server this interface goes with.
-    "invisible-playwright-mcp>=0.11.0",
+    # 0.13.0: the server fetches the engine the moment it starts instead of
+    # inside the first tool call, and the README stopped telling people to
+    # run `invisible-playwright fetch` on the strength of that. Against an
+    # older server the README would promise a download that does not happen
+    # until the first page is asked for.
+    "invisible-playwright-mcp>=0.13.0",
     "mcp>=1.2",
     # Declared rather than inherited. It arrives transitively through mcp today,
     # and a transitive dependency is one somebody else can drop in a minor

--- a/src/aihawk/cli.py
+++ b/src/aihawk/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 
 import click
 
@@ -67,6 +68,62 @@ def browser_options(fn):
     return fn
 
 
+class _EngineLine:
+    """One terminal line that follows the download, redrawn in place.
+
+    On a terminal every whole percent is drawn; anywhere else (a log, a pipe)
+    every tenth, because a carriage return in a file is not a redraw and a
+    thousand of them is a wall of text.
+    """
+
+    def __init__(self, echo, tty: bool) -> None:
+        self._echo = echo
+        self._step = 1 if tty else 10
+        self._drawn = None
+
+    def _draw(self, text: str) -> None:
+        self._echo("\rbrowser  %-40s" % text, nl=False)
+
+    def progress(self, done: int, total: int) -> None:
+        pct = int(done * 100 / total) if total else 0
+        bucket = pct // self._step
+        if bucket == self._drawn:
+            return
+        self._drawn = bucket
+        self._draw("downloading %3d%%  %d MB" % (pct, done // (1 << 20)))
+
+    def status(self, phase: str) -> None:
+        if phase != "downloading":
+            self._draw(phase)
+
+    def done(self) -> None:
+        self._draw("ready")
+        self._echo("")
+
+
+def engine_on_disk(binary, echo=click.echo, fetch=None, tty=None) -> None:
+    """Have the browser on disk before anything is served.
+
+    The MCP server fetches it on its own the first time it starts, but from
+    here that moment used to be invisible: this command printed "browser ready"
+    while nothing had been downloaded, and the first message then sat for a
+    minute with nothing moving, or died on a slow line with an error that named
+    a timeout. So the download happens in front of the person, on one line that
+    follows it, before the port opens. A given --binary skips it here the way it
+    skips the download everywhere else; the server still checks that binary
+    against the seal when it launches.
+    """
+    if binary:
+        echo("browser  %s" % binary)
+        return
+    if fetch is None:
+        from invisible_core import ensure_binary
+        fetch = ensure_binary
+    line = _EngineLine(echo, tty=sys.stdout.isatty() if tty is None else tty)
+    fetch(progress=line.progress, status=line.status)
+    line.done()
+
+
 @click.group()
 def main() -> None:
     """Drive a stealth browser with an LLM.
@@ -129,11 +186,15 @@ def ui(openrouter_key, model, host, port, proxy, seed, headed, binary, profile_d
     opts = {"proxy": proxy, "seed": seed, "headed": headed,
             "binary": binary, "profile_dir": profile_dir}
 
+    # Before the port opens and before the server is spawned: the download,
+    # if there is one, happens here where it can be watched.
+    engine_on_disk(binary)
+
     async def serve() -> None:
         import uvicorn
 
         link = await Link(opts, key=key).open()
-        click.echo("browser  ready, %d tools" % len(link.tools))
+        click.echo("server   connected, %d tools" % len(link.tools))
         click.echo("open     http://%s:%d" % (host, port))
         service = ChatService(link, brain, model_label=label)
         app = build_app(link, service)

--- a/tests/test_cli_surface.py
+++ b/tests/test_cli_surface.py
@@ -111,6 +111,26 @@ def link(monkeypatch):
     return rec
 
 
+class EngineRecorder:
+    """Stands in for `engine_on_disk`: records the binary it was handed."""
+
+    def __init__(self):
+        self.calls: list = []
+
+    def __call__(self, binary, **kwargs):
+        self.calls.append(binary)
+
+
+@pytest.fixture(autouse=True)
+def engine(monkeypatch):
+    """No test here may download an engine, and none needs one on disk: the
+    step that puts it there is recorded instead, which is also how its place
+    in the sequence is asserted below."""
+    rec = EngineRecorder()
+    monkeypatch.setattr(climod, "engine_on_disk", rec)
+    return rec
+
+
 def run(*args, **kwargs):
     return CliRunner().invoke(climod.main, list(args), **kwargs)
 
@@ -118,6 +138,30 @@ def run(*args, **kwargs):
 def stopped_at_link(result) -> bool:
     """The command got as far as connecting, which is as far as we let it."""
     return isinstance(result.exception, _Stop)
+
+
+# --------------------------------------------------------------------------
+# the engine: on disk before anything else
+# --------------------------------------------------------------------------
+
+def test_the_engine_is_on_disk_before_the_link_opens(link, engine):
+    """The link is where a browser would be launched, and the recorder stops
+    the command there, so an engine step that ran after it would never be
+    seen: "called at all" is the ordering assertion. And --binary must reach
+    it unchanged, because a given binary is what tells it not to download."""
+    result = run("ui", "--openrouter-key", FAKE_KEY, "--binary", "C:/engines/firefox.exe")
+
+    assert stopped_at_link(result)
+    assert engine.calls == ["C:/engines/firefox.exe"]
+
+
+def test_no_key_means_no_download_either(link, engine):
+    """A refusal that came after a quarter-gigabyte download would be a
+    refusal with a bill attached."""
+    result = run("ui")
+
+    assert result.exit_code != 0
+    assert engine.calls == [], "the engine was fetched before the key refusal"
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_engine_first.py
+++ b/tests/test_engine_first.py
@@ -1,0 +1,84 @@
+"""The interface puts the browser on disk before it serves anything, and says
+what it is doing while it does.
+
+Until 0.7.0 `aihawk ui` printed "browser ready" with nothing downloaded: the
+engine arrived inside the first message, invisibly, a minute of nothing moving.
+These tests drive `engine_on_disk` with a fake fetch that behaves like
+`invisible_core.ensure_binary` (byte progress, then the two silent phases) and
+read what reached the terminal.
+"""
+from __future__ import annotations
+
+import aihawk.cli as climod
+
+
+def _echo_into(lines):
+    def echo(text, nl=True):
+        lines.append(text)
+    return echo
+
+
+def test_the_download_is_shown_phase_by_phase_and_ends_in_ready():
+    lines = []
+
+    def fetch(progress, status):
+        status("downloading")
+        progress(0, 100 << 20)
+        progress(50 << 20, 100 << 20)
+        status("verifying")
+        status("extracting")
+        return "C:/cache/firefox.exe"
+
+    climod.engine_on_disk(None, echo=_echo_into(lines), fetch=fetch, tty=False)
+
+    joined = "".join(lines)
+    for word in ("downloading", "50%", "50 MB", "verifying", "extracting", "ready"):
+        assert word in joined, "%r never reached the terminal: %r" % (word, lines)
+    assert lines[-1] == "", "the line was left without a newline after ready"
+
+
+def test_a_given_binary_is_named_and_not_downloaded():
+    lines, fetched = [], []
+
+    climod.engine_on_disk("C:/engines/firefox.exe", echo=_echo_into(lines),
+                          fetch=lambda **kw: fetched.append(kw), tty=False)
+
+    assert fetched == [], "a given binary was downloaded over"
+    assert "C:/engines/firefox.exe" in "".join(lines)
+
+
+def test_off_a_terminal_only_every_tenth_percent_is_drawn():
+    """A pipe or a CI log gets eleven lines, not a hundred and one."""
+    lines = []
+
+    def fetch(progress, status):
+        for done in range(101):
+            progress(done, 100)
+
+    climod.engine_on_disk(None, echo=_echo_into(lines), fetch=fetch, tty=False)
+
+    drawn = [line for line in lines if "downloading" in line]
+    assert len(drawn) == 11, "%d redraws off a terminal" % len(drawn)
+
+
+def test_on_a_terminal_every_percent_is_drawn():
+    lines = []
+
+    def fetch(progress, status):
+        for done in range(101):
+            progress(done, 100)
+
+    climod.engine_on_disk(None, echo=_echo_into(lines), fetch=fetch, tty=True)
+
+    assert sum("downloading" in line for line in lines) == 101
+
+
+def test_an_unknown_total_does_not_divide_by_zero():
+    lines = []
+
+    def fetch(progress, status):
+        progress(1 << 20, 0)
+
+    climod.engine_on_disk(None, echo=_echo_into(lines), fetch=fetch, tty=False)
+
+    assert any("downloading" in line for line in lines)


### PR DESCRIPTION
aihawk ui printed "browser ready" with nothing downloaded: the engine arrived inside the first message, invisibly, a minute of nothing moving on a fresh machine, or an error about a timeout on a slow line. The download now happens before the port opens, on one terminal line that follows it: a percentage and the megabytes while it comes down, then verifying, extracting, ready. Every percent on a terminal, every tenth in a log. A given --binary skips it, as it skips the download everywhere else, and a missing key still refuses before anything is fetched.

The floor moves to invisible-playwright-mcp 0.13.0, where the server fetches the engine the moment it starts instead of inside the first tool call, and the README stops telling people to run invisible-playwright fetch on the strength of that: the browser downloads itself on both ways in. Verified from the index in a clean environment with an empty cache: the first page waited 9.0 s, which is the browser launch.

Seven tests, two known-bad mutations killed: the engine step removed, and the engine step moved before the key check.