### PR TITLE
The assistant route fetches the browser as its second line

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ which is where `pip` comes from.
 ### 1. From your assistant, over MCP
 
 Your assistant brings the model. You add this browser to it, and nothing
-changes about how you work. Install the browser server:
+changes about how you work. Install the browser server, then the browser
+itself: about 250 MB, once, where you can watch it come down.
 
 ```bash
 pip install invisible-playwright-mcp
+invisible-playwright fetch
 ```
 
 Then tell your assistant it exists.


### PR DESCRIPTION
Two commands instead of one: install the server, then fetch the browser, in a terminal where the 250 MB can be watched. The server would fetch it on its own the first time it starts, but that download happens out of sight, and a person who has just typed pip install is already in the right place to see it.