### PR TITLE
One command: aihawk is the server, aihawk ui the interface (0.11.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           /tmp/clean/bin/pip install dist/*.whl
           /tmp/clean/bin/aihawk --help
           /tmp/clean/bin/python -c "import aihawk.web, aihawk.brain, aihawk.link, aihawk.cli, aihawk.mcp.server"
-          test -x /tmp/clean/bin/invisible-playwright-mcp
+          /tmp/clean/bin/python -m aihawk --help > /dev/null
           unzip -l dist/*.whl | grep -q "aihawk/mcp/server.py"
 
   # 2026-09-04: aihawk 0.4.0 went to the index, then main gained two more

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -126,7 +126,7 @@ jobs:
           python -m venv /tmp/clean
           /tmp/clean/bin/pip install dist/*.whl
           /tmp/clean/bin/aihawk --help
-          test -x /tmp/clean/bin/invisible-playwright-mcp
+          /tmp/clean/bin/python -m aihawk --help > /dev/null
           /tmp/clean/bin/python -c "import aihawk.mcp.server"
           unzip -l dist/*.whl | grep -q "aihawk/mcp/server.py"
 

--- a/README.md
+++ b/README.md
@@ -45,19 +45,19 @@ Then tell your assistant it exists.
 **Claude Code:**
 
 ```bash
-claude mcp add --scope user stealth -- uvx invisible-playwright-mcp
+claude mcp add --scope user stealth -- uvx aihawk
 ```
 
 **Codex:**
 
 ```bash
-codex mcp add stealth -- uvx invisible-playwright-mcp
+codex mcp add stealth -- uvx aihawk
 ```
 
 **Gemini CLI:**
 
 ```bash
-gemini mcp add --scope user stealth uvx invisible-playwright-mcp
+gemini mcp add --scope user stealth uvx aihawk
 ```
 
 ### 2. Standalone: the web UI
@@ -149,8 +149,8 @@ among others. Worked examples, transcripts and their outputs live in
 
 ## The rest of the family: engine, core
 
-The MCP server from option 1 ships inside this package: the command
-`invisible-playwright-mcp`, the module `aihawk.mcp`. Its config blocks for
+The MCP server from option 1 ships inside this package: `aihawk` with no
+subcommand is the server, `aihawk ui` the interface. Its config blocks for
 clients that take a file, its settings and its tools are on the wiki page
 [The MCP server](https://github.com/feder-cr/AIHawk/wiki/mcp-server).
 

--- a/docs/ai-browser-agent-local-llm.md
+++ b/docs/ai-browser-agent-local-llm.md
@@ -41,7 +41,7 @@ The attachment mechanics do not change based on where the model lives. The
 shape, even though Claude Code's own model is hosted rather than local:
 
 ```bash
-claude mcp add --scope user stealth -- uvx invisible-playwright-mcp
+claude mcp add --scope user stealth -- uvx aihawk
 ```
 
 One command, once, and the browser's tools show up in that client from then on. A

--- a/docs/ai-browser-agent-vs-no-code-automation.md
+++ b/docs/ai-browser-agent-vs-no-code-automation.md
@@ -88,7 +88,7 @@ spends the agent's more expensive reasoning only where a connector
 genuinely does not exist. In practice that call-out is usually an HTTP
 request to whatever endpoint fronts the agent, or an MCP client talking to
 a server the agent exposes; AIHawk runs through
-`uvx invisible-playwright-mcp` for exactly this kind of hookup. n8n's own
+`uvx aihawk` for exactly this kind of hookup. n8n's own
 documentation describes the generic route in one line: the HTTP Request
 node "allows you to make HTTP requests to query data from any app or
 service with a REST API", and calls it one of the most versatile nodes

--- a/docs/aihawk-review.md
+++ b/docs/aihawk-review.md
@@ -37,7 +37,7 @@ wiki documents; that earlier use is not covered here.
 There are two ways to run it, and they share one browser:
 
 - **Inside an assistant you already use.** One command
-  (`claude mcp add --scope user stealth -- uvx invisible-playwright-mcp`)
+  (`claude mcp add --scope user stealth -- uvx aihawk`)
   registers the browser as an MCP server in Claude Code, Claude Desktop or
   Cursor, and your assistant's model does the thinking.
 - **Standalone.** `uvx aihawk ui` serves a local page with chat on the

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -14,13 +14,13 @@ reader, on a Firefox whose fingerprint is set inside the engine rather than
 bolted onto the page.
 
 The engine is [`invisible-playwright`](https://github.com/feder-cr/invisible_playwright),
-a Firefox patched at the C++ source. Since aihawk 0.10.0 the server ships
-inside the `aihawk` package, as the module `aihawk.mcp` and the command
-`invisible-playwright-mcp`: every tool below is a thin wrapper over the engine,
-and the interface the rest of this wiki describes is a client of it like any
-other. The PyPI name `invisible-playwright-mcp` lives on as a shim over
-`aihawk`, so `uvx invisible-playwright-mcp` keeps starting it and nothing
-changes in a client that already has it registered.
+a Firefox patched at the C++ source. The server ships inside the `aihawk`
+package and is what `aihawk` runs with no subcommand: `uvx aihawk` is what a
+client registers, `python -m aihawk` is what the interface spawns. Every tool
+below is a thin wrapper over the engine, and the interface (`aihawk ui`) is a
+client of it like any other. The PyPI name `invisible-playwright-mcp` lives on
+as a shim over `aihawk`, so a client that registered
+`uvx invisible-playwright-mcp` before 0.11.0 keeps working unchanged.
 
 **How to install this, and the two ways to use it, are in
 [AIHawk's README](https://github.com/feder-cr/AIHawk#readme).** This page keeps
@@ -45,7 +45,7 @@ shows.
   "mcpServers": {
     "stealth": {
       "command": "uvx",
-      "args": ["invisible-playwright-mcp"]
+      "args": ["aihawk"]
     }
   }
 }
@@ -67,7 +67,7 @@ shows.
   "context_servers": {
     "stealth": {
       "command": "uvx",
-      "args": ["invisible-playwright-mcp"]
+      "args": ["aihawk"]
     }
   }
 }
@@ -81,7 +81,7 @@ shows.
     "stealth": {
       "type": "stdio",
       "command": "uvx",
-      "args": ["invisible-playwright-mcp"]
+      "args": ["aihawk"]
     }
   }
 }
@@ -92,7 +92,7 @@ shows.
 ```toml
 [mcp_servers.stealth]
 command = "uvx"
-args = ["invisible-playwright-mcp"]
+args = ["aihawk"]
 ```
 
 **Continue** uses YAML with its own block format, which changed recently enough
@@ -110,7 +110,7 @@ whatever shape your client uses:
   "mcpServers": {
     "stealth": {
       "command": "uvx",
-      "args": ["invisible-playwright-mcp"],
+      "args": ["aihawk"],
       "env": {
         "STEALTHFOX_PROXY": "http://user:pass@proxy.example.com:8080",
         "STEALTHFOX_SEED": "4242"
@@ -285,10 +285,10 @@ server, so a second client can attach to the browser the first one left open,
 and closing a client no longer kills the browser.
 
 ```bash
-STEALTHFOX_MCP_TRANSPORT=http uvx invisible-playwright-mcp        # Linux
+STEALTHFOX_MCP_TRANSPORT=http uvx aihawk        # Linux
 ```
 ```powershell
-$env:STEALTHFOX_MCP_TRANSPORT = "http"; uvx invisible-playwright-mcp   # Windows
+$env:STEALTHFOX_MCP_TRANSPORT = "http"; uvx aihawk   # Windows
 ```
 
 To SEE the browser rather than share it, [AIHawk](https://github.com/feder-cr/AIHawk)

--- a/docs/running-aihawk-with-claude-code.md
+++ b/docs/running-aihawk-with-claude-code.md
@@ -31,7 +31,7 @@ engine build for it was `firefox-20` - and [uv](https://docs.astral.sh/uv/),
 because the command runs the server with `uvx`. Then, once:
 
 ```bash
-claude mcp add --scope user stealth -- uvx invisible-playwright-mcp
+claude mcp add --scope user stealth -- uvx aihawk
 ```
 
 Reading it left to right: `--scope user` registers the server at user scope, so it
@@ -110,7 +110,7 @@ results, and short steps keep its context small and its mistakes cheap.
   to see what is registered and at which scope. If the add command was run
   while a session was open, the running session may not know it yet; start a
   new one. If `uvx` is not on your PATH, the server can be registered and
-  still fail to start - install uv and try `uvx invisible-playwright-mcp` by
+  still fail to start - install uv and try `uvx aihawk` by
   hand, which surfaces the real error.
 - **The first browsing prompt hangs or times out.** Almost always the engine
   download. Run the prefetch command above and retry; afterwards a first page
@@ -128,7 +128,7 @@ results, and short steps keep its context small and its mistakes cheap.
 ## Short answers to the questions that lead here
 
 **How do I add AIHawk's browser to Claude Code?**
-`claude mcp add --scope user stealth -- uvx invisible-playwright-mcp`, once, with uv
+`claude mcp add --scope user stealth -- uvx aihawk`, once, with uv
 installed. New sessions then have the browser tools in `/mcp`.
 
 **Do I need an OpenRouter key for this?** No. The key is only for AIHawk's own

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.10.0"
+version = "0.11.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -23,9 +23,9 @@ classifiers = [
 ]
 authors = [{ name = "feder-cr", email = "85809106+feder-cr@users.noreply.github.com" }]
 dependencies = [
-    # The MCP server is part of this package since 0.10.0: the module
-    # `aihawk.mcp`, started by the `invisible-playwright-mcp` command or by
-    # `python -m aihawk.mcp`. It was the separate package
+    # The MCP server is part of this package since 0.10.0, and since 0.11.0 it
+    # is what `aihawk` runs with no subcommand: `uvx aihawk` for a client,
+    # `python -m aihawk` from a checkout. It was the separate package
     # invisible-playwright-mcp until 0.15.2; that name lives on as a shim
     # that depends on this one, so every registered client keeps working.
     # >=1.8, because main() offers the streamable HTTP transport and the SDK
@@ -64,7 +64,6 @@ test = ["pytest>=8", "pytest-asyncio>=0.23"]
 
 [project.scripts]
 aihawk = "aihawk.cli:main"
-invisible-playwright-mcp = "aihawk.mcp.server:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/aihawk"]

--- a/scripts/check_content.py
+++ b/scripts/check_content.py
@@ -18,8 +18,9 @@ real incident rather than a hypothetical:
      in every fence that installs uv (one per system), the run from the
      installer line through the fetch line, PATH line included; and the first
      fetch line names the launcher in front of every command (`uvx` today).
-     A page that carries the uv installer carries those lines verbatim, every code block runs `aihawk ui`, the server and
-     the fetch with the README's launcher, and no page teaches a way in that
+     A page that carries the uv installer carries those lines verbatim,
+     every code block runs `aihawk` (the server, or `aihawk ui`) and the fetch
+     with the README's launcher, and no page teaches a way in that
      the README does not (`pip install aihawk`). On 2026-09-06 the route went
      uv, pip, uv in one day, and each flip touched the README plus twenty-odd
      wiki pages by hand.
@@ -65,14 +66,16 @@ PNG_OK = {b"IHDR", b"PLTE", b"IDAT", b"IEND", b"tRNS", b"gAMA", b"cHRM",
 
 # `aihawk <token>` counts as a command reference only in code-shaped contexts:
 # after `uvx `, inside backticks, or in a quoted argv list.
-CMD_RE = re.compile(r"(?:uvx\s+|[\"'`])aihawk[\"',\s]+([a-z][a-z-]*)")
+CMD_RE = re.compile(r"(?:uvx[ \t]+|[\"'`])aihawk[\"', \t]+([a-z][a-z-]*)")
 
 
 # The way in is written once, in the README: the install block, and the
 # launcher in front of every command. A page repeats them verbatim or not at
 # all. Born 2026-09-06, when the route went uv, pip, uv in one day and each
 # flip touched the README plus twenty-odd wiki pages by hand.
-WAY_IN = ("aihawk ui", "invisible-playwright-mcp", "invisible-playwright fetch")
+# `aihawk` alone is the server, `aihawk ui` the interface: one token covers
+# both, matched as a whole word (never inside aihawk.mcp or a path).
+WAY_IN = ("aihawk", "invisible-playwright fetch")
 INSTALLER = "astral.sh/uv/install"
 OTHER_WAYS = ("pip install aihawk", "pip install invisible-playwright-mcp",
               "pipx install aihawk", "pipx run aihawk")
@@ -144,7 +147,8 @@ def check_way_in(rel, text, launcher, block, readme_text):
         joined = chr(10).join(lines)
         for line in lines:
             for cmd in WAY_IN:
-                for m in re.finditer(re.escape(cmd), line):
+                pattern = r"(?<![\w./-])" + re.escape(cmd) + r"(?![\w./-])"
+                for m in re.finditer(pattern, line):
                     before = line[:m.start()]
                     if before.endswith("/"):
                         continue                      # a URL or a path
@@ -324,7 +328,7 @@ def selftest():
             "config block with another launcher": (
                 "docs/cfg.md",
                 b'```json\n{"command": "python", '
-                b'"args": ["invisible-playwright-mcp"]}\n```\n'),
+                b'"args": ["aihawk"]}\n```\n'),
         }
         for label, (rel, content) in bad.items():
             p = root / rel
@@ -368,7 +372,7 @@ def selftest():
             "config block with the README's launcher": (
                 "docs/okcfg.md",
                 b'```json\n{\n  "command": "uvx",\n'
-                b'  "args": ["invisible-playwright-mcp"]\n}\n```\n'),
+                b'  "args": ["aihawk"]\n}\n```\n'),
             "a unit file with a full path to the launcher": (
                 "docs/unit.md",
                 b"```ini\nExecStart=/usr/bin/uvx aihawk ui\n```\n"),

--- a/src/aihawk/cli.py
+++ b/src/aihawk/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
 
 import click
 
@@ -67,9 +68,14 @@ def browser_options(fn):
     return fn
 
 
-@click.group()
-def main() -> None:
+@click.group(invoke_without_command=True)
+@click.pass_context
+def main(ctx) -> None:
     """Drive a stealth browser with an LLM.
+
+    Without a subcommand this is the MCP server over stdio: `uvx aihawk` is
+    what an assistant registers, `python -m aihawk` is what the interface
+    spawns. `aihawk ui` is the interface, which brings a model.
 
     The model comes from OpenRouter and nowhere else: pass --openrouter-key or
     set OPENROUTER_API_KEY. Without one the interface refuses to start - an
@@ -89,7 +95,25 @@ def main() -> None:
     if applied:
         # Names, never values: this line exists so a reader knows the file was
         # found, and printing what was in it would put the key on the terminal.
-        click.echo("env      %s: %s" % (ENV_FILE, ", ".join(sorted(applied))))
+        # On stderr when serving, because stdout is then the protocol channel.
+        click.echo("env      %s: %s" % (ENV_FILE, ", ".join(sorted(applied))),
+                   err=ctx.invoked_subcommand is None)
+    if ctx.invoked_subcommand is None:
+        _serve()
+
+
+def _serve() -> None:
+    """The MCP server over stdio: the whole of `aihawk` with no subcommand.
+
+    stdout is the protocol channel, so nothing is printed there. A person at a
+    terminal gets one line on stderr saying what is waiting; a client gets the
+    protocol and nothing else.
+    """
+    if sys.stdin.isatty():
+        click.echo("aihawk: MCP server over stdio, waiting for a client. "
+                   "For the interface: aihawk ui --openrouter-key ...", err=True)
+    from .mcp.server import main as serve
+    serve()
 
 
 @main.command()

--- a/src/aihawk/link.py
+++ b/src/aihawk/link.py
@@ -59,7 +59,7 @@ class Link:
     async def open(self) -> "Link":
         params = StdioServerParameters(
             command=sys.executable,
-            args=["-m", "aihawk.mcp"],
+            args=["-m", "aihawk"],
             env=child_env(self._opts, os.environ, key=self._key),
         )
         self._ctx = stdio_client(params)

--- a/src/aihawk/mcp/__main__.py
+++ b/src/aihawk/mcp/__main__.py
@@ -1,4 +1,0 @@
-from .server import main
-
-if __name__ == "__main__":
-    main()

--- a/tests/mcp_server/test_real_launch.py
+++ b/tests/mcp_server/test_real_launch.py
@@ -71,7 +71,7 @@ async def test_stdio_drive_screenshot_is_image_content():
     env = dict(os.environ)
     env["STEALTHFOX_BINARY"] = BINARY
     params = StdioServerParameters(
-        command=sys.executable, args=["-m", "aihawk.mcp"], env=env,
+        command=sys.executable, args=["-m", "aihawk"], env=env,
     )
     async with stdio_client(params) as (read, write):
         async with ClientSession(read, write) as client:

--- a/tests/mcp_server/test_shim_contract.py
+++ b/tests/mcp_server/test_shim_contract.py
@@ -1,14 +1,19 @@
-"""The PyPI package invisible-playwright-mcp is a shim over this module.
+"""`aihawk` with no subcommand is the server, and the old name is a shim over it.
 
-Since 0.16.0 it ships three files that re-export `aihawk.mcp.server`, and its
-console script points at `aihawk.mcp.server:main`; every client registered
-with `uvx invisible-playwright-mcp` runs through those names. The shim lives
-in an archived repository and cannot follow a rename, so the names are pinned
-here: a rename that breaks them breaks every registered client at once.
+The PyPI package invisible-playwright-mcp ships, since its 0.16.0, three files
+that re-export `aihawk.mcp.server` and a console script that points at
+`aihawk.mcp.server:main`; every client that registered
+`uvx invisible-playwright-mcp` runs through those names. The shim lives in an
+archived repository and cannot follow a rename, so the names are pinned here.
+
+New registrations use `uvx aihawk`, and the interface spawns `python -m aihawk`:
+the group with no subcommand serves over stdio, which is the second contract
+pinned here. It is the one command this package declares.
 """
-import importlib.metadata
 import tomllib
 from pathlib import Path
+
+from click.testing import CliRunner
 
 
 def test_the_names_the_shim_binds_exist():
@@ -19,14 +24,35 @@ def test_the_names_the_shim_binds_exist():
     assert hasattr(server.registry, "close_all")
 
 
-def test_the_console_script_target_is_the_one_the_shim_declares():
+def test_aihawk_is_the_only_command_this_package_declares():
     root = Path(__file__).resolve().parents[2]
     with open(root / "pyproject.toml", "rb") as fh:
         scripts = tomllib.load(fh)["project"]["scripts"]
-    assert scripts["invisible-playwright-mcp"] == "aihawk.mcp.server:main"
+    assert scripts == {"aihawk": "aihawk.cli:main"}
 
 
-def test_python_m_aihawk_mcp_is_the_entry_the_interface_spawns():
-    import aihawk.mcp.__main__ as entry
+def test_aihawk_without_a_subcommand_serves_over_stdio(monkeypatch):
+    from aihawk import cli
 
-    assert entry.main is importlib.import_module("aihawk.mcp.server").main
+    called = []
+    monkeypatch.setattr(cli, "_serve", lambda: called.append(True))
+    result = CliRunner().invoke(cli.main, [])
+    assert result.exit_code == 0, result.output
+    assert called == [True]
+
+
+def test_aihawk_ui_does_not_start_the_server(monkeypatch):
+    from aihawk import cli
+
+    called = []
+    monkeypatch.setattr(cli, "_serve", lambda: called.append(True))
+    result = CliRunner().invoke(cli.main, ["ui", "--help"])
+    assert result.exit_code == 0, result.output
+    assert called == []
+
+
+def test_python_m_aihawk_is_the_cli():
+    import aihawk.__main__ as entry
+    from aihawk import cli
+
+    assert entry.main is cli.main

--- a/tests/mcp_server/test_stdio_e2e.py
+++ b/tests/mcp_server/test_stdio_e2e.py
@@ -7,7 +7,7 @@ from mcp.client.stdio import stdio_client
 @pytest.mark.asyncio
 async def test_stdio_lists_tools():
     params = StdioServerParameters(
-        command=sys.executable, args=["-m", "aihawk.mcp"],
+        command=sys.executable, args=["-m", "aihawk"],
     )
     async with stdio_client(params) as (read, write):
         async with ClientSession(read, write) as mcp:

--- a/tests/mcp_server/test_stdio_shutdown.py
+++ b/tests/mcp_server/test_stdio_shutdown.py
@@ -50,7 +50,7 @@ def test_closing_stdin_with_a_page_open_ends_the_server_and_its_browser():
     env["STEALTHFOX_BINARY"] = BINARY
     before = _profiles()
     p = subprocess.Popen(
-        [sys.executable, "-m", "aihawk.mcp"],
+        [sys.executable, "-m", "aihawk"],
         stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
         text=True, bufsize=1, env=env)
     try:

--- a/tests/mcp_server/test_who_is_browsing_e2e.py
+++ b/tests/mcp_server/test_who_is_browsing_e2e.py
@@ -81,7 +81,7 @@ def _server():
     src = str(pathlib.Path(__file__).resolve().parents[2] / "src")
     env["PYTHONPATH"] = src + os.pathsep + env.get("PYTHONPATH", "")
     return StdioServerParameters(
-        command=sys.executable, args=["-m", "aihawk.mcp"], env=env)
+        command=sys.executable, args=["-m", "aihawk"], env=env)
 
 
 async def test_the_seed_decides_what_the_page_sees():

--- a/tests/test_cli_surface.py
+++ b/tests/test_cli_surface.py
@@ -359,11 +359,18 @@ def test_ui_help_names_openrouter_and_the_environment_variables():
         assert option in result.output, "the help never names %s" % option
 
 
-def test_bare_invocation_shows_the_ui_command():
-    """`aihawk` with no arguments lists what it can do rather than failing."""
-    result = run()
+def test_bare_invocation_is_the_server_and_the_help_names_the_interface(monkeypatch):
+    """`aihawk` with no arguments is the MCP server over stdio: that is what a
+    client registers as `uvx aihawk` and what the interface spawns as
+    `python -m aihawk`. The help still says so and still lists `ui`."""
+    called = []
+    monkeypatch.setattr(climod, "_serve", lambda: called.append(True))
 
-    assert "ui" in result.output
+    assert run().exit_code == 0
+    assert called == [True]
+    rendered = run("--help").output
+    assert "ui" in rendered
+    assert "MCP server" in rendered
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_key_isolation.py
+++ b/tests/test_key_isolation.py
@@ -406,7 +406,7 @@ async def test_the_link_hands_the_child_the_scrubbed_environment(monkeypatch):
     try:
         params = captured["params"]
         assert params.command == sys.executable
-        assert params.args == ["-m", "aihawk.mcp"]
+        assert params.args == ["-m", "aihawk"]
 
         child = params.env
         assert child is not None, "an explicit environment is what carries the options"

--- a/tests/test_readme_offers_both.py
+++ b/tests/test_readme_offers_both.py
@@ -30,11 +30,12 @@ README = pathlib.Path(__file__).resolve().parents[1] / "README.md"
 #: The literal command for each path. Literal on purpose: this is what a reader
 #: copies, and a paraphrase in the README is not a way in.
 #:
-#: Bare on purpose, without the `uvx ` the page puts in front of them today:
-#: they matched the pip form the page showed for one day (2026-09-05 to
-#: 2026-09-06) and they match the uv form it shows now, so the test measures
-#: the offer and not the launcher that happens to start it.
-MCP_WAY = "invisible-playwright-mcp"
+#: The MCP way is the registration command a reader copies, not the server's
+#: name: since 0.11.0 the server is `uvx aihawk` with no subcommand, and
+#: `aihawk` alone is also the start of `aihawk ui`, so the server name could
+#: not tell the two ways apart. The UI way stays bare, without the `uvx `, so
+#: the test measures the offer and not the launcher that starts it.
+MCP_WAY = "claude mcp add"
 UI_WAY = "aihawk ui"
 
 

--- a/tests/test_ui_drive.py
+++ b/tests/test_ui_drive.py
@@ -338,7 +338,7 @@ class _McpDriver:
         self._stopped = asyncio.Event()
         params = StdioServerParameters(
             command=sys.executable,
-            args=["-m", "aihawk.mcp"],
+            args=["-m", "aihawk"],
             env=self._env,
         )
         async with stdio_client(params) as (read, write):


### PR DESCRIPTION
No command spells aihawk.mcp or invisible-playwright-mcp any more. aihawk with no subcommand is the MCP server over stdio: uvx aihawk is what a client registers, python -m aihawk is what the interface spawns. aihawk ui is the interface as before. The second console script is gone, and so is python -m aihawk.mcp; the PyPI name invisible-playwright-mcp stays a shim over aihawk so existing registrations keep working. README, the server wiki page and every config block say uvx aihawk; the content gate reads aihawk as the command. Measured with the built wheel: suite green, 29 e2e green against a cached engine, python -m aihawk and uvx aihawk both answer the MCP handshake and open a page, uvx aihawk ui --help is the interface.