### PR TITLE
A verb for browser_watch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.8.0"
+version = "0.8.1"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -383,6 +383,7 @@ const VERB = {
   browser_press_key:['Pressing','Pressed'],    browser_read_text:['Reading','Read'],
   browser_read_html:['Reading','Read'],        browser_snapshot:['Inspecting','Inspected'],
   browser_evaluate:['Evaluating','Evaluated'], browser_take_screenshot:['Capturing','Captured'],
+  browser_watch:['Watching','Watched'],
   browser_select_option:['Choosing','Chose'],
   session_new_page:['Opening tab','Opened tab'],   session_select_page:['Switching tab','Switched tab'],
   session_close_page:['Closing tab','Closed tab'], session_list_pages:['Listing tabs','Listed tabs'],


### PR DESCRIPTION
invisible-playwright-mcp 0.15.0 added browser_watch, and a tool without a verb in this table renders as Called with raw arguments in the step list. The test that exists for exactly this went red on every open pull request.