### PR TITLE
One complete block per system, and it works as pasted

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,19 @@
 
 ### 1. From your assistant, over MCP
 
-Windows:
+Windows, in PowerShell:
 
 ```powershell
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+$env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
+uvx invisible-playwright fetch
 ```
 
 Linux:
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-Then, in a new terminal, on either:
-
-```bash
+source $HOME/.local/bin/env
 uvx invisible-playwright fetch
 ```
 
@@ -67,21 +65,20 @@ gemini mcp add --scope user stealth uvx invisible-playwright-mcp
 We bring the interface, you bring an [OpenRouter](https://openrouter.ai) key.
 Chat on the left, the live browser on the right.
 
-Windows:
+Windows, in PowerShell:
 
 ```powershell
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+$env:Path = "$env:USERPROFILE\.local\bin;$env:Path"
+uvx invisible-playwright fetch
+uvx aihawk ui --openrouter-key sk-or-...
 ```
 
 Linux:
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-Then, in a new terminal, on either:
-
-```bash
+source $HOME/.local/bin/env
 uvx invisible-playwright fetch
 uvx aihawk ui --openrouter-key sk-or-...
 ```

--- a/scripts/check_content.py
+++ b/scripts/check_content.py
@@ -15,10 +15,10 @@ real incident rather than a hypothetical:
   4. Internal links. Every `](page.md)` in docs/ must point at a page that
      exists, and image assets must carry no metadata chunks.
   5. The way in is written once. The README's code blocks are the source:
-     the lines that install uv (one fence per system) and the line that
-     fetches the engine, whose leading word is the launcher in front of every
-     command (`uvx` today). A page that carries the uv installer carries
-     those lines verbatim, every code block runs `aihawk ui`, the server and
+     in every fence that installs uv (one per system), the run from the
+     installer line through the fetch line, PATH line included; and the first
+     fetch line names the launcher in front of every command (`uvx` today).
+     A page that carries the uv installer carries those lines verbatim, every code block runs `aihawk ui`, the server and
      the fetch with the README's launcher, and no page teaches a way in that
      the README does not (`pip install aihawk`). On 2026-09-06 the route went
      uv, pip, uv in one day, and each flip touched the README plus twenty-odd
@@ -96,24 +96,34 @@ def fenced_blocks(text):
 
 
 def way_in(readme_text):
-    """(launcher, install lines) as the README teaches them: every fenced line
-    that installs uv, in order and once, plus the first fenced line that
-    fetches the engine, whose leading word is the launcher. The README keeps
-    one fence per system for the installer and a shared fence for the rest, so
-    the lines are collected across fences rather than read from one block.
+    """(launcher, install lines) as the README teaches them.
+
+    The README keeps one complete fence per system. In each fence that carries
+    the uv installer, the install lines are the run from the installer line
+    through the fetch line: the installer itself asks for a PATH line before
+    `uvx` works in the same shell, and a page that copies the installer
+    without it teaches a command that fails. Collected in order and once
+    across fences. The launcher is the word before the first fetch line.
     (None, None) without a fetch line."""
-    installer, fetch, launcher = [], None, None
+    install, fetch, launcher = [], None, None
     for block in fenced_blocks(readme_text):
+        taking = False
         for line in block:
-            if INSTALLER in line and line.rstrip() not in installer:
-                installer.append(line.rstrip())
-            if fetch is None and "invisible-playwright fetch" in line:
-                before = line.split("invisible-playwright fetch")[0].split()
-                launcher = before[-1] if before else ""
-                fetch = line.rstrip()
+            if INSTALLER in line:
+                taking = True
+            if taking and line.strip() and line.rstrip() not in install:
+                install.append(line.rstrip())
+            if "invisible-playwright fetch" in line:
+                if fetch is None:
+                    before = line.split("invisible-playwright fetch")[0].split()
+                    launcher = before[-1] if before else ""
+                    fetch = line.rstrip()
+                taking = False
     if fetch is None:
         return None, None
-    return launcher, installer + [fetch]
+    if fetch not in install:
+        install.append(fetch)
+    return launcher, install
 
 
 def check_way_in(rel, text, launcher, block, readme_text):
@@ -268,11 +278,14 @@ def selftest():
         # The README is the source the fifth check reads: one block, one
         # launcher, the same shape as the real page.
         (root / "README.md").write_bytes(
-            b"# AIHawk\n\nWindows:\n\n```powershell\n"
+            b"# AIHawk\n\nWindows, in PowerShell:\n\n```powershell\n"
             b'powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"\n'
+            b'$env:Path = "$env:USERPROFILE\\.local\\bin;$env:Path"\n'
+            b"uvx invisible-playwright fetch\n"
+            b"uvx aihawk ui --openrouter-key sk-or-...\n"
             b"```\n\nLinux:\n\n```bash\n"
             b"curl -LsSf https://astral.sh/uv/install.sh | sh\n"
-            b"```\n\nThen, in a new terminal, on either:\n\n```bash\n"
+            b"source $HOME/.local/bin/env\n"
             b"uvx invisible-playwright fetch\n"
             b"uvx aihawk ui --openrouter-key sk-or-...\n"
             b"```\n")
@@ -299,6 +312,15 @@ def selftest():
             "one system's installer line, exact, without the rest": (
                 "docs/onlyone.md",
                 b"```bash\ncurl -LsSf https://astral.sh/uv/install.sh | sh\n```\n"),
+            "the installer and the fetch without the PATH line between them": (
+                "docs/nopath.md",
+                b"```powershell\n"
+                b'powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"\n'
+                b"uvx invisible-playwright fetch\n"
+                b"```\n```bash\n"
+                b"curl -LsSf https://astral.sh/uv/install.sh | sh\n"
+                b"uvx invisible-playwright fetch\n"
+                b"```\n"),
             "config block with another launcher": (
                 "docs/cfg.md",
                 b'```json\n{"command": "python", '
@@ -336,9 +358,11 @@ def selftest():
                 "docs/same.md",
                 b"```powershell\n"
                 b'powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"\n'
+                b'$env:Path = "$env:USERPROFILE\\.local\\bin;$env:Path"\n'
+                b"uvx invisible-playwright fetch\n"
                 b"```\n```bash\n"
                 b"curl -LsSf https://astral.sh/uv/install.sh | sh\n"
-                b"```\n```bash\n"
+                b"source $HOME/.local/bin/env\n"
                 b"uvx invisible-playwright fetch\n"
                 b"```\n"),
             "config block with the README's launcher": (


### PR DESCRIPTION
A reader on Windows now reads only the Windows block and a reader on Linux only the Linux one: installer, the PATH line the installer itself asks for, the fetch, and for the UI way the run line. No shared fence is left. The content gate now takes, in every fence that installs uv, the run from the installer through the fetch, so a page that copies the installer without the PATH line is refused; one more mutation in the selftest says so.