### PR TITLE
Identify the app to OpenRouter, and default to GLM 5.3 Flash (0.12.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ It drives the page the way a person would: the pointer moves, keys are pressed.
 ## Options: proxy, profile, seed
 
 - **`--openrouter-key`** Your key, or the `OPENROUTER_API_KEY` variable.
-- **`--model`** An OpenRouter model id, or `AIHAWK_MODEL`. Defaults to `z-ai/glm-4.6`.
+- **`--model`** An OpenRouter model id, or `AIHAWK_MODEL`. Defaults to `z-ai/glm-5.3-flash`.
 - **`--proxy`** Optional. `http://user:pass@proxy.example.com:8080` or
   `socks5://proxy.example.com:1080`. Host and port are both required. The
   timezone, locale and egress follow it.

--- a/docs/ai-browser-agents-vs-traditional-scraping.md
+++ b/docs/ai-browser-agents-vs-traditional-scraping.md
@@ -52,12 +52,15 @@ lumpy and unplanned.
 Now the agent. Each loop turn sends the page state to a model: on a complex page, an
 observation is thousands to tens of thousands of tokens. A realistic multi-step
 task, navigate, search, open results, extract, takes ten to twenty turns with
-history accumulating in the context. Using the pricing of GLM-4.6, AIHawk's default
-model and one of the cheaper capable options at $0.43 per million input tokens and
-$1.75 per million output on OpenRouter: a task moving 500,000 input tokens and
-10,000 output tokens costs roughly $0.23. As an estimate, call it cents per task on
-a budget model, and ten times that on frontier-priced models. Retries and wandering
-multiply it; agents that misread a page can spend forty turns on a six-step task.
+history accumulating in the context. Using the pricing of GLM-5.3-Flash, AIHawk's
+default model and one of the cheaper options in the catalog, at $0.071 to $0.388
+per million input tokens and $0.237 to $1.358 per million output on OpenRouter
+depending which of its two dozen providers serves the request: a task moving
+500,000 input tokens and 10,000 output tokens costs roughly $0.04 at the cheap end
+of that range and $0.21 at the expensive end. As an estimate, call it cents per task
+on a budget model, and eight to forty times that on frontier-priced models. Retries
+and wandering multiply it; agents that misread a page can spend forty turns on a
+six-step task.
 
 Put the two curves side by side and the crossover is stark. At ten pages a day, the
 agent's cents are noise and the scraper's maintenance is the whole cost. At a
@@ -157,9 +160,10 @@ change (nothing structural is hardcoded) and a scraper is better per page (near-
 marginal cost). Volume and volatility decide which axis matters for your case.
 
 **How much does an AI agent cost per page or per task?** Order of magnitude: cents
-per multi-step task on a budget model like GLM-4.6 ($0.43 per million input tokens
-on OpenRouter as of 2026-09-03), roughly ten times that on frontier-priced models,
-plus multipliers for retries. A scripted request costs effectively nothing.
+per multi-step task on a budget model like GLM-5.3-Flash ($0.071 to $0.388 per
+million input tokens on OpenRouter as of 2026-09-08, depending on the provider the
+request routes to), tens of times that on frontier-priced models, plus multipliers
+for retries. A scripted request costs effectively nothing.
 
 **Will agents replace web scraping?** Not at current per-token prices for
 high-volume extraction, where deterministic code wins on cost, speed and
@@ -183,12 +187,12 @@ volume. The two failure modes cover for each other.
 
 ## Sources
 
-All retrieved 2026-09-03.
+All retrieved 2026-09-03, except the OpenRouter pricing, retrieved 2026-09-08.
 
 - [Scrapy](https://www.scrapy.org/), for the framework's positioning and its
   fifteen-plus years of maintained history.
-- [GLM-4.6 on OpenRouter](https://openrouter.ai/z-ai/glm-4.6), for the per-token
-  prices used in the cost arithmetic.
+- [GLM-5.3-Flash on OpenRouter](https://openrouter.ai/z-ai/glm-5.3-flash), for the
+  per-token prices used in the cost arithmetic.
 - [WebArena paper abstract (arXiv:2307.13854)](https://arxiv.org/abs/2307.13854),
   for the 14.41% versus 78.24% end-to-end success figures.
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README in this

--- a/docs/ai-web-agent-explained.md
+++ b/docs/ai-web-agent-explained.md
@@ -73,11 +73,13 @@ This is the section vendors skip, so it gets the detail here.
   agent spend forty steps on a six-step task is a rite of passage. Caps on steps and
   spend are not optional.
 - **Cost per task.** Every observation of a complex page is thousands of tokens.
-  Multiply by steps and by retries. Concretely: AIHawk's default model, GLM-4.6, is
-  priced on OpenRouter at $0.43 per million input tokens and $1.75 per million
-  output, which is cheap for the class; a multi-step task still routinely moves
-  hundreds of thousands of input tokens. On frontier-priced models the same task
-  costs an order of magnitude more. The full cost argument, against the alternative
+  Multiply by steps and by retries. Concretely: AIHawk's default model,
+  GLM-5.3-Flash, is priced on OpenRouter between $0.071 and $0.388 per million
+  input tokens and between $0.237 and $1.358 per million output, depending which
+  provider serves the request, which is cheap even for the cheap end of the class;
+  a multi-step task still routinely moves hundreds of thousands of input tokens. On
+  frontier-priced models the same task costs one to two orders of magnitude more.
+  The full cost argument, against the alternative
   of writing a scraper, is on
   [agents vs traditional scraping](ai-browser-agents-vs-traditional-scraping.md).
 - **Sites that push back.** Some pages detect and block automation, and an agent
@@ -171,7 +173,7 @@ fix the first, influence the fourth, and cannot fix the middle two;
 
 ## Sources
 
-All retrieved 2026-09-03.
+All retrieved 2026-09-03, except the OpenRouter pricing, retrieved 2026-09-08.
 
 - [WebArena paper abstract (arXiv:2307.13854)](https://arxiv.org/abs/2307.13854),
   for the 14.41% agent versus 78.24% human end-to-end success rates.
@@ -179,8 +181,8 @@ All retrieved 2026-09-03.
   OSWorld figure and its human-level comparison.
 - [browser-use/browser-use](https://github.com/browser-use/browser-use), as the
   reference example of a DOM-plus-screenshot observation design.
-- [GLM-4.6 on OpenRouter](https://openrouter.ai/z-ai/glm-4.6), for current per-token
-  pricing of AIHawk's default model.
+- [GLM-5.3-Flash on OpenRouter](https://openrouter.ai/z-ai/glm-5.3-flash), for
+  current per-token pricing of AIHawk's default model.
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README in this
   repository, for the claims about AIHawk itself.
 

--- a/docs/aihawk-review.md
+++ b/docs/aihawk-review.md
@@ -15,8 +15,9 @@ have not read, and because a first-party review can do one thing a
 third-party one cannot: state plainly what the project does not do, and be
 accountable for it. Every factual claim below is checkable against the
 [repository](https://github.com/feder-cr/AIHawk) and the published package,
-both read on 2026-09-03, and the honest move for a reader is to treat the
-praise with suspicion and the self-criticism as reliable.
+both read on 2026-09-03 with the default model re-read on 2026-09-08, and the
+honest move for a reader is to treat the praise with suspicion and the
+self-criticism as reliable.
 
 ## What AIHawk is
 
@@ -42,7 +43,7 @@ There are two ways to run it, and they share one browser:
   Cursor, and your assistant's model does the thinking.
 - **Standalone.** `uvx aihawk ui` serves a local page with chat on the
   left and the live browser on the right. It takes an
-  [OpenRouter](https://openrouter.ai) key, defaults to `z-ai/glm-4.6`,
+  [OpenRouter](https://openrouter.ai) key, defaults to `z-ai/glm-5.3-flash`,
   and accepts `--model` for anything OpenRouter serves. Since 0.3.0 this
   is the only aihawk entrypoint; headless one-shots run through the
   assistant path above.
@@ -207,7 +208,7 @@ the MCP route.
 
 ## Sources
 
-- The [AIHawk repository](https://github.com/feder-cr/AIHawk): README, LICENSE, `pyproject.toml` and `tests/test_key_isolation.py` read in the working tree on 2026-09-03; stars, forks, license and creation date read via the GitHub API the same day.
+- The [AIHawk repository](https://github.com/feder-cr/AIHawk): README, LICENSE, `pyproject.toml` and `tests/test_key_isolation.py` read in the working tree on 2026-09-03; stars, forks, license and creation date read via the GitHub API the same day; `src/aihawk/llm.py`, for the default model id, re-read 2026-09-08.
 - [`aihawk` on PyPI](https://pypi.org/project/aihawk/), version 0.3.0 metadata checked against the index 2026-09-04.
 - The relicense commit ("Relicense under MIT", dated 2026-09-02) in the repository history, and the README's license section stating the AGPL-3.0 boundary for earlier distributions, both read 2026-09-03.
 - For comparative claims about other tools, the pages linked above carry their own dated sources; none are repeated here.

--- a/docs/which-model-to-use-with-aihawk.md
+++ b/docs/which-model-to-use-with-aihawk.md
@@ -10,8 +10,8 @@ nav_order: 2
 
 AIHawk brings the browser and you bring the model, from
 [OpenRouter](https://openrouter.ai) and nowhere else. If you set nothing, you get
-`z-ai/glm-4.6`: that is the default written into the source, and it sits at the
-cheap-and-capable end of the catalog rather than the flagship end. You override it
+`z-ai/glm-5.3-flash`: that is the default written into the source, and it sits at
+the cheap-and-fast end of the catalog rather than the flagship end. You override it
 with `--model` on `aihawk ui`, or the `AIHAWK_MODEL` environment variable, and
 any model id OpenRouter serves is legal. So the real question is not "which model
 does AIHawk support" - all of them - but which one is worth paying for on this
@@ -64,30 +64,41 @@ Speed matters more than in chat, too: a person watches the interface while up to
 
 ## Real prices, and one worked comparison
 
-Retrieved from OpenRouter on 2026-09-03. OpenRouter routes each model across
+Retrieved from OpenRouter on 2026-09-08. OpenRouter routes each model across
 several providers, so cheap models show a price range rather than one number,
 and all of these move; check the model's page before relying on them.
 
 | Model | Input, per 1M tokens | Output, per 1M tokens |
 |---|---|---|
-| `z-ai/glm-4.6` (the default) | $0.43 - $0.60 | $1.75 - $2.20 |
-| `anthropic/claude-sonnet-4.5` | $3.00 | $15.00 |
+| `z-ai/glm-5.3-flash` (the default) | $0.071 - $0.388 | $0.237 - $1.358 |
+| `anthropic/claude-sonnet-4.5` | $3.00 - $3.30 | $15.00 - $16.50 |
 
-Sonnet's figures are the standard tier; above 200,000 prompt tokens a higher
-tier applies ($6.00 / $22.50), which an agent transcript can in principle reach,
-though with this loop's 25-turn cap and clipped tool results it rarely will.
+The default's range is that wide because two dozen providers serve it and
+OpenRouter picks one per request, so a task's bill depends on where it landed as
+well as on how long it ran. Sonnet's lower figures are the standard tier; above
+200,000 prompt tokens a higher tier applies ($6.00 / $22.50), which an agent
+transcript can in principle reach, though with this loop's 25-turn cap and
+clipped tool results it rarely will.
+
+One more number from the same page, because it changes what stops a run: the
+default's context window is 1,310,720 tokens, against 204,800 for `z-ai/glm-4.6`,
+the default before it. With a 25-turn cap and tool results clipped at 8,000
+characters, a transcript will not come near filling that window, so the ceiling
+you actually meet is the turn cap or the bill, not the model's context.
 
 Now the arithmetic, illustrative rather than measured: take a 20-turn task whose
 transcript averages 15,000 tokens per turn. That is about 300,000 input tokens,
 plus a few thousand output tokens.
 
-- On GLM 4.6 at the top of its range: about $0.18 of input and a cent of
-  output. Call it **$0.19**.
+- On the default, at the top of its range: about $0.12 of input and under a cent
+  of output. Call it **$0.12**. Routed to the cheap end of the same range, the
+  same task is about **$0.02**.
 - On Claude Sonnet 4.5: $0.90 of input and $0.06 of output. Call it **$0.96**.
 
-Same task, roughly a 5x multiplier. Both are under a dollar, which is the honest
-scale of a single task; the multiplier is what compounds when you run fifty of
-them, or when a monitoring job runs one every hour.
+Same task: an 8x multiplier against the default's most expensive provider, and
+around 40x against its cheapest. All of them are under a dollar, which is the
+honest scale of a single task; the multiplier is what compounds when you run
+fifty of them, or when a monitoring job runs one every hour.
 
 ## The catch: a cheaper model that retries is not cheaper
 
@@ -97,7 +108,14 @@ pages it already read, or wanders into the 25-turn ceiling - and a task that
 dies at the ceiling costs more than a task that succeeds, because the transcript
 was at its largest exactly when it was being resent most. Three failed cheap
 runs plus one successful one can overtake a single clean run on a model five
-times the price. Neither direction of this is guaranteed, which is why the only
+times the price.
+
+That caveat applies to the default as much as to anything you might downgrade
+to. It is a fast, cheap model, and this wiki has no measurement of how it holds
+up over twenty turns of tool calls in this particular loop. What is known is the
+price, the context window, and that it is what you get if you set nothing; how
+many turns it takes on your tasks is something to read off your own transcripts,
+not off this page. Neither direction of this is guaranteed, which is why the only
 trustworthy comparison is empirical: same task, both models, read the
 transcripts. [Browser problem or model problem?](browser-problem-or-model-problem.md)
 covers how to make that comparison clean, and passing the same `--seed` keeps
@@ -127,7 +145,7 @@ criteria above do not.
 
 ## Short answers to the questions that lead here
 
-**What model does AIHawk use by default?** `z-ai/glm-4.6`, via OpenRouter. Set
+**What model does AIHawk use by default?** `z-ai/glm-5.3-flash`, via OpenRouter. Set
 `--model` or `AIHAWK_MODEL` to use anything else OpenRouter serves.
 
 **Do I need an OpenRouter account?** For AIHawk's own interface, yes - the
@@ -158,10 +176,12 @@ visible while it is still cheap.
 
 ## Sources
 
-All retrieved 2026-09-03.
+All retrieved 2026-09-08.
 
-- [OpenRouter: Z.ai GLM 4.6](https://openrouter.ai/z-ai/glm-4.6), for the
-  default model's per-provider pricing range.
+- [OpenRouter: Z.ai GLM 5.3 Flash](https://openrouter.ai/z-ai/glm-5.3-flash), for
+  the default model's per-provider pricing range and its context length.
+- [OpenRouter: Z.ai GLM 4.6](https://openrouter.ai/z-ai/glm-4.6), the previous
+  default, for the context-window comparison only.
 - [OpenRouter: Claude Sonnet 4.5](https://openrouter.ai/anthropic/claude-sonnet-4.5),
   for the frontier comparison pricing and the long-context tier.
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), this repository's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.11.1"
+version = "0.12.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/llm.py
+++ b/src/aihawk/llm.py
@@ -4,7 +4,15 @@ from __future__ import annotations
 from typing import Mapping
 
 BASE_URL = "https://openrouter.ai/api/v1"
-DEFAULT_MODEL = "z-ai/glm-4.6"
+DEFAULT_MODEL = "z-ai/glm-5.3-flash"
+
+#: App attribution for the public rankings at https://openrouter.ai/apps.
+#: OpenRouter groups usage by these two headers and by nothing else: without
+#: them every request is anonymous traffic on the key, so the app appears
+#: nowhere however much it is used. They are constants rather than settings
+#: because they name THIS package, not the person running it.
+APP_URL = "https://github.com/feder-cr/AIHawk"
+APP_TITLE = "AIHawk"
 
 
 def resolve_key(explicit: str | None, env: Mapping[str, str]) -> str:
@@ -22,4 +30,8 @@ def resolve_model(explicit: str | None, env: Mapping[str, str]) -> str:
 
 def make_client(key: str):
     from openai import OpenAI
-    return OpenAI(base_url=BASE_URL, api_key=key)
+    return OpenAI(
+        base_url=BASE_URL,
+        api_key=key,
+        default_headers={"HTTP-Referer": APP_URL, "X-Title": APP_TITLE},
+    )

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,5 +1,5 @@
 import pytest
-from aihawk.llm import resolve_key, resolve_model
+from aihawk.llm import DEFAULT_MODEL, resolve_key, resolve_model
 
 
 def test_key_arg_wins_then_env_then_error():
@@ -12,4 +12,7 @@ def test_key_arg_wins_then_env_then_error():
 def test_model_arg_env_default():
     assert resolve_model("m1", {"AIHAWK_MODEL": "m2"}) == "m1"
     assert resolve_model(None, {"AIHAWK_MODEL": "m2"}) == "m2"
-    assert resolve_model(None, {}) == "z-ai/glm-4.6"
+    # Against the constant, never a copy of its value: a literal here drifts
+    # from the exported default the day it is changed, and then the suite pins
+    # a model nobody ships.
+    assert resolve_model(None, {}) == DEFAULT_MODEL

--- a/tests/test_openrouter_only.py
+++ b/tests/test_openrouter_only.py
@@ -34,7 +34,15 @@ from urllib.parse import urlparse
 import pytest
 
 from aihawk import llm
-from aihawk.llm import BASE_URL, DEFAULT_MODEL, make_client, resolve_key, resolve_model
+from aihawk.llm import (
+    APP_TITLE,
+    APP_URL,
+    BASE_URL,
+    DEFAULT_MODEL,
+    make_client,
+    resolve_key,
+    resolve_model,
+)
 
 # Environment variables that must never influence this package. OPENAI_* are
 # read by the openai SDK itself; the rest stand in for other vendors.
@@ -275,6 +283,49 @@ def test_a_real_request_carries_the_given_key(clean_env):
     with _StubOpenRouter() as stub:
         _send_one_completion("or-control-key", stub)
         assert stub.headers.get("authorization") == "Bearer or-control-key"
+
+
+# --------------------------------------------------------------------------
+# make_client: app attribution
+# --------------------------------------------------------------------------
+
+def test_a_real_request_carries_the_app_attribution_headers(clean_env):
+    """OpenRouter groups the /apps rankings by these two headers and nothing else.
+
+    Asserted on the wire rather than on ``client.default_headers``, for the same
+    reason the key is: an attribute can hold a value the request never sends.
+
+    Known-bad: dropping ``default_headers`` from the OpenAI(...) call. Nothing
+    fails when it goes - no error, no changed answer - the traffic simply
+    becomes anonymous and the app leaves the rankings, which is why it needs a
+    test rather than an occasional look at the site.
+    """
+    with _StubOpenRouter() as stub:
+        _send_one_completion("or-control-key", stub)
+        assert stub.headers.get("http-referer") == APP_URL
+        assert stub.headers.get("x-title") == APP_TITLE
+
+
+def test_app_attribution_survives_a_foreign_environment(foreign_env):
+    """Another vendor's variables must not displace our own identification.
+
+    Known-bad: passing the two headers per-request at one call site instead of
+    on the client, which leaves every other call site anonymous.
+    """
+    with _StubOpenRouter() as stub:
+        _send_one_completion("or-real-key", stub)
+        assert stub.headers.get("http-referer") == APP_URL
+        assert stub.headers.get("x-title") == APP_TITLE
+
+
+def test_app_attribution_constants_are_a_url_and_a_name():
+    """Known-bad: an empty title, or a referer that is not a URL. OpenRouter
+    accepts both without complaint and produces an unusable rankings entry."""
+    parsed = urlparse(APP_URL)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "github.com"
+    assert APP_TITLE.strip() == APP_TITLE
+    assert APP_TITLE != ""
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Two changes to what leaves the process for the model, plus the wiki pages that described the old default.

## App attribution

OpenRouter groups the rankings at openrouter.ai/apps by `HTTP-Referer` and `X-Title`, and this package sent neither, so every request was anonymous traffic on the key. They go on the client in `make_client` rather than at the call site, so one place sets them and every request carries them whatever calls it.

Nothing fails when they are missing - no error, no changed answer, the app is simply absent from the rankings - so the tests assert them on the wire against the local stub server already in `test_openrouter_only.py`, not on a client attribute. Removing `default_headers` turns both of those red; the constants test stays green, which is correct since it does not touch the client.

## New default model

`z-ai/glm-4.6` to `z-ai/glm-5.3-flash`. Retrieved from OpenRouter today:

| | input, per 1M | output, per 1M | context |
|---|---|---|---|
| `z-ai/glm-5.3-flash` | $0.071 - $0.388 | $0.237 - $1.358 | 1,310,720 |
| `z-ai/glm-4.6` | $0.43 - $0.60 | $1.75 - $2.20 | 204,800 |

Anyone who set `--model` or `AIHAWK_MODEL` is unaffected.

## The wiki

Four pages named the old default and three rested cost arithmetic on its prices. All four carry today's figures, and the worked example moves from $0.19 to $0.12 against Sonnet's $0.96, an 8x multiplier against the default's most expensive provider and around 40x against its cheapest.

The section arguing that a cheaper model which retries is not cheaper now says plainly that the caveat applies to this default too: there is no measurement here of how a flash model holds up over twenty turns of tool calls, and the pages say so rather than guessing in either direction. Two GLM 4.6 mentions remain, both labelled as the previous default, because the context-window jump only means something against the old number.

One test pinned the default as a literal copy of its value and now reads the constant, which is the drift the test beside it already warned about.

## Version

0.11.1 is on the index and `llm.py` ships, so `test_version_is_not_taken` would refuse this without a bump: 0.12.0.

## Test plan

- [x] `pytest -q`: 341 passed, 3 xfailed unchanged (the known defects did not accidentally XPASS)
- [x] known-bad mutation on the new gate: dropping `default_headers` turns both wire tests red, restored byte-identical
- [x] `AIHAWK_CHECK_VERSION=1 pytest tests/test_version_is_not_taken.py`: 4 passed
- [x] `scripts/check_english_only.py` and `scripts/check_content.py`: both clean
- [x] no em-dash, no stale `glm-4.6` claim about the current default