### PR TITLE
uv is the way in, because it is the one that works for every reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@
 ### 1. From your assistant, over MCP
 
 ```bash
-pip install aihawk
-invisible-playwright fetch
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"   # Windows: uv, once
+curl -LsSf https://astral.sh/uv/install.sh | sh                                         # Linux: uv, once
+uvx invisible-playwright fetch                                                          # in a new terminal
 ```
 
 Then tell your assistant it exists.
@@ -34,19 +35,19 @@ Then tell your assistant it exists.
 **Claude Code:**
 
 ```bash
-claude mcp add --scope user stealth -- invisible-playwright-mcp
+claude mcp add --scope user stealth -- uvx invisible-playwright-mcp
 ```
 
 **Codex:**
 
 ```bash
-codex mcp add stealth -- invisible-playwright-mcp
+codex mcp add stealth -- uvx invisible-playwright-mcp
 ```
 
 **Gemini CLI:**
 
 ```bash
-gemini mcp add --scope user stealth invisible-playwright-mcp
+gemini mcp add --scope user stealth uvx invisible-playwright-mcp
 ```
 
 ### 2. Standalone: the web UI
@@ -55,9 +56,10 @@ We bring the interface, you bring an [OpenRouter](https://openrouter.ai) key.
 Chat on the left, the live browser on the right.
 
 ```bash
-pip install aihawk
-invisible-playwright fetch
-aihawk ui --openrouter-key sk-or-...
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"   # Windows: uv, once
+curl -LsSf https://astral.sh/uv/install.sh | sh                                         # Linux: uv, once
+uvx invisible-playwright fetch                                                          # in a new terminal
+uvx aihawk ui --openrouter-key sk-or-...
 ```
 
 Then open **http://127.0.0.1:8765** and type the same thing.

--- a/docs/ai-agent-download-invoices.md
+++ b/docs/ai-agent-download-invoices.md
@@ -81,7 +81,7 @@ What runs well today, per portal:
    persistent profile and a visible window:
 
    ```bash
-   aihawk ui --headed --profile-dir ~/.hawk-invoices
+   uvx aihawk ui --headed --profile-dir ~/.hawk-invoices
    ```
 
    Ask the agent to open the portal's login page, then sign in yourself in

--- a/docs/ai-agent-lead-list.md
+++ b/docs/ai-agent-lead-list.md
@@ -66,7 +66,7 @@ Three lines, and each is a different kind of risk:
 
 Rows come from pages an organization already published to be read: a
 company's own about or contact page, a business directory, a conference's
-exhibitor list. Typed into `aihawk ui`, or handed to your assistant with
+exhibitor list. Typed into `uvx aihawk ui`, or handed to your assistant with
 AIHawk's browser attached:
 
 > Go to `<the exhibitor list page>`. For each exhibitor, open its entry and
@@ -148,7 +148,7 @@ generally on
 Retrieved 2026-09-05.
 
 - [AIHawk README](https://github.com/feder-cr/AIHawk#readme), for the
-  `aihawk ui` interface and the MCP path for assistants that can already
+  `uvx aihawk ui` interface and the MCP path for assistants that can already
   run tools.
 
 ---

--- a/docs/ai-agent-post-to-x.md
+++ b/docs/ai-agent-post-to-x.md
@@ -106,7 +106,7 @@ file-upload action, so an image post needs your hands for the attachment
 in a headed session; text and link posts are fully within reach.
 
 ```bash
-aihawk ui --profile-dir ~/.aihawk-x
+uvx aihawk ui --profile-dir ~/.aihawk-x
 ```
 
 > Go to x.com. Open the composer, type exactly this post, and stop without

--- a/docs/ai-agent-price-tracking.md
+++ b/docs/ai-agent-price-tracking.md
@@ -36,7 +36,7 @@ coupon-only price, a subscription price beside the one-time price. A vague
 between runs.
 
 Naming the one you want, and what to ignore, fixes that. Typed into
-`aihawk ui`, or handed to your assistant with AIHawk's browser attached:
+`uvx aihawk ui`, or handed to your assistant with AIHawk's browser attached:
 
 > Go to `<the product page URL>`. Find the price a first-time buyer pays
 > today: no subscription, no coupon. Ignore any crossed-out or "was" price. If
@@ -145,7 +145,7 @@ pages a day, a script is cheaper, faster, and the better tool.
 Retrieved 2026-09-05.
 
 - [AIHawk README](https://github.com/feder-cr/AIHawk#readme), for the
-  `aihawk ui` interface, the `--proxy` option and its effect on timezone,
+  `uvx aihawk ui` interface, the `--proxy` option and its effect on timezone,
   locale and egress, and the `--profile-dir` option for keeping a session
   between runs.
 

--- a/docs/ai-agent-to-test-website.md
+++ b/docs/ai-agent-to-test-website.md
@@ -39,7 +39,7 @@ code open - or from the terminal:
 > with placeholder data. Report every field, every validation message, and
 > whether registration succeeded.
 
-Typed into `aihawk ui`, which runs the task with the live page beside the
+Typed into `uvx aihawk ui`, which runs the task with the live page beside the
 chat - and for testing the watching is worth having: seeing the agent
 hesitate on your form is itself a finding. Two properties of
 this browser matter specifically for testing. It fills forms through real key

--- a/docs/ai-agent-web-research.md
+++ b/docs/ai-agent-web-research.md
@@ -87,7 +87,7 @@ scripted, one question per run:
 > the three most common price bands you observe. Ground every number in what
 > the pages show; do not estimate.
 
-(Typed into `aihawk ui`, or handed to your assistant with AIHawk's
+(Typed into `uvx aihawk ui`, or handed to your assistant with AIHawk's
 browser attached - research is judgment work, and since aihawk 0.3.0 the
 judgment paths are those two.)
 

--- a/docs/ai-apartment-hunting.md
+++ b/docs/ai-apartment-hunting.md
@@ -82,7 +82,7 @@ minutes is a bill and a signature.
 ## The workflow, concretely
 
 Reading listings against criteria is judgment work, so it runs where the
-model is: `aihawk ui`, or your assistant with AIHawk's browser attached.
+model is: `uvx aihawk ui`, or your assistant with AIHawk's browser attached.
 A worked instruction to paste, with the portal URL being whatever
 search-results page you have already set up by hand:
 
@@ -107,7 +107,7 @@ scheduled script on the same engine captures the listing count or the newest
 title each morning, and when that signal moves you bring the judgment prompt
 above to the agent. Once a day, or twice in a genuinely fast market. For
 interactive sessions - "open the third FIT and tell me what
-the photos show about the kitchen" - `aihawk ui` gives you the same
+the photos show about the kitchen" - `uvx aihawk ui` gives you the same
 agent beside a live browser view, and if you already use Claude Code or
 Claude Desktop, the same browser attaches to your assistant instead
 ([the setup page](running-aihawk-with-claude-code.md) has the one-liner).
@@ -172,7 +172,7 @@ binding, human reviews and submits. See
 All retrieved 2026-09-03.
 
 - The [AIHawk README](https://github.com/feder-cr/AIHawk#readme), for the
-  `aihawk ui` command, the MCP path for assistants, and the profile and
+  `uvx aihawk ui` command, the MCP path for assistants, and the profile and
   proxy behavior (updated for aihawk 0.3.0, which removed the `do`
   subcommand).
 - [Rightmove's terms-of-use page](https://www.rightmove.co.uk/this-site/terms-of-use.html),

--- a/docs/ai-browser-agent-local-llm.md
+++ b/docs/ai-browser-agent-local-llm.md
@@ -16,7 +16,7 @@ uses.
 
 ## The two routes, and the one that is not actually local
 
-`aihawk ui --openrouter-key ...` reaches OpenRouter and nowhere else. That is not
+`uvx aihawk ui --openrouter-key ...` reaches OpenRouter and nowhere else. That is not
 a default that can be pointed elsewhere with a flag: `src/aihawk/llm.py` hardcodes the
 OpenRouter base URL, and the `ui` command refuses to start at all without a key. If
 you came here hoping for `--ollama`, it does not exist in the current source.
@@ -41,7 +41,7 @@ The attachment mechanics do not change based on where the model lives. The
 shape, even though Claude Code's own model is hosted rather than local:
 
 ```bash
-claude mcp add --scope user stealth -- invisible-playwright-mcp
+claude mcp add --scope user stealth -- uvx invisible-playwright-mcp
 ```
 
 One command, once, and the browser's tools show up in that client from then on. A
@@ -107,7 +107,7 @@ the whole local approach is the wrong fit.
 
 ## Short answers to the questions that lead here
 
-**Can I use a local model with AIHawk's own interface?** No. `aihawk ui` only
+**Can I use a local model with AIHawk's own interface?** No. `uvx aihawk ui` only
 ever calls OpenRouter, hardcoded in the source. A local model means attaching this
 browser to a different client over MCP instead.
 

--- a/docs/ai-browser-agent-open-source.md
+++ b/docs/ai-browser-agent-open-source.md
@@ -107,7 +107,7 @@ which is where the star count and the TechCrunch, Business Insider and Wired cov
 came from, and it is now a general web agent. There are two ways in: add its MCP
 server (`invisible-playwright-mcp`) to an assistant that can run tools, such as
 Claude Code, Claude Desktop or Cursor, where the assistant brings the model, or run
-`aihawk ui` with an OpenRouter key and get a chat interface with a live browser
+`uvx aihawk ui` with an OpenRouter key and get a chat interface with a live browser
 view (the key is required; model-free browser driving is the underlying
 library's job).
 

--- a/docs/ai-browser-agent-vs-no-code-automation.md
+++ b/docs/ai-browser-agent-vs-no-code-automation.md
@@ -88,7 +88,7 @@ spends the agent's more expensive reasoning only where a connector
 genuinely does not exist. In practice that call-out is usually an HTTP
 request to whatever endpoint fronts the agent, or an MCP client talking to
 a server the agent exposes; AIHawk runs through
-`invisible-playwright-mcp` for exactly this kind of hookup. n8n's own
+`uvx invisible-playwright-mcp` for exactly this kind of hookup. n8n's own
 documentation describes the generic route in one line: the HTTP Request
 node "allows you to make HTTP requests to query data from any app or
 service with a REST API", and calls it one of the most versatile nodes

--- a/docs/ai-web-agent-explained.md
+++ b/docs/ai-web-agent-explained.md
@@ -117,7 +117,7 @@ Where this project sits, stated once and with its boundary: AIHawk is a local,
 open-source, structure-reading agent whose browser is a Firefox patched at the C++
 level rather than a stock automation build, which addresses the fingerprint layer
 of blocking and does nothing for the IP, volume or pacing layers. Two ways in, an
-MCP server for assistants like Claude Code, or `aihawk ui` with an OpenRouter
+MCP server for assistants like Claude Code, or `uvx aihawk ui` with an OpenRouter
 key. This is AIHawk's wiki, so weigh that paragraph as a maintainer describing his
 own tool.
 

--- a/docs/aihawk-review.md
+++ b/docs/aihawk-review.md
@@ -37,10 +37,10 @@ wiki documents; that earlier use is not covered here.
 There are two ways to run it, and they share one browser:
 
 - **Inside an assistant you already use.** One command
-  (`claude mcp add --scope user stealth -- invisible-playwright-mcp`)
+  (`claude mcp add --scope user stealth -- uvx invisible-playwright-mcp`)
   registers the browser as an MCP server in Claude Code, Claude Desktop or
   Cursor, and your assistant's model does the thinking.
-- **Standalone.** `aihawk ui` serves a local page with chat on the
+- **Standalone.** `uvx aihawk ui` serves a local page with chat on the
   left and the live browser on the right. It takes an
   [OpenRouter](https://openrouter.ai) key, defaults to `z-ai/glm-4.6`,
   and accepts `--model` for anything OpenRouter serves. Since 0.3.0 this
@@ -98,12 +98,12 @@ it is what the product is.
 - **No macOS.** Windows x86_64 and Linux x86_64/arm64 only; the last
   macOS engine build was `firefox-20`, and support ended. A Mac user
   cannot run the standalone product today.
-- **There is no free mode.** Since 0.4.0 `aihawk ui` refuses to start
+- **There is no free mode.** Since 0.4.0 `uvx aihawk ui` refuses to start
   without an OpenRouter key: an agent is a model with a browser, and tokens
   cost money. Driving the browser by hand without a model is the
   invisible_playwright library's job, not this product's.
 - **The browser is a quarter-gigabyte separate download** that arrives on
-  first use unless you pre-fetch it (`invisible-playwright fetch`),
+  first use unless you pre-fetch it (`uvx invisible-playwright fetch`),
   and a slow connection can time out confusingly on the first task.
 - **The model is not included, and results track the model.** A weak
   model drives the good browser badly;
@@ -172,7 +172,7 @@ zero-setup product, or the largest possible community -
 adopters, and the [alternatives hub](guides-alternatives-and-comparisons.md)
 compares the field with the same disclosure this page opens with. And
 whatever this page just told you, it was the project grading its own
-exam: run `aihawk ui` against a real task of yours, which costs an
+exam: run `uvx aihawk ui` against a real task of yours, which costs an
 afternoon and answers the only question that matters.
 
 ## Short answers to the questions that lead here

--- a/docs/browser-problem-or-model-problem.md
+++ b/docs/browser-problem-or-model-problem.md
@@ -74,7 +74,7 @@ These appear with any model, and with no model:
   failure's own page.
 - **The very first instruction ever hangs for minutes.** Probably not a
   failure at all: the browser engine, roughly a quarter of a gigabyte, downloads
-  on the first request that needs a page. `invisible-playwright fetch` in a
+  on the first request that needs a page. `uvx invisible-playwright fetch` in a
   terminal gets it over with where you can watch it.
 
 ## Symptoms that point at the model side

--- a/docs/claude-computer-use-detected-as-bot.md
+++ b/docs/claude-computer-use-detected-as-bot.md
@@ -100,7 +100,7 @@ them. This is the general agent-timing problem, and it has
    screenshotting a whole desktop, Claude Code, Claude Desktop or Cursor can drive a
    Firefox patched at the C++ level as a set of tools, via
    [invisible-playwright-mcp](https://github.com/feder-cr/invisible-playwright-mcp) -
-   one line for Claude Code: `claude mcp add --scope user stealth --
+   one line for Claude Code: `claude mcp add --scope user stealth -- uvx
    invisible-playwright-mcp`. Disclosure: that server and this wiki have the same
    maintainer, and it is the route [AIHawk](https://github.com/feder-cr/AIHawk)
    itself uses. For staying with the screenshot loop instead, the engine wiki shows

--- a/docs/how-to-monitor-a-page-with-an-ai-agent.md
+++ b/docs/how-to-monitor-a-page-with-an-ai-agent.md
@@ -69,7 +69,7 @@ next section shows, costs no model at all.
 
 ## Scheduling it: a script, as of aihawk 0.3.0
 
-Since 0.3.0 AIHawk itself is interactive-only (`aihawk ui`): there is no
+Since 0.3.0 AIHawk itself is interactive-only (`uvx aihawk ui`): there is no
 headless subcommand to put in cron anymore. That is less of a loss than it
 sounds, because the scheduled half of monitoring is deliberately mechanical -
 fetch the page, extract one signal, save it - and mechanical work belongs in
@@ -110,7 +110,7 @@ A real crontab line, deliberately not on the hour:
 17 8 * * *  python $HOME/hawk-mon/check_page.py >> $HOME/hawk-mon/$(date +\%F).txt 2>&1
 ```
 
-The interface (`aihawk ui`) has no scheduler; the recurring path is this
+The interface (`uvx aihawk ui`) has no scheduler; the recurring path is this
 script plus whatever scheduler your system already has.
 
 ## What to store between runs
@@ -132,7 +132,7 @@ means the memory of the monitor is yours to keep. Two files do it:
 
 - **The dated archive.** Keep every line with its timestamp. When the diff
   fires and the question becomes "does this change MATTER", that is the
-  judgment half - open `aihawk ui` (or your assistant with this browser
+  judgment half - open `uvx aihawk ui` (or your assistant with this browser
   attached) and ask exactly that, with the two saved lines pasted in. The
   agent earns its per-session cost only on the days something actually moved,
   which is the whole economics of the hybrid this page keeps arguing for.

--- a/docs/post-to-facebook-with-an-ai-agent.md
+++ b/docs/post-to-facebook-with-an-ai-agent.md
@@ -105,7 +105,7 @@ the session survives restarts - the README describes `--profile-dir` as a
 directory that keeps logins and cookies across runs:
 
 ```bash
-aihawk ui --profile-dir ~/.aihawk-facebook
+uvx aihawk ui --profile-dir ~/.aihawk-facebook
 ```
 
 Log in by hand in that first session. A login page is where a site's

--- a/docs/post-to-instagram-with-an-ai-agent.md
+++ b/docs/post-to-instagram-with-an-ai-agent.md
@@ -70,7 +70,7 @@ What works instead is a division of labor that is honest about who does
 what. Run headed, so the browser is a normal window on your desktop:
 
 ```bash
-aihawk ui --profile-dir ~/.aihawk-instagram --headed
+uvx aihawk ui --profile-dir ~/.aihawk-instagram --headed
 ```
 
 Log in yourself once; the profile directory keeps the session for later

--- a/docs/run-ai-agent-on-a-schedule.md
+++ b/docs/run-ai-agent-on-a-schedule.md
@@ -8,14 +8,14 @@ nav_order: 24
 
 # Run an AI browser agent on a schedule
 
-AIHawk's own interface has no headless mode: since 0.3.0 it is `aihawk ui`, a chat
+AIHawk's own interface has no headless mode: since 0.3.0 it is `uvx aihawk ui`, a chat
 window for a person watching, not a cron target. A scheduled run means one of two
 routes instead: a non-interactive assistant command that still spends tokens, or the
 invisible_playwright library driving fixed steps with no model at all.
 
 ## Why the interactive UI is the wrong shape for a cron job
 
-`aihawk ui` serves a small local web app, chat on the left, a live browser pane on
+`uvx aihawk ui` serves a small local web app, chat on the left, a live browser pane on
 the right, and it refuses to start without an OpenRouter key. That's a reasonable
 design for a person typing an instruction and watching the pointer move, and the
 wrong shape for a job starting at three in the morning with nobody at the keyboard.
@@ -148,7 +148,7 @@ Retrieved 2026-09-05.
 
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), this repo's README and
   `src/aihawk/cli.py`: the `ui` subcommand, its OpenRouter-key requirement, its
-  run-until-interrupted server loop, and the `invisible-playwright fetch`
+  run-until-interrupted server loop, and the `uvx invisible-playwright fetch`
   prefetch command.
 
 ---

--- a/docs/running-aihawk-with-claude-code.md
+++ b/docs/running-aihawk-with-claude-code.md
@@ -23,37 +23,41 @@ file instead of a command, and have their own pages:
 the [server's README](https://github.com/feder-cr/invisible-playwright-mcp),
 which is the one place they are kept current.
 
-## The three lines
+## The one line
 
-One prerequisite, the same as everywhere in this project: Python 3.11 or newer
-on Windows (x86_64) or Linux (x86_64, arm64) - macOS is not supported, the last
-engine build for it was `firefox-20`. Then, once:
+Two prerequisites, same as everywhere in this project: Python 3.11 or newer on
+Windows (x86_64) or Linux (x86_64, arm64) - macOS is not supported, the last
+engine build for it was `firefox-20` - and [uv](https://docs.astral.sh/uv/),
+because the command runs the server with `uvx`. Then, once:
 
 ```bash
-pip install aihawk
-invisible-playwright fetch
-claude mcp add --scope user stealth -- invisible-playwright-mcp
+claude mcp add --scope user stealth -- uvx invisible-playwright-mcp
 ```
 
-The first line installs AIHawk and, with it, the MCP server. The second
-downloads the browser itself, a patched Firefox of roughly a quarter of a
-gigabyte, once, in a terminal where you can watch it. Reading the third left to
-right: `--scope user` registers the server at user scope, so it is available in
-every project rather than only the directory you happened to be in; `stealth`
-is the name it appears under; everything after `--` is the command Claude Code
-will run to start the server, which the first line put on your PATH. Start a
-fresh Claude Code session afterwards if one was already open, and `/mcp` should
-list `stealth` among the connected servers.
+Reading it left to right: `--scope user` registers the server at user scope, so it
+is available in every project rather than only the directory you happened to be
+in; `stealth` is the name it appears under; everything after `--` is the
+command Claude Code will run to start the server, and `uvx` fetches and runs
+the published package, so there is nothing to clone or pip-install first. Start
+a fresh Claude Code session afterwards if one was already open, and `/mcp`
+should list `stealth` among the connected servers.
 
-## First run, if you skipped the fetch
+## First run: the download nobody warns you about
 
-Installing the server does not install the browser; the second line above
-does. Skip it and the engine downloads on the first request that needs a page,
-which, from inside a chat, looks like your first browsing prompt sitting there
-doing nothing, and on a slow connection can end in a timeout message that says
-nothing about a download. Run `invisible-playwright fetch` in a terminal
-instead; it is cached afterwards and shared by every way into the engine,
-including AIHawk's own interface if you later run that too.
+Installing the server does not install the browser. The engine is a patched
+Firefox of roughly a quarter of a gigabyte, and it downloads on the first
+request that needs a page - which, from inside a chat, looks like your first
+browsing prompt sitting there doing nothing, and on a slow connection can end
+in a timeout message that says nothing about a download.
+
+Get it over with first, in a terminal where you can watch the progress:
+
+```bash
+uvx invisible-playwright fetch
+```
+
+It is cached afterwards and shared by every way into the engine, including
+AIHawk's own interface if you later run that too.
 
 ## What Claude actually gains
 
@@ -105,10 +109,9 @@ results, and short steps keep its context small and its mistakes cheap.
 - **`stealth` is not listed in `/mcp`.** Run `claude mcp list` in a terminal
   to see what is registered and at which scope. If the add command was run
   while a session was open, the running session may not know it yet; start a
-  new one. If `invisible-playwright-mcp` is not on your PATH, the server can
-  be registered and still fail to start: run it by hand in a terminal, which
-  surfaces the real error, or register it as
-  `python -m invisible_playwright_mcp` instead of the bare name.
+  new one. If `uvx` is not on your PATH, the server can be registered and
+  still fail to start - install uv and try `uvx invisible-playwright-mcp` by
+  hand, which surfaces the real error.
 - **The first browsing prompt hangs or times out.** Almost always the engine
   download. Run the prefetch command above and retry; afterwards a first page
   load is seconds, not minutes.
@@ -125,9 +128,8 @@ results, and short steps keep its context small and its mistakes cheap.
 ## Short answers to the questions that lead here
 
 **How do I add AIHawk's browser to Claude Code?**
-`pip install aihawk`, `invisible-playwright fetch`, then
-`claude mcp add --scope user stealth -- invisible-playwright-mcp`, once. New
-sessions then have the browser tools in `/mcp`.
+`claude mcp add --scope user stealth -- uvx invisible-playwright-mcp`, once, with uv
+installed. New sessions then have the browser tools in `/mcp`.
 
 **Do I need an OpenRouter key for this?** No. The key is only for AIHawk's own
 interface and CLI, where AIHawk must bring a model. In Claude Code, Claude is
@@ -135,7 +137,7 @@ the model.
 
 **Why does the first browsing request take so long?** The engine, about a
 quarter of a gigabyte, downloads on the first request that needs a page. Run
-`invisible-playwright fetch` once in a terminal to do it up front.
+`uvx invisible-playwright fetch` once in a terminal to do it up front.
 
 **Is this different from what AIHawk's own UI drives?** No - same server, same
 engine, same tools. The interface is just another MCP client of it, with no
@@ -153,8 +155,9 @@ client starts its own - so a page open in one is not visible in the other.
 All retrieved 2026-09-03.
 
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), this repository's
-  README (the verbatim install, fetch and add commands, "anything the
-  interface can do, your assistant can do too") and source: `src/aihawk/link.py` and `src/aihawk/web.py` (the
+  README (the verbatim add command, the prerequisites and platforms, the
+  engine download and prefetch, "anything the interface can do, your assistant
+  can do too") and source: `src/aihawk/link.py` and `src/aihawk/web.py` (the
   interface reaching the browser over MCP as an ordinary client),
   `src/aihawk/actions_help.py` (the tool names above), and `pyproject.toml`
   (the server version floor and why `browser_select_option` is in it).
@@ -171,5 +174,5 @@ and [browser problem or model problem?](browser-problem-or-model-problem.md).
 
 *From the [AIHawk](https://github.com/feder-cr/AIHawk) wiki. Claude Code is
 the shortest route into this browser - one command, against a config file
-everywhere else - and the README puts the engine fetch right after the install,
-so consider yourself warned.*
+everywhere else - and the README calls the engine fetch "the download nobody
+warns you about", so consider yourself warned.*

--- a/docs/running-aihawk-with-claude-desktop.md
+++ b/docs/running-aihawk-with-claude-desktop.md
@@ -26,8 +26,7 @@ combination is a Windows setup today.
 
 ## What changes after the server is added
 
-Mechanically: `pip install aihawk` and `invisible-playwright fetch` in a
-terminal, then you edit the config (Desktop's Settings, under Developer, has an
+Mechanically: you edit the config (Desktop's Settings, under Developer, has an
 Edit Config button that opens the right file), paste the server block from the
 README, then quit Desktop completely and restart it. The full restart is not
 superstition; Desktop loads MCP servers at startup, and the official MCP
@@ -112,7 +111,7 @@ In the order people hit them:
    a terminal where you can watch progress:
 
    ```bash
-   invisible-playwright fetch
+   uvx invisible-playwright fetch
    ```
 
    The engine is cached afterwards and shared with every other way into
@@ -124,13 +123,12 @@ In the order people hit them:
    own errors - and the MCP quickstart documents where they live on each
    platform. Read the per-server log before guessing.
 
-3. **The command is not found.** The config launches
-   `invisible-playwright-mcp`, which `pip install aihawk` put on your PATH, and
-   a GUI application does not always inherit your shell's PATH: a terminal
-   that finds it does not guarantee Desktop does. If the per-server log shows
-   a not-found error, give `command` the absolute path to the script
-   (`where invisible-playwright-mcp` on Windows), or your Python's absolute
-   path with `["-m", "invisible_playwright_mcp"]` as the arguments.
+3. **`uvx` is not found.** The config launches the server with `uvx`, which
+   means [uv](https://docs.astral.sh/uv/) must be installed, and installed
+   where a GUI application can see it. A shell that finds `uvx` does not
+   guarantee Desktop does, since GUI apps do not always inherit your shell's
+   PATH; if the per-server log shows a not-found error, the server README's
+   troubleshooting is the place to start.
 
 4. **It is a Mac.** No engine build, per the boundary at the top. Nothing to
    debug.
@@ -142,20 +140,19 @@ In the order people hit them:
 
 ## Short answers to the questions that lead here
 
-**How do I add AIHawk's browser to Claude Desktop?** `pip install aihawk` and
-`invisible-playwright fetch` in a terminal, then paste the server block from
-the [server README](https://github.com/feder-cr/invisible-playwright-mcp) into
-Desktop's MCP config (Settings, Developer, Edit Config), then fully quit and
-restart Desktop. The block and file path live in that README on purpose.
+**How do I add AIHawk's browser to Claude Desktop?** Paste the server block
+from the [server README](https://github.com/feder-cr/invisible-playwright-mcp)
+into Desktop's MCP config (Settings, Developer, Edit Config), then fully quit
+and restart Desktop. The block and file path live in that README on purpose.
 
 **Do I need an API key for this?** No. Your Claude subscription is the model;
 the server only adds the browser, and its config block contains no secret. The
 OpenRouter key belongs to a different way in, AIHawk's own interface
-(`aihawk ui`), which requires one.
+(`uvx aihawk ui`), which requires one.
 
 **Why does the first instruction take so long?** The engine downloads on the
 first call that needs a page, about a quarter of a gigabyte, and nothing warns
-you. Prefetch it with `invisible-playwright fetch` and the first
+you. Prefetch it with `uvx invisible-playwright fetch` and the first
 instruction behaves like every later one.
 
 **Why can I not see the browser?** It runs headless by default; screenshots

--- a/docs/running-aihawk-with-cline.md
+++ b/docs/running-aihawk-with-cline.md
@@ -27,11 +27,10 @@ engine to run. This combination works on Windows and Linux today.
 
 ## What changes after the server is added
 
-After `pip install aihawk` and `invisible-playwright fetch` in a terminal,
-paste the README's block under `mcpServers` in the file the Configure tab
+Paste the README's block under `mcpServers` in the file the Configure tab
 opens, and Cline gains the browser as a set of tools. A server entry in that
-file carries a `command` and `args` (here: `invisible-playwright-mcp`, which
-the install put on your PATH, and no arguments), an optional `env` map, and two Cline-side
+file carries a `command` and `args` (here: `uvx` running
+`invisible-playwright-mcp`), an optional `env` map, and two Cline-side
 fields worth knowing from day one: `disabled`, which switches a server off
 without deleting its entry, and `autoApprove`, a list of tool names allowed
 to run without asking you each time.
@@ -111,20 +110,17 @@ two most useful for repeated testing sessions.
    where you can watch:
 
    ```bash
-   invisible-playwright fetch
+   uvx invisible-playwright fetch
    ```
 
    The engine is cached and shared with every other way into AIHawk.
 
 2. **The server never appears.** Check the JSON you pasted (a trailing comma
-   is the classic), and check that `invisible-playwright-mcp` resolves for
-   the process VS Code runs: `pip install aihawk` put it on your PATH, but an
-   editor does not always inherit your shell's PATH, so one working terminal
-   is no guarantee. If it is not found, give `command` the absolute path to
-   the script (`where invisible-playwright-mcp` on Windows, `which`
-   elsewhere), or your Python's absolute path with
-   `["-m", "invisible_playwright_mcp"]` as the arguments. The `disabled`
-   field is also worth a glance before deeper debugging.
+   is the classic), and check that `uvx` resolves for the process VS Code
+   runs: the block launches the server with `uvx`, so
+   [uv](https://docs.astral.sh/uv/) must be installed where the editor finds
+   it, which one working shell does not guarantee. The `disabled` field is
+   also worth a glance before deeper debugging.
 
 3. **Every step asks permission.** That is the design default, and while you
    are learning what the browser does, keep it. Loosen deliberately by
@@ -143,8 +139,7 @@ two most useful for repeated testing sessions.
 
 ## Short answers to the questions that lead here
 
-**How do I add AIHawk's browser to Cline?** `pip install aihawk` and
-`invisible-playwright fetch` in a terminal; then MCP Servers icon in Cline's
+**How do I add AIHawk's browser to Cline?** MCP Servers icon in Cline's
 toolbar, Configure tab, Configure MCP Servers, then paste the block from the
 [server README](https://github.com/feder-cr/invisible-playwright-mcp) under
 `mcpServers` and save. No key, no signup; Cline's model does the thinking.
@@ -156,11 +151,11 @@ chosen tools run unasked; keep it to reading tools while the browser is new.
 **Do I need an API key for the browser?** No. The server's block carries no
 secret and there is nothing to sign up for; your existing Cline model setup
 is untouched. The OpenRouter key belongs to AIHawk's own interface
-(`aihawk ui`), a different way in, and that one requires it.
+(`uvx aihawk ui`), a different way in, and that one requires it.
 
 **Why is the first instruction so slow?** Engine download: about a quarter
 of a gigabyte on the first call that needs a page, silent from the editor's
-side. `invisible-playwright fetch` in a terminal moves that wait to a
+side. `uvx invisible-playwright fetch` in a terminal moves that wait to a
 moment you choose.
 
 **Can I watch it drive?** Headless by default, screenshots as the window.

--- a/docs/running-aihawk-with-cursor.md
+++ b/docs/running-aihawk-with-cursor.md
@@ -55,9 +55,7 @@ at length.
 
 ## Config: project or global, and how Cursor runs the tools
 
-Two terminal steps come first, `pip install aihawk` and
-`invisible-playwright fetch`; the JSON only tells Cursor how to start what they
-installed. Choose the level by audience. Global (`~/.cursor/mcp.json`) makes the browser
+Choose the level by audience. Global (`~/.cursor/mcp.json`) makes the browser
 available in every project, which fits a personal research tool. Project-level
 (`.cursor/mcp.json`) travels with the repository, which fits a team that wants
 "the agent can drive our staging app" to be part of the checkout. The server's
@@ -120,19 +118,16 @@ identity seed are the two most useful for repeated testing).
    download. Prefetch it once, in a terminal where you can watch:
 
    ```bash
-   invisible-playwright fetch
+   uvx invisible-playwright fetch
    ```
 
    The engine is cached and shared with every other way into AIHawk.
 
 2. **The server does not appear in Cursor's MCP list.** Check the JSON, check
-   the file is at one of the two documented locations, and check that
-   `invisible-playwright-mcp` resolves for Cursor: `pip install aihawk` put it
-   on your PATH, but an editor does not always inherit your shell's PATH, so
-   one working terminal is no guarantee. If it is not found, give `command`
-   the absolute path to the script (`where invisible-playwright-mcp` on
-   Windows, `which` elsewhere), or your Python's absolute path with
-   `["-m", "invisible_playwright_mcp"]` as the arguments.
+   the file is at one of the two documented locations, and check that `uvx`
+   resolves for Cursor: the config launches the server with `uvx`, so
+   [uv](https://docs.astral.sh/uv/) must be installed where the editor can
+   find it, which is not guaranteed by it working in one particular shell.
 
 3. **Tools exist but every step asks permission.** That is the documented
    default, and while you are learning what the browser does, leave it on.
@@ -148,8 +143,7 @@ identity seed are the two most useful for repeated testing).
 
 ## Short answers to the questions that lead here
 
-**How do I add AIHawk's browser to Cursor?** `pip install aihawk` and
-`invisible-playwright fetch` in a terminal, then paste the block from the
+**How do I add AIHawk's browser to Cursor?** Paste the block from the
 [server README](https://github.com/feder-cr/invisible-playwright-mcp) into
 `.cursor/mcp.json` in a project or `~/.cursor/mcp.json` globally, both
 locations per Cursor's own MCP docs. No key, no signup; Cursor's model does
@@ -171,7 +165,7 @@ browser.
 
 **Why is the first instruction so slow?** Engine download: a quarter of a
 gigabyte on the first call that needs a page, silent from the editor's side.
-`invisible-playwright fetch` in a terminal moves that cost to a moment you
+`uvx invisible-playwright fetch` in a terminal moves that cost to a moment you
 choose.
 
 **Can I watch the browser work?** By default no, it is headless and the


### PR DESCRIPTION
Owner decision, 2026-09-06, after measuring the alternatives and reading what comparable projects do. pip install aihawk is refused outside a virtual environment on current Ubuntu and Debian, and on Windows a Store Python or an install without Add to PATH leaves the commands unreachable; browser-use, aider and the official MCP servers all lead with uv for the same reason. Both blocks now install uv once, one line per system, then run everything through uvx.

The wiki goes back to the uv form it had yesterday.