### PR TITLE
The live pane is the window the server captures, not a page screenshot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.8.1"
+version = "0.9.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -48,7 +48,13 @@ dependencies = [
     # owner withdrew on 2026-09-06 so that the download is a thing a person
     # runs and watches; this interface stopped fetching before the port opens
     # for the same reason, in the same release.
-    "invisible-playwright-mcp>=0.14.0",
+    # 0.15.0: `browser_watch`, the window capture the live pane is built on
+    # since 2026-09-06 - tab strip, address bar, page and the pointer, which a
+    # page screenshot can never contain. Against 0.14.0 the pane would answer
+    # 503 on every frame with "unknown tool", so the floor is the pane.
+    # 0.15.0 was on the index before this line was written, as the rule above
+    # requires.
+    "invisible-playwright-mcp>=0.15.0",
     "mcp>=1.2",
     # Declared rather than inherited. It arrives transitively through mcp today,
     # and a transitive dependency is one somebody else can drop in a minor

--- a/src/aihawk/agent.py
+++ b/src/aihawk/agent.py
@@ -111,7 +111,7 @@ class Conversation:
         `call_tool(name, args)` performs a tool call and returns the MCP result;
         `tools` is the server's tool list. Both are passed rather than a session,
         so this has no opinion about how the browser is reached - which is what
-        lets the interface serialise its calls against the screenshot pump.
+        lets the interface serialise its calls against the frame pump.
         """
         if self.tool_defs is None:
             self.tool_defs = mcp_tools_to_openai(tools)

--- a/src/aihawk/link.py
+++ b/src/aihawk/link.py
@@ -1,8 +1,8 @@
 """One long-lived MCP connection, shared by the conversation and the live view.
 
 The connection outlives any single instruction, because the browser has to still
-be there when the next line is typed and the live pane has to keep photographing
-it in between. There was a second, shorter-lived form of this - `runner.drive`,
+be there when the next line is typed and the live pane has to keep watching it
+in between. There was a second, shorter-lived form of this - `runner.drive`,
 one task then close, behind an `aihawk do` subcommand - and both were removed on
 2026-09-03: one way in is the whole point of the page this serves.
 
@@ -115,11 +115,12 @@ def text_of(result) -> str:
 
 
 def image_of(result) -> "tuple[bytes, str] | None":
-    """The PNG bytes of a tool result that carries an image, or None.
+    """The image bytes of a tool result that carries one, with its MIME type, or None.
 
-    `browser_take_screenshot` answers with image content rather than text, and
-    over MCP that arrives base64-encoded. This is the only place that knows it,
-    so the live view never learns the wire format.
+    `browser_watch` and `browser_take_screenshot` answer with image content
+    rather than text, and over MCP that arrives base64-encoded with the type
+    beside it: JPEG for the window capture, PNG for a screenshot. This is the
+    only place that knows it, so the live view never learns the wire format.
     """
     import base64
 

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -17,11 +17,21 @@ Three consequences, each handled rather than hidden:
   `session_list_pages` calls `ensure`. `Link` remembers whether an instruction
   has been issued and the view stays quiet until then.
 
-  Screenshots and actions now share one pipe. They are serialised in `Link`, and
-  they would have been serialised by the browser anyway.
+  Frames and actions share one pipe. They are serialised in `Link`, and they
+  would have been serialised by the browser anyway.
 
   The page URL is no longer free. It is fetched on its own slower timer rather
   than with every frame, so watching costs one cheap call every two seconds.
+
+The picture on the right is `browser_watch`: the window as a person at the
+machine sees it - tab strip, address bar, the page and the pointer - from a
+capture the server keeps running on the active tab. It is not
+`browser_take_screenshot`, which the pane was built on until 2026-09-06. A
+screenshot is the page alone, and the engine draws the pointer outside the page
+on purpose so that no page can see it, so that pane could never show where the
+agent's hand was; and a page mid-load cannot be painted, so the pane went blank
+on every navigation. The window is always there to be captured, and a frame is
+one JPEG the server already holds rather than a paint it has to do.
 """
 from __future__ import annotations
 
@@ -35,7 +45,7 @@ from starlette.responses import HTMLResponse, JSONResponse, Response, StreamingR
 from starlette.routing import Route
 
 from .brain import Brain
-from .link import Link, image_of
+from .link import Link, image_of, text_of
 
 # A RAW string. The script below contains \n, \w and \s inside JavaScript
 # literals and regular expressions; in an ordinary triple-quoted string Python
