### PR TITLE
Fix stale invisible-playwright-mcp references left over from the aihawk merge

### DIFF
--- a/articles/extracting-a-category-to-csv/README.md
+++ b/articles/extracting-a-category-to-csv/README.md
@@ -94,10 +94,10 @@ changed.
 ## Reproducing it
 
 Attach the browser to your assistant (from the
-[README](../../README.md#1-you-already-use-an-assistant-that-can-run-tools)):
+[README](../../README.md#1-from-your-assistant-over-mcp)):
 
 ```bash
-claude mcp add -s user stealth -- uvx invisible-playwright-mcp
+claude mcp add -s user stealth -- uvx aihawk
 ```
 
 Then paste the prompt. The reading companion for this task shape, including

--- a/articles/web-research-audited/README.md
+++ b/articles/web-research-audited/README.md
@@ -104,7 +104,7 @@ the same pages.
 ## Reproducing it
 
 Attach the browser to your assistant
-([README, option 1](../../README.md#1-you-already-use-an-assistant-that-can-run-tools)),
+([README, option 1](../../README.md#1-from-your-assistant-over-mcp)),
 paste the prompt, then run `python ground_truth.py` (needs
 `pip install invisible-playwright`) and compare. The reading companion for
 this task shape is

--- a/docs/ai-browser-agent-local-llm.md
+++ b/docs/ai-browser-agent-local-llm.md
@@ -46,7 +46,7 @@ claude mcp add --scope user stealth -- uvx aihawk
 
 One command, once, and the browser's tools show up in that client from then on. A
 client built around a local model takes the equivalent command or config screen for
-adding an MCP server; the package on the other end, `invisible-playwright-mcp`, the
+adding an MCP server; the package on the other end, `aihawk`, the
 tool names it exposes, and the roughly quarter-gigabyte engine it downloads on first
 use are identical regardless of what is asking. The server has no idea whether the
 model calling it runs on your GPU or on someone else's, and that is by design: it

--- a/docs/ai-browser-agent-open-source.md
+++ b/docs/ai-browser-agent-open-source.md
@@ -105,7 +105,7 @@ library in your code.
 page applies to this paragraph most of all. AIHawk started as a job-application bot,
 which is where the star count and the TechCrunch, Business Insider and Wired coverage
 came from, and it is now a general web agent. There are two ways in: add its MCP
-server (`invisible-playwright-mcp`) to an assistant that can run tools, such as
+server (`uvx aihawk`) to an assistant that can run tools, such as
 Claude Code, Claude Desktop or Cursor, where the assistant brings the model, or run
 `uvx aihawk ui` with an OpenRouter key and get a chat interface with a live browser
 view (the key is required; model-free browser driving is the underlying

--- a/docs/claude-computer-use-detected-as-bot.md
+++ b/docs/claude-computer-use-detected-as-bot.md
@@ -101,7 +101,7 @@ them. This is the general agent-timing problem, and it has
    Firefox patched at the C++ level as a set of tools, via
    [the MCP server](mcp-server.md) that ships with AIHawk -
    one line for Claude Code: `claude mcp add --scope user stealth -- uvx
-   invisible-playwright-mcp`. Disclosure: that server and this wiki have the same maintainer, and it is the route AIHawk's own interface uses. For staying with the screenshot loop instead, the engine wiki shows
+   aihawk`. Disclosure: that server and this wiki have the same maintainer, and it is the route AIHawk's own interface uses. For staying with the screenshot loop instead, the engine wiki shows
    [how to back a computer-use agent with a real browser engine](https://github.com/feder-cr/invisible_playwright/wiki/back-computer-use-agent-real-browser).
 2. **Fix the exit.** A clean, residential-quality address, with the browser's
    timezone and locale agreeing with it. A perfect machine on a distrusted address

--- a/docs/running-aihawk-with-cline.md
+++ b/docs/running-aihawk-with-cline.md
@@ -29,7 +29,7 @@ engine to run. This combination works on Windows and Linux today.
 Paste the block from the [MCP server page](mcp-server.md) under `mcpServers` in the file the Configure tab
 opens, and Cline gains the browser as a set of tools. A server entry in that
 file carries a `command` and `args` (here: `uvx` running
-`invisible-playwright-mcp`), an optional `env` map, and two Cline-side
+`aihawk`), an optional `env` map, and two Cline-side
 fields worth knowing from day one: `disabled`, which switches a server off
 without deleting its entry, and `autoApprove`, a list of tool names allowed
 to run without asking you each time.

--- a/tests/mcp_server/test_shim_contract.py
+++ b/tests/mcp_server/test_shim_contract.py
@@ -1,14 +1,17 @@
-"""`aihawk` with no subcommand is the server, and the old name is a shim over it.
+"""`aihawk` is the one command this package declares, and the old name is a
+shim over it.
+
+New registrations use `uvx aihawk`, and the interface spawns `python -m aihawk`:
+the group with no subcommand serves over stdio, `aihawk ui` is the interface,
+and there is no second script and no `aihawk.mcp` command - pinned here.
 
 The PyPI package invisible-playwright-mcp ships, since its 0.16.0, three files
 that re-export `aihawk.mcp.server` and a console script that points at
-`aihawk.mcp.server:main`; every client that registered
-`uvx invisible-playwright-mcp` runs through those names. The shim lives in an
-archived repository and cannot follow a rename, so the names are pinned here.
-
-New registrations use `uvx aihawk`, and the interface spawns `python -m aihawk`:
-the group with no subcommand serves over stdio, which is the second contract
-pinned here. It is the one command this package declares.
+`aihawk.mcp.server:main` (a module path, not a command); every client that
+registered `uvx invisible-playwright-mcp` before this package went to one
+command still runs through those names. The shim lives in an archived
+repository and cannot follow a rename, so the names it binds are pinned here
+too.
 """
 import tomllib
 from pathlib import Path


### PR DESCRIPTION
Seven leftovers found after the server moved into this package (0.10.0/0.11.0): a command wrapped across a line break that escaped a blanket replace, three pages still naming invisible-playwright-mcp where the rest of the docs say aihawk, a dead anchor repeated in two articles pointing at a reworded README heading, one live instruction that should have followed the update (its nearby historical table is untouched), and a test docstring describing the old two-script contract while the tests below it already checked the new one. Historical references (dated tables, aihawk-do removal notes, the shim note in mcp-server.md) left alone.