### PR TITLE
Version 0.9.1: the README on the index shows the two ways as they are on main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.9.0"
+version = "0.9.1"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
No code changed since 0.9.0. The README is the package description on PyPI, and the one there still teaches pip install aihawk, which this repository stopped carrying today.