@@ -54,7 +64,7 @@ PAGE = r"""<!doctype html>
   /* Surfaces as a ladder rather than two greys. The steps widen going up
      (5,7,7,8) because equal hex steps read as progressively smaller the lighter
      they get. */
-  --well:   #0b0d10;   /* recessed: behind the screenshot, the deepest thing here */
+  --well:   #0b0d10;   /* recessed: behind the frame, the deepest thing here */
   --base:   #101317;   /* the ground */
   --raised: #171b21;   /* composer, header, browser chrome, expanded output */
   --hover:  #1e232a;   /* row hover, and the user's own bubble */
@@ -286,7 +296,7 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
    before the first frame the whole browser collapsed to a 20px strip with the
    placeholder inside it, which reads as broken rather than as empty. Now the
    frame keeps a browser's shape from the first paint, and --arn moves it to the
-   real one as soon as a screenshot lands. */
+   real one as soon as a frame lands. */
 #shot{ aspect-ratio:var(--arn); min-height:0; position:relative;
        background:var(--well); display:grid; place-items:center }
 #frame{ width:100%; height:100%; object-fit:contain; object-position:top center;
@@ -558,7 +568,12 @@ const img = $('frame'), empty = $('empty'), right = $('right'), stateEl = $('sta
       browser = $('browser'), urlEl = $('url');
 let frozen = false;
 
-function say(s){ right.dataset.state = s; stateEl.textContent = s; }
+/* The second argument is the sentence behind a one-word state, shown on hover:
+   an "error" with no reason is a thing to restart, an "error" that says the
+   engine has no screencast is a thing to upgrade. */
+function say(s, why){ right.dataset.state = s; stateEl.textContent = s;
+                      stateEl.title = why || ''; }
+async function reason(r){ try { return (await r.json()).error || ''; } catch(err) { return ''; } }
 
 $('mode').onclick = (e) => {
   const b = e.target.closest('button'); if(!b) return;
@@ -579,16 +594,23 @@ async function tick(){
       if(img.naturalWidth) browser.style.setProperty(
         '--arn', (img.naturalWidth / img.naturalHeight).toFixed(4));
     }
-    /* Busy, not broken: a screenshot cannot be taken mid-navigation, and at this
-       rate an ordinary navigation produces several in a row. The last frame
-       stays on screen, because a stale picture of where the browser was beats a
-       red word about where it is going. */
-    else if(r.status === 503){ say('busy'); }
+    /* The capture could not answer, and the body says why: no frame within the
+       server's wait (a minimised window is captured as nothing), or an engine
+       without the screencast. While the pane was a screenshot this was "busy",
+       because a page mid-load cannot be painted and every navigation produced
+       a few; the window is always there to be captured, so a 503 now is a
+       thing to read. The last frame stays on screen either way: a stale
+       picture of where the browser was beats a blank pane. */
+    else if(r.status === 503){ say('error', await reason(r)); }
     else { say('error'); }
   } catch(err){ say('offline'); }
   /* Ask for the next frame only once this one has landed, or a browser slower
-     than the interval accumulates requests it can never serve. */
-  setTimeout(tick, 500);
+     than the interval accumulates requests it can never serve. A frame is one
+     JPEG the server already holds, not a paint, so five a second cost the pipe
+     almost nothing; the engine produces ten, and asking faster than that would
+     only show the same frame twice. Actions share this pipe and wait at most
+     one frame. */
+  setTimeout(tick, 200);
 }
 
 /* Built from elements with textContent and never innerHTML: this string comes
@@ -746,19 +768,41 @@ def build_app(link: Link, service: ChatService) -> Starlette:
                                  headers={"Cache-Control": "no-store"})
 
     async def frame(_request: Request) -> Response:
+        """The window the active tab lives in, as `browser_watch` captures it.
+
+        Not `browser_take_screenshot`: that is the page alone, and the engine
+        draws the pointer outside the page on purpose, so no screenshot can
+        show it. The window capture shows the pointer, the tab strip and the
+        address bar, keeps answering while a page loads, and costs one frame
+        the server already holds rather than a paint. The tool exists from
+        0.15.0 of the server, which is the floor pyproject declares.
+
+        The strip and the address in the picture are pixels; the ones the
+        page draws above it are the same facts as elements, and those can be
+        clicked and copied. Both stay.
+        """
         if not link.touched:
             # 204, not an error: nothing is wrong, there is simply nothing to
             # look at. Asking the server would START a browser, which is exactly
             # what a view is not allowed to cause.
             return Response(status_code=204)
         try:
-            got = image_of(await link.call("browser_take_screenshot"))
+            result = await link.call("browser_watch")
         except Exception as exc:
             return JSONResponse({"error": str(exc)[:200]}, status_code=503)
+        got = image_of(result)
         if got is None:
+            # A tool that raised reaches a client as an error RESULT with the
+            # reason as text, not as an exception: an engine without the
+            # screencast, or a window captured as nothing. That is a 503 with
+            # the reason, never a 204, which would read as "nothing to look at"
+            # in the one case where a person needs to read a sentence.
+            reason = text_of(result) if getattr(result, "isError", False) else ""
+            if reason:
+                return JSONResponse({"error": reason[:200]}, status_code=503)
             return Response(status_code=204)
-        png, mime = got
-        return Response(png, media_type=mime, headers={"Cache-Control": "no-store"})
+        jpeg, mime = got
+        return Response(jpeg, media_type=mime, headers={"Cache-Control": "no-store"})
 
     async def tabs(_request: Request) -> JSONResponse:
         """Every tab, and which one is current.

--- a/tests/test_ui_drive.py
+++ b/tests/test_ui_drive.py
@@ -237,12 +237,18 @@ PAGES = {
     "noise.html": NOISE_HTML,
 }
 
-# The tools the README promises and the agent hands to the model. A rename
-# upstream has to fail here rather than in a prompt.
+# The tools the server at the floor in pyproject offers, which the agent hands
+# to the model. A rename upstream has to fail here rather than in a prompt.
+# Eighteen since invisible-playwright-mcp 0.15.0: session_start and
+# session_status arrived with 0.11.0 and browser_watch with 0.15.0, and this
+# set stood at fifteen through all three because it is opt-in and nothing in
+# CI runs it - measured 2026-09-06, the day the pane moved to browser_watch.
 EXPECTED_TOOLS = {
+    "session_start", "session_status",
     "session_new_page", "session_list_pages", "session_select_page",
     "session_close_page", "browser_navigate", "browser_read_text",
     "browser_snapshot", "browser_read_html", "browser_take_screenshot",
+    "browser_watch",
     "browser_click", "browser_click_at", "browser_type", "browser_press_key",
     "browser_evaluate", "browser_select_option",
 }
@@ -473,7 +479,7 @@ def _ids(snapshot):
 def test_the_live_server_exposes_exactly_the_documented_tools(browser):
     """The tool set the agent converts is the one the README promises.
 
-    Known-bad: rename `browser_read_text` upstream, or add a fifteenth tool,
+    Known-bad: rename `browser_read_text` upstream, or add a nineteenth tool,
     and this fails. It matters because the system prompt in `agent.py` names
     tools in prose ("Inspect pages with browser_read_text / browser_snapshot"),
     and prose does not break when a name moves.
@@ -888,3 +894,33 @@ def test_a_click_at_coordinates_lands_but_reaches_the_model_as_no_content(browse
     shot = browser.call_result("browser_take_screenshot", {}, timeout=60.0)
     assert not shot.isError, _result_text_all(shot)
     assert _result_text(shot) == "[non-text result]"
+
+
+# --- what the live pane receives --------------------------------------------
+
+@pytest.mark.ui
+def test_the_window_capture_is_a_jpeg_that_the_pane_can_show(browser, site):
+    """The live pane is `browser_watch` since 2026-09-06, so what the pane
+    receives is checked here against a real server and a real browser, not
+    against a double: one image part, JPEG by type and by its first bytes, of
+    a size that is a picture and not a placeholder, and the same call answers
+    twice, which is what a pane asking five times a second relies on.
+
+    The route itself is covered in test_web_service.py with a double; this is
+    the half a double cannot prove - that the server the floor names really
+    answers this tool with a frame.
+    """
+    import base64
+
+    browser.goto(site + "input.html")
+    first = browser.call_result("browser_watch", {}, timeout=60.0)
+    assert not first.isError, _result_text_all(first)
+    images = [c for c in first.content if getattr(c, "data", None) is not None]
+    assert len(images) == 1, "one picture, and nothing else in the result"
+    assert images[0].mimeType == "image/jpeg"
+    jpeg = base64.b64decode(images[0].data)
+    assert jpeg[:3] == b"\xff\xd8\xff", "not a JPEG by its first bytes"
+    assert len(jpeg) > 4000, "a window with a tab strip and a page is more than this"
+
+    second = browser.call_result("browser_watch", {}, timeout=60.0)
+    assert not second.isError, _result_text_all(second)

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -13,6 +13,7 @@ tests is a claim rather than a feature.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 
 import pytest
@@ -233,6 +234,108 @@ async def test_the_live_view_asks_for_nothing_until_an_instruction_has_been_give
     resp = await frame.endpoint(Req())
     assert resp.status_code == 204
     assert link.calls == [], "the view asked the server something before any instruction"
+
+
+# --------------------------------------------------------------------------
+# the picture: the window the server captures, never a page screenshot
+# --------------------------------------------------------------------------
+
+# Two signatures a decoder would recognise, so a swapped MIME type cannot pass
+# on the bytes alone.
+JPEG = b"\xff\xd8\xff\xe0" + b"\x00\x10JFIF" + b"\x00" * 20
+PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 20
+
+
+class Item:
+    """One part of a tool result's content, shaped like the mcp types: an
+    ImageContent has `data` and `mimeType` and no `text`; a TextContent has
+    `text` and no `data`."""
+
+    def __init__(self, **fields):
+        self.__dict__.update(fields)
+
+
+class Result:
+    def __init__(self, *content, isError=False):
+        self.content = list(content)
+        self.isError = isError
+
+
+class WatchingLink(FakeLink):
+    """Answers both picture tools the way the server does - `browser_watch`
+    with a JPEG, `browser_take_screenshot` with a PNG - so which one the view
+    asked for is visible in what came back and not only in the call log."""
+
+    def __init__(self):
+        super().__init__()
+        self.touched = True
+
+    async def call(self, name, arguments=None):
+        await super().call(name, arguments)
+        if name == "browser_watch":
+            return Result(Item(type="image", data=base64.b64encode(JPEG).decode(),
+                               mimeType="image/jpeg"))
+        if name == "browser_take_screenshot":
+            return Result(Item(type="image", data=base64.b64encode(PNG).decode(),
+                               mimeType="image/png"))
+        return Result()
+
+
+async def _frame_route(link):
+    app = build_app(link, ChatService(link, SilentBrain()))
+    return [r for r in app.routes if r.path == "/live/frame"][0].endpoint
+
+
+async def test_the_live_view_is_the_window_capture_and_never_a_screenshot():
+    """`browser_watch`, not `browser_take_screenshot`.
+
+    A screenshot is the page alone, and the engine draws the pointer outside
+    the page on purpose so that no page can see it: a view built on screenshots
+    could never show where the agent's hand is, and it went blank on every
+    navigation because a page mid-load cannot be painted. The window capture
+    shows the pointer, the tab strip and the address bar, keeps answering while
+    a page loads, and is one frame the server already holds rather than a paint.
+
+    Known-bad: the route as it stood until 2026-09-06 asked for the screenshot,
+    and fails every line below the status.
+    """
+    link = WatchingLink()
+    route = await _frame_route(link)
+
+    class Req: query_params = {}
+    resp = await route(Req())
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/jpeg"
+    assert resp.body == JPEG
+    assert [n for n, _ in link.calls] == ["browser_watch"], (
+        "the picture is the window capture, and one call per frame")
+
+
+async def test_a_capture_that_cannot_answer_says_why_instead_of_looking_idle():
+    """A tool that raises reaches a client as an error RESULT carrying the
+    reason as text, not as an exception. Before this, such a result fell
+    through `image_of` into a 204, and the pane hid the picture and said "idle"
+    about an engine without the screencast - the one case where a person needs
+    to read a sentence. The reason now rides a 503, which the page shows.
+
+    Known-bad: the previous route answered 204 here.
+    """
+    class RefusingLink(WatchingLink):
+        async def call(self, name, arguments=None):
+            await FakeLink.call(self, name, arguments)
+            return Result(Item(type="text", text=(
+                "the live window view needs invisible-playwright with "
+                "page.screencast and an engine from firefox-28 on")), isError=True)
+
+    link = RefusingLink()
+    route = await _frame_route(link)
+
+    class Req: query_params = {}
+    resp = await route(Req())
+
+    assert resp.status_code == 503
+    assert "page.screencast" in json.loads(resp.body)["error"]
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
The right-hand pane asked browser_take_screenshot five times a second: the page alone, never the pointer, and blank on every navigation. It asks browser_watch now, the window as a person at the machine sees it, from the capture the server keeps running on the active tab. A capture that cannot answer used to look idle; the reason now rides a 503 onto the state label. Floor to invisible-playwright-mcp 0.15.0, where the tool arrived (on the index already), version 0.9.0. Both new route tests were red against the previous route; the opt-in UI suite passes 16 of 16 against a real server.