### PR TITLE
No turn ceiling, and a stop button that is always there (0.13.0)

### DIFF
--- a/docs/agent-retry-loops-rate-limits.md
+++ b/docs/agent-retry-loops-rate-limits.md
@@ -65,28 +65,40 @@ clean fingerprint still gets blocked, volume and address are the usual reasons -
 
 ## What bounds the loop in AIHawk
 
-AIHawk's loop carries two bounds worth knowing about, because they shape what a
-runaway task can and cannot do:
+Less than you might assume, and it is worth being exact, because this is what
+decides how big a runaway task can get. There is no turn ceiling: the loop takes
+turns until the model stops calling tools, so nothing in the code ends a task
+that keeps deciding to look again. What is actually there:
 
-- **A turn ceiling.** One instruction runs for at most 25 model turns by default,
-  and when the ceiling is hit the task stops with a plain message instead of
-  looping on. The message tells you the remedy too: narrow the task.
 - **One thing at a time.** Instructions are serialised - one instruction at a time
   on one browser - and the system prompt tells the model to prefer one clear action
   per turn over long chains.
+- **A ceiling on each reply.** 8,192 tokens per model reply. That bounds how big a
+  single turn gets, not how many turns happen.
+- **Tolerance for a malformed tool call.** Unreadable arguments go back to the model
+  to try again rather than ending the task. Good for finishing the job, and also one
+  more request.
+- **A person watching.** The interface holds the running task's handle, and while
+  work is in flight the send button becomes a red stop button that cancels it. Two
+  details matter when you reach for it: it is a stop button only while the message
+  box is empty (type something and the same button queues that message for the next
+  turn instead), and the cancel lands at the next tool call, so the step already in
+  flight finishes first.
 
-Be honest about what a ceiling is, though: it is a stop, not a throttle. It caps how
-big a burst one instruction can become; it does not pace the requests inside the
-burst, and it does not stop *you* from immediately issuing the same instruction
-again. The half that no product can supply is how often you run it.
+Be honest about what that adds up to: a person is a stop, not a throttle, and a stop
+that only works while someone is looking. It does not pace the requests inside a
+burst, it does not bound a burst you are not watching, and it does not stop *you*
+from immediately issuing the same instruction again. The half that no product can
+supply is how often you run it.
 
 ## The throttle lives in how you drive it
 
 - **Do not re-run a failed task immediately.** The worst response to a block or a
   failure is the identical request again, faster. Wait, and wait longer each time.
-- **Narrow the task instead of repeating it.** If an instruction hits the turn
-  ceiling, splitting it into smaller instructions with pauses between them produces
-  less traffic than re-running the big one until it fits.
+- **Narrow the task instead of repeating it.** If an instruction is still going
+  after a lot of turns without getting closer, stop it and split it into smaller
+  instructions with pauses between them. That produces less traffic than letting the
+  big one run on, and far less than re-running it whole.
 - **Mind the exit, not the browser count.** The unit a counter sees is requests per
   address and per account. Several agents behind one exit IP, each politely pacing
   itself, are one very busy client to the site.
@@ -136,9 +148,10 @@ decides how often the agent runs, which is you.
 
 Retrying and re-planning are what make an agent an agent, and they are also what
 turn one instruction into a burst of requests. Bursts are counted, and a counter is
-a different defence from a fingerprint check. AIHawk bounds the burst - a turn
-ceiling, serialised instructions - but pacing between runs, backoff after failures
-and a sane request budget live in how you drive it, and a clean exit lives under it.
+a different defence from a fingerprint check. AIHawk bounds less of that than you
+might hope - instructions are serialised, and a person can stop a run - but pacing
+between runs, backoff after failures and a sane request budget live in how you drive
+it, and a clean exit lives under it.
 The browser's job is to make each request real; keeping the requests few and
 well-spaced is yours.
 
@@ -152,10 +165,11 @@ with detection, not with volume.
 always because the agent sent many more requests, much faster, than you did.
 Retries, re-reads and reloads multiply traffic a person never generates.
 
-**Does AIHawk retry forever?** No. One instruction is capped at 25 model turns by
-default and then stops with a plain message. But the cap is a stop, not a throttle:
-re-issuing the same instruction immediately is still a retry loop, just with you in
-it.
+**Does AIHawk retry forever?** Nothing in the loop stops it: it keeps taking turns
+for as long as the model keeps calling tools, so a task that decides to keep trying
+will keep trying. What ends it is you, with the stop button the interface shows while
+a run is in flight. And stopping is not a throttle: re-issuing the same instruction
+immediately is still a retry loop, just with you in it.
 
 **Where should backoff live?** In whatever decides when tasks run: your habits at
 the prompt, or the script wrapping the one-shot run. No browser setting paces a loop
@@ -171,10 +185,12 @@ immediate identical re-run.
 
 ## Sources
 
-- AIHawk's own source, read 2026-09-03: `src/aihawk/agent.py` (the 25-turn default
-  ceiling and its stop message, tool errors fed back to the model as results, the
-  one-action-at-a-time system prompt) and `src/aihawk/link.py` (one instruction at a
-  time on one browser).
+- AIHawk's own source, read 2026-09-03 and the loop re-read 2026-09-08:
+  `src/aihawk/agent.py` (a loop with no turn ceiling, the per-reply token cap, tool
+  errors fed back to the model as results, the one-action-at-a-time system prompt),
+  `src/aihawk/web.py` (the task handle, the stop button, and the cancel landing at
+  the next tool call) and `src/aihawk/link.py` (one instruction at a time on one
+  browser).
 - The engine wiki's
   [rate limiting mechanics](https://github.com/feder-cr/invisible_playwright/wiki/how-to-rate-limit-your-scraper-playwright)
   and its notes on

--- a/docs/ai-agent-web-research.md
+++ b/docs/ai-agent-web-research.md
@@ -98,9 +98,9 @@ Prompt habits that separate usable research from confident noise:
   pushes it to report only what pages show; your instruction should pull the
   same direction.
 - **Bound the walk.** "The first three pages", "stop after five sources".
-  Unbounded research runs are where
-  [turn budgets](how-to-extract-data-to-csv-with-an-ai-agent.md) expire
-  mid-thought.
+  Nothing in the loop bounds it for you, so an unbounded research run keeps
+  reading, and [keeps costing more per source](how-to-extract-data-to-csv-with-an-ai-agent.md)
+  as the transcript grows, until it answers or you stop it.
 - **Separate gathering from judging.** Two passes - collect the claims, then
   evaluate them - beat one pass doing both, for the same reason it works with
   human researchers: the gatherer stops shading the evidence toward a thesis.

--- a/docs/browser-problem-or-model-problem.md
+++ b/docs/browser-problem-or-model-problem.md
@@ -94,10 +94,13 @@ handles fine:
 - **Misreading the task.** It did something coherent, just not what you asked.
   Usually fixable with a more explicit instruction before it is a reason to
   change models.
-- **The turn ceiling.** An error saying the task did not finish within
-  `max_turns=25` means the model spent 25 turns without converging. On a
-  genuinely long task, that is the task's problem; on a short one, it is the
-  model wandering.
+- **A run that never converges.** The loop has no turn ceiling: it takes turns
+  until the model stops calling tools, so a model going in circles goes in
+  circles until a person ends it. That person is you, watching the live pane.
+  Stop the run when the steps stop making progress, then reissue a narrower
+  instruction rather than the same one. On a genuinely long task a long run is
+  the task's shape; on a short one it is the model wandering, and the
+  transcript tells you which, because wandering repeats itself.
 - **Unreadable tool arguments.** The transcript notes the model's arguments
   were not valid JSON and it was told to retry. Occasional is tolerable;
   frequent is a model quality signal in itself.
@@ -150,9 +153,15 @@ changes nothing there.
 transcript shows the page loaded correctly. Try a sharper instruction first,
 then a stronger model on the same task and seed.
 
-**What does the max_turns error mean?** The model used its 25-turn budget
-without finishing. On a short task, that is a model-side symptom; on a long
-one, split the task into smaller instructions before blaming anything.
+**The run keeps going and never finishes - how do I stop it?** From the
+interface: while work is in flight the send button becomes a red stop button,
+and pressing it cancels the run. One detail worth knowing before you go looking
+for it: the button is a stop button only while the message box is empty, so if
+you have typed something the same button queues that message for the next turn
+instead - clear the box and the stop button is back. The cancel lands at the
+next tool call, so the step already in flight finishes first. Nothing else ends
+a run: the loop has no turn ceiling, so on a short task that will not converge,
+stopping it and narrowing the instruction is the move.
 
 **Can I run this diagnosis without spending anything?** The replay half, yes -
 the library needs no model and no key, and the engine download is one-time.
@@ -164,12 +173,14 @@ which is a certainty no model-driven run gives you.
 
 ## Sources
 
-All retrieved 2026-09-03.
+All retrieved 2026-09-03, except the loop itself, re-read 2026-09-08.
 
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), this repository's
-  source: `src/aihawk/agent.py` (the shared loop, the
-  turn ceiling, the invalid-arguments retry), and the README (the
-  engine download and prefetch command).
+  source: `src/aihawk/agent.py` (the shared loop, which runs until the model
+  stops calling tools and has no turn ceiling, and the invalid-arguments
+  retry), `src/aihawk/web.py` (the task handle, the stop button and the cancel
+  that lands at the next tool call), and the README (the engine download and
+  prefetch command).
 - [invisible_playwright](https://github.com/feder-cr/invisible_playwright),
   the engine as a library; the replay snippet above was executed against
   books.toscrape.com on 2026-09-03 and printed the line quoted.

--- a/docs/how-to-extract-data-to-csv-with-an-ai-agent.md
+++ b/docs/how-to-extract-data-to-csv-with-an-ai-agent.md
@@ -65,19 +65,23 @@ nine still in the context. A 20-page walk is not twenty times the cost of one
 page; it is worse, because the pages ride along. The comparison page
 [runs the actual numbers](ai-browser-agents-vs-traditional-scraping.md).
 
-Three hard limits in AIHawk's own loop, taken from its source, bound one run:
+Two hard limits in AIHawk's own loop, taken from its source, bound one run:
 
 - **Tool results are clipped at 8,000 characters** before the model sees them.
   A 20-item page fits comfortably; a page listing hundreds of items may not.
-- **The loop stops at 25 turns** by default. A navigate-and-read cycle per page
-  plus the reading turns means a full 50-page walk does not fit in one run.
 - **The final reply has a token ceiling** (8,192 tokens). Around a thousand
   rows, the CSV itself outgrows the answer that is supposed to carry it.
 
-These are budgets, not defects, and the practical consequence is one habit:
-batch. "Pages one to ten, then stop" completes and verifies; "all fifty pages"
-runs long, costs more per row, and can hit a ceiling with the work
-half-carried.
+What is not limited is how long a run goes on. The loop has no turn ceiling: a
+50-page walk will not be cut short part way, it will keep going, one page at a
+time, until it answers or you stop it.
+
+That makes the batching habit more useful rather than less. "Pages one to ten,
+then stop" completes, is cheap to verify, and is short enough to watch. "All
+fifty pages" is a run whose cost per row climbs the further it gets, because
+every turn resends the whole transcript, and a long run is exactly the one you
+stop paying attention to - which matters, because attention is what ends a walk
+that has gone wrong.
 
 ## Where this beats a scraper, and where it loses
 
@@ -160,8 +164,8 @@ in the instruction.
 
 **Why is my extracted CSV incomplete?** Three usual causes: a long page
 truncated before the model saw all of it, an early "done" before the last
-pages, or a turn budget exhausted mid-walk. Counting rows against the site's
-own total finds all three; batching into smaller runs prevents them.
+pages, or a run stopped mid-walk. Counting rows against the site's own total
+finds all three; batching into smaller runs prevents them.
 
 **Can it handle pagination?** Yes, by walking it: find next, click, read,
 repeat, with cost per page climbing as the transcript grows. Bound the walk
@@ -179,14 +183,14 @@ with a header row.
 
 ## Sources
 
-All retrieved 2026-09-03.
+All retrieved 2026-09-03, except the loop's own bounds, re-read 2026-09-08.
 
 - [books.toscrape.com](https://books.toscrape.com/), the scraping sandbox used
   as the running example: 1,000 fictional items, 20 per page, with the site's
   own disclaimer that prices and ratings are randomly assigned.
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its README and
-  source in this repository: the loop, the 25-turn default, the 8,000-character
-  tool-result clip and the reply ceiling are in
+  source in this repository: the loop, its lack of a turn ceiling, the
+  8,000-character tool-result clip and the reply ceiling are in
   [`src/aihawk/agent.py`](https://github.com/feder-cr/AIHawk/blob/main/src/aihawk/agent.py),
   and the CLI surface in
   [`src/aihawk/cli.py`](https://github.com/feder-cr/AIHawk/blob/main/src/aihawk/cli.py).

--- a/docs/move-data-between-web-apps-with-an-ai-agent.md
+++ b/docs/move-data-between-web-apps-with-an-ai-agent.md
@@ -32,7 +32,7 @@ The fix costs one more step per row. After the write, have the agent reload the 
 
 ## Batching and pacing
 
-Batch the run and stop between batches; do not ask for the whole migration in one instruction. AIHawk's own loop caps a run at 25 turns by default, and one full read-transform-write-confirm cycle is already several of those, so "the next twenty rows, then stop" fits comfortably where "all of them" does not.
+Batch the run and stop between batches; do not ask for the whole migration in one instruction. AIHawk's own loop has no turn ceiling, so "all of them" will not be cut off part way - it will simply run on, and that is the problem rather than the reassurance it sounds like. One full read-transform-write-confirm cycle is several turns, every turn resends the whole transcript, so the cost per row climbs the longer the batch runs; and a long unattended run is the one where a bad mapping writes forty wrong rows before anyone looks. "The next twenty rows, then stop" is short enough to read the log before the next twenty start.
 
 Writing dozens of rows back to back is also the kind of steady, gap-free rhythm that gets a session rate-limited or logged out mid-batch. The order-of-checks for a session that stops responding is on [why does my AI agent get blocked](why-does-my-ai-agent-get-blocked.md), and a short pause between batches, not only within one, is the cheapest fix; [agent retry loops and rate limits](agent-retry-loops-rate-limits.md) covers what happens when a failed write gets retried instead of paused.
 
@@ -60,7 +60,7 @@ A plain text or CSV log next to the moved data turns "trust the agent ran" into 
 
 ## Sources
 
-- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its source in this repository (`src/aihawk/agent.py`), retrieved 2026-09-05, for the 25-turn default loop cap referenced in the batching section above.
+- [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), plus its source in this repository (`src/aihawk/agent.py`), retrieved 2026-09-05 and the loop re-read 2026-09-08, for what the batching section above rests on: a loop with no turn ceiling, and the whole transcript resent on every turn.
 
 ---
 

--- a/docs/which-model-to-use-with-aihawk.md
+++ b/docs/which-model-to-use-with-aihawk.md
@@ -23,9 +23,10 @@ Worth knowing before choosing, because the loop's shape decides the bill. The
 interface runs one fixed loop: the model receives the task and
 the browser tools, replies with one thought and usually one tool call, the tool
 runs, the result goes into the transcript, and the model is called again. In the
-current source the loop is capped at 25 turns per instruction, each reply is
-capped at 8,192 tokens, temperature is pinned to 0, and each tool result is
-clipped to 8,000 characters before it enters the transcript.
+current source nothing caps the number of turns - the loop runs until the model
+stops calling tools - while each reply is capped at 8,192 tokens, temperature is
+pinned to 0, and each tool result is clipped to 8,000 characters before it
+enters the transcript.
 
 Two consequences follow directly:
 
@@ -56,11 +57,15 @@ What the loop actually exercises:
   extracted page text. The model has to find the price in the noise, and notice
   when a click changed nothing.
 - **Knowing when it is done, and when it is stuck.** The worst outcome is not a
-  wrong answer, it is 25 turns of confident wandering: the loop then stops with
-  an error and you have paid for the whole journey with no answer at the end.
+  wrong answer, it is confident wandering, and nothing in the loop ends it. A
+  model that does not notice it is stuck keeps taking turns, each one resending
+  a bigger transcript than the last, until someone stops it. That is what makes
+  a model's self-awareness a cost question here, and it is why the run is worth
+  watching rather than starting and walking away.
 
-Speed matters more than in chat, too: a person watches the interface while up to
-25 round trips happen in sequence, so per-turn latency multiplies.
+Speed matters more than in chat, too: a person watches the interface while round
+trip follows round trip, so per-turn latency multiplies - and that person is
+also the thing that ends a run which will not converge.
 
 ## Real prices, and one worked comparison
 
@@ -76,15 +81,17 @@ and all of these move; check the model's page before relying on them.
 The default's range is that wide because two dozen providers serve it and
 OpenRouter picks one per request, so a task's bill depends on where it landed as
 well as on how long it ran. Sonnet's lower figures are the standard tier; above
-200,000 prompt tokens a higher tier applies ($6.00 / $22.50), which an agent
-transcript can in principle reach, though with this loop's 25-turn cap and
-clipped tool results it rarely will.
+200,000 prompt tokens a higher tier applies ($6.00 / $22.50), which a long agent
+transcript can reach, though clipped tool results keep an ordinary task well
+under it.
 
 One more number from the same page, because it changes what stops a run: the
 default's context window is 1,310,720 tokens, against 204,800 for `z-ai/glm-4.6`,
-the default before it. With a 25-turn cap and tool results clipped at 8,000
-characters, a transcript will not come near filling that window, so the ceiling
-you actually meet is the turn cap or the bill, not the model's context.
+the default before it. With tool results clipped at 8,000 characters an ordinary
+task stays far below either figure, so what you meet first is the bill, or your
+own decision to end the run - not the model's context. A run left to wander long
+enough does eventually meet the window, and meets it much sooner on the smaller
+one.
 
 Now the arithmetic, illustrative rather than measured: take a 20-turn task whose
 transcript averages 15,000 tokens per turn. That is about 300,000 input tokens,
@@ -104,11 +111,10 @@ fifty of them, or when a monitoring job runs one every hour.
 
 The table above assumes both models take the same 20 turns, and they do not. A
 weaker model clicks the wrong element and has to notice and recover, re-reads
-pages it already read, or wanders into the 25-turn ceiling - and a task that
-dies at the ceiling costs more than a task that succeeds, because the transcript
-was at its largest exactly when it was being resent most. Three failed cheap
-runs plus one successful one can overtake a single clean run on a model five
-times the price.
+pages it already read, or wanders without converging - and wandering is the
+expensive failure, because nothing ends it and the transcript is at its largest
+exactly while it is being resent most. Three failed cheap runs plus one
+successful one can overtake a single clean run on a model five times the price.
 
 That caveat applies to the default as much as to anything you might downgrade
 to. It is a fast, cheap model, and this wiki has no measurement of how it holds
@@ -131,7 +137,7 @@ you moved.
    challenge page is not a model problem, and no model spend fixes it; the
    [diagnostic page](browser-problem-or-model-problem.md) separates the two.
 3. **Upgrade on model-side symptoms only**: wrong elements, loops, premature
-   "done", turn-ceiling errors on tasks that ought to be short. Try a frontier
+   "done", long wandering runs on tasks that ought to be short. Try a frontier
    model on the same task and compare transcripts, not vibes.
 4. **Match the model to the task's stakes.** A nightly check that reads one
    number can live on the cheapest thing that works ([monitoring is exactly
@@ -169,10 +175,14 @@ OpenRouter API and stripped from the environment the browser engine starts
 with, by name and by value; the repository carries a test that fails if that
 stops being true.
 
-**Can I cap what a task spends?** There is no money cap in the current source.
-The structural caps are 25 turns per instruction and 8,192 tokens per reply,
-and the interface shows running token usage while a task runs, so a runaway is
-visible while it is still cheap.
+**Can I cap what a task spends?** There is no money cap in the current source,
+and no cap on turns either: the only structural one is 8,192 tokens per reply.
+What you get instead is visibility and a stop. The interface shows running token
+usage while a task runs, and while work is in flight the send button becomes a
+red stop button - as long as the message box is empty, since typing turns it
+back into a button that queues your message for the next turn. So a runaway is
+visible, and endable, while it is still cheap, but only by someone who is
+looking.
 
 ## Sources
 
@@ -186,9 +196,11 @@ All retrieved 2026-09-08.
   for the frontier comparison pricing and the long-context tier.
 - [feder-cr/AIHawk](https://github.com/feder-cr/AIHawk), this repository's
   source: `src/aihawk/llm.py` (default model, OpenRouter-only base URL, key and
-  model resolution), `src/aihawk/agent.py` (the loop, turn cap, token caps,
-  transcript resending, usage meter), and `src/aihawk/runner.py` with
-  `tests/test_key_isolation.py` (the key never reaching the browser process).
+  model resolution), `src/aihawk/agent.py` (the loop, its lack of a turn cap,
+  the per-reply token cap, transcript resending, usage meter),
+  `src/aihawk/web.py` (the token meter and the stop button), and
+  `src/aihawk/runner.py` with `tests/test_key_isolation.py` (the key never
+  reaching the browser process).
 
 **See also:** [browser problem or model problem?](browser-problem-or-model-problem.md),
 [agent retry loops and rate limits](agent-retry-loops-rate-limits.md), and the

--- a/docs/writing-tasks-for-an-ai-browser-agent.md
+++ b/docs/writing-tasks-for-an-ai-browser-agent.md
@@ -113,10 +113,11 @@ reliable than it looks.
 
 ### A limit on pages and time
 
-An unbounded task ("check every listing") can run until a turn budget stops
-it mid-thought, on a page the agent had no way to know was this large.
-Stating a cap, "the first three pages," "stop after ten minutes," turns an
-open-ended risk into a bounded one with a clean stopping point.
+An unbounded task ("check every listing") runs until it is done or until you
+stop it, on a page the agent had no way to know was this large - and nothing
+in the loop will end it for you. Stating a cap, "the first three pages,"
+"stop after ten minutes," turns an open-ended risk into a bounded one with a
+clean stopping point you did not have to sit and watch for.
 
 [AI agents for web research](ai-agent-web-research.md) bounds a walk the
 same way, one page range at a time, for exactly this reason.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.12.0"
+version = "0.13.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/agent.py
+++ b/src/aihawk/agent.py
@@ -13,6 +13,7 @@ behaviours to test.
 """
 from __future__ import annotations
 
+import asyncio
 import json
 from typing import Any, Awaitable, Callable, List, Optional
 
@@ -79,11 +80,10 @@ class Conversation:
     #: one. Generous for that, sixteen times smaller than the default.
     MAX_TOKENS = 8192
 
-    def __init__(self, client, model: str, *, max_turns: int = 25,
+    def __init__(self, client, model: str, *,
                  max_tokens: int = MAX_TOKENS) -> None:
         self.client = client
         self.model = model
-        self.max_turns = max_turns
         self.max_tokens = max_tokens
         self.messages: List[dict] = [{"role": "system", "content": SYSTEM_PROMPT}]
         self.tool_defs: Optional[List[dict]] = None
@@ -117,8 +117,35 @@ class Conversation:
             self.tool_defs = mcp_tools_to_openai(tools)
         self.messages.append({"role": "user", "content": task})
 
-        for _turn in range(self.max_turns):
-            resp = self.client.chat.completions.create(
+        # No turn ceiling. There was one, and what it did in practice was end
+        # long tasks that were going fine with "task did not finish within
+        # max_turns=25" - a task the person had watched work for twenty-five
+        # steps, thrown away one step before it might have answered, with the
+        # transcript at its largest and every one of those steps already paid
+        # for. A number cannot tell a loop that is stuck from a task that is
+        # simply long, and guessing wrong costs the whole run.
+        #
+        # What stops a run instead is the person watching it: the interface
+        # keeps the task handle and the send button becomes a stop button while
+        # work is in flight, so a cancel lands at the next tool call. That is a
+        # judgement about THIS run rather than a constant chosen in advance,
+        # and unlike the ceiling it can also stop a run on turn three.
+        while True:
+            # IN A THREAD, and that is what makes the stop button work. The
+            # client is synchronous, so called here it would occupy the event
+            # loop for the whole request: measured at zero scheduler slices
+            # during a 300 ms call, which means `/chat/stop` cannot be served,
+            # no event reaches the page and the live pane does not repaint -
+            # for the entire time the model is thinking, which is exactly when
+            # somebody reaches for stop.
+            #
+            # It is also a cancellation point, so a stop lands here rather than
+            # waiting for the turn to reach its next tool call. What it does
+            # NOT do is unsend the request: the thread runs to completion and
+            # its answer is dropped, so a run stopped mid-turn still pays for
+            # the reply it never used.
+            resp = await asyncio.to_thread(
+                self.client.chat.completions.create,
                 model=self.model, messages=self.messages,
                 tools=self.tool_defs, tool_choice="auto", temperature=0,
                 max_tokens=self.max_tokens,
@@ -158,10 +185,8 @@ class Conversation:
                 self.messages.append({"role": "tool", "tool_call_id": call.id,
                                       "content": text[:8000]})
 
-        raise RuntimeError(f"task did not finish within max_turns={self.max_turns}")
 
-
-async def run_task(mcp, task: str, *, client, model: str, max_turns: int = 25,
+async def run_task(mcp, task: str, *, client, model: str,
                    max_tokens: int = Conversation.MAX_TOKENS) -> str:
     """One instruction, one answer, no narration.
 
@@ -171,5 +196,5 @@ async def run_task(mcp, task: str, *, client, model: str, max_turns: int = 25,
     would move a lot of code to delete four lines.
     """
     tools = (await mcp.list_tools()).tools
-    convo = Conversation(client, model, max_turns=max_turns, max_tokens=max_tokens)
+    convo = Conversation(client, model, max_tokens=max_tokens)
     return await convo.run(task, mcp.call_tool, tools)

--- a/src/aihawk/brain.py
+++ b/src/aihawk/brain.py
@@ -50,8 +50,8 @@ class OpenRouterBrain(Brain):
     machinery" goes false with nobody editing it, and why this one is four lines.
     """
 
-    def __init__(self, client, model: str, *, max_turns: int = 25) -> None:
-        self._convo = Conversation(client, model, max_turns=max_turns)
+    def __init__(self, client, model: str) -> None:
+        self._convo = Conversation(client, model)
 
     @property
     def usage(self) -> dict:
@@ -62,11 +62,10 @@ class OpenRouterBrain(Brain):
         return self._convo.messages
 
     async def handle(self, text: str, link: Link, say: Say) -> None:
-        try:
-            await self._convo.run(text, link.call, link.tools,
-                                  say=say, describe=actions_help.summarise)
-        except RuntimeError as exc:
-            # The turn ceiling. It is the one failure a person can act on - by
-            # narrowing the task - so it is said plainly rather than raised into
-            # the generic handler that prefixes an exception class.
-            await say("err", str(exc))
+        # Nothing is caught here. There used to be a handler for the turn
+        # ceiling, the one failure a person could act on by narrowing the task;
+        # the ceiling is gone, and every remaining failure is either the
+        # cancellation the stop button raises or something the interface's own
+        # handler already reports.
+        await self._convo.run(text, link.call, link.tools,
+                              say=say, describe=actions_help.summarise)

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -223,15 +223,17 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
     font:var(--t-body)/1.55 var(--sans); min-height:24px; max-height:200px;
     overflow-y:hidden; padding:0; caret-color:var(--accent) }
 #i::placeholder{ color:var(--fg-4) }
-#go{ width:32px; height:32px; flex:none; border:0; border-radius:50%; display:grid;
+#go, #halt{ width:32px; height:32px; flex:none; border:0; border-radius:50%; display:grid;
      place-items:center; cursor:pointer; background:var(--accent);
      box-shadow:inset 0 1px 0 rgba(255,255,255,.22);
      transition:background 120ms ease-out, transform 80ms ease-out }
-#go:active{ transform:scale(.92); box-shadow:none }
+#go:active, #halt:active{ transform:scale(.92); box-shadow:none }
 #go:disabled{ opacity:.3; cursor:default }
-#go[data-mode="stop"]{ background:#d94f45 }
-#go svg{ display:none }
-#go[data-mode="send"] .s-send, #go[data-mode="stop"] .s-stop{ display:block }
+/* Its own button, not a mode of the send button. As a mode it disappeared the
+   moment somebody typed, because the same control then meant "queue this for
+   the next turn" - and the loop has no turn ceiling, so this button is the only
+   thing that ends a run that will not converge. It follows the RUN. */
+#halt{ background:#d94f45 }
 #chip{ display:inline-flex; align-items:center; gap:6px; margin-bottom:var(--s2);
        background:var(--hover); border:1px solid var(--line-2); color:var(--fg-2);
        font-size:var(--t-label); padding:3px 9px; border-radius:var(--r-pill);
@@ -345,11 +347,13 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
     <span id="chip" hidden>1 message queued <span aria-hidden="true">&#9998;</span></span>
     <div class="composer">
       <textarea id="i" rows="1" placeholder="What should the agent do?"></textarea>
-      <button id="go" type="submit" data-mode="send" aria-label="Send" disabled>
-        <svg class="s-send" width="14" height="14" viewBox="0 0 14 14" fill="none"
+      <button id="go" type="submit" aria-label="Send" disabled>
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none"
              stroke="#101317" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
           <path d="M7 12V2M2.5 6.5L7 2l4.5 4.5"/></svg>
-        <svg class="s-stop" width="12" height="12" viewBox="0 0 12 12">
+      </button>
+      <button id="halt" type="button" hidden aria-label="Stop">
+        <svg width="12" height="12" viewBox="0 0 12 12">
           <rect width="12" height="12" rx="2" fill="#fff"/></svg>
       </button>
     </div>
@@ -513,15 +517,16 @@ $('jump').onclick = () => anchor.scrollIntoView({block:'end', behavior:'smooth'}
 
 /* ---- the composer. It is never disabled: greying out the input the moment the
    run gets interesting is most of what reads as unfinished. ---- */
-const i = $('i'), go = $('go'), f = $('f'), chip = $('chip');
+const i = $('i'), go = $('go'), halt = $('halt'), f = $('f'), chip = $('chip');
 
 function paint(){
   const typed = i.value.trim().length > 0;
-  const stop = busyNow && !typed;
-  go.dataset.mode = stop ? 'stop' : 'send';
-  go.disabled = !stop && !typed;
-  go.setAttribute('aria-label', stop ? 'Stop'
-    : queued ? 'Replace queued message' : busyNow ? 'Queue for next turn' : 'Send');
+  /* Shown for as long as work is in flight and for no other reason: it is tied
+     to the run, never to what the composer happens to contain. */
+  halt.hidden = !busyNow;
+  go.disabled = !typed;
+  go.setAttribute('aria-label',
+    queued ? 'Replace queued message' : busyNow ? 'Queue for next turn' : 'Send');
   i.placeholder = queued ? 'Type to replace the queued message'
     : busyNow ? 'Type to queue a message' : 'What should the agent do?';
   chip.hidden = !queued;
@@ -544,10 +549,11 @@ function send(text){
   fetch('/chat/send', {method:'POST', headers:{'Content-Type':'application/json'},
                        body: JSON.stringify({text})});
 }
+halt.onclick = () => fetch('/chat/stop', {method:'POST'});
 f.onsubmit = (e) => {
   e.preventDefault();
   const t = i.value.trim();
-  if(!t){ if(busyNow) fetch('/chat/stop', {method:'POST'}); return; }
+  if(!t){ return; }
   i.value = ''; i.style.height = 'auto';
   if(busyNow){ queued = t; paint(); return; }
   send(t); paint();
@@ -719,10 +725,16 @@ class ChatService:
             try:
                 await self._brain.handle(text, self._link, self.emit)
             except asyncio.CancelledError:
-                # The cancellation lands at the next await, which is the next
-                # tool call: the request to the model itself is synchronous. So
-                # stop means "after the step in flight", and the page is told
-                # that rather than promising something faster.
+                # The cancellation lands at the next await, and since the model
+                # request runs in a thread that is either the request itself or
+                # the tool call after it - so stop is prompt rather than "after
+                # the step in flight", which is what this comment used to say
+                # and what the loop used to do.
+                #
+                # Prompt is not free: a model request already sent finishes in
+                # its thread and its answer is discarded, so a run stopped
+                # mid-turn is still billed for that reply. Stopping cuts what
+                # comes next, never what is already in the air.
                 await self.emit("err", "stopped")
                 raise
             except Exception as exc:

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -44,9 +44,13 @@ No test in this file starts a browser or spawns the MCP server.
 """
 from __future__ import annotations
 
+import ast
+import asyncio
 import copy
 import inspect
 import json
+import pathlib
+import time
 
 import pytest
 
@@ -58,7 +62,14 @@ from openai.types.chat.chat_completion_message_function_tool_call import (
     Function,
 )
 
-from aihawk.agent import SYSTEM_PROMPT, _result_text, mcp_tools_to_openai, run_task
+from aihawk import agent as agent_module
+from aihawk.agent import (
+    SYSTEM_PROMPT,
+    Conversation,
+    _result_text,
+    mcp_tools_to_openai,
+    run_task,
+)
 
 
 # --------------------------------------------------------------------------
@@ -631,56 +642,127 @@ async def test_a_result_at_or_below_the_limit_is_sent_whole():
     assert len(sent) == 8000
 
 
-async def test_max_turns_is_enforced_and_the_error_names_the_limit():
-    """A model that keeps calling tools forever must stop costing money.
+async def test_a_long_task_runs_past_the_old_ceiling_and_still_returns():
+    """There is no turn ceiling, and this is the test that says so.
 
-    Known-bad: `while True`, which never returns; or an error message that does
-    not carry the number, leaving the operator with no idea what to raise."""
+    The loop used to stop at 25 and raise, which ended long tasks that were
+    going fine one step before they might have answered. This drives it well
+    past that number and expects the answer.
+
+    Known-bad: any `range(...)` back around the loop, or a re-added constant.
+    Either one makes this raise instead of returning, at whatever number it was
+    set to.
+    """
     mcp = ScriptedMCP(tools=tools_result(tool("browser_navigate")))
-    model = ScriptedModel(
-        [assistant_tool_calls(("c", "browser_navigate", '{"url": "http://127.0.0.1"}'))],
-        repeat_last=True,
-    )
+    steps = [assistant_tool_calls(("c%d" % i, "browser_navigate",
+                                   '{"url": "http://127.0.0.1"}'))
+             for i in range(40)]
+    model = ScriptedModel(steps + [assistant_answer("done after forty steps")])
 
-    with pytest.raises(RuntimeError) as excinfo:
-        await run_task(mcp, "loop forever", client=model, model="m", max_turns=3)
+    out = await run_task(mcp, "a long one", client=model, model="m")
 
-    assert "max_turns=3" in str(excinfo.value)
-    assert len(model.requests) == 3
-    assert len(mcp.calls) == 3
+    assert out == "done after forty steps"
+    assert len(model.requests) == 41
+    assert len(mcp.calls) == 40
 
 
-async def test_a_task_finishing_on_the_last_allowed_turn_still_returns():
-    """The boundary from the other side. Known-bad: `range(max_turns - 1)`, which
-    raises on a run that finished exactly within its budget."""
+async def test_the_model_call_does_not_hold_the_event_loop():
+    """A blocking call on the loop turns the stop button into a decoration.
+
+    The model request is a SYNCHRONOUS HTTP call. Run directly on the event
+    loop it holds the whole server for its duration: `/chat/stop` cannot be
+    served, no event reaches the page, and the live browser pane freezes. With
+    no turn ceiling that repeats on every turn of an arbitrarily long run, and
+    the stop button is the only thing that ends such a run - so it has to be
+    answerable while the model is thinking, which is exactly when a person
+    reaches for it.
+
+    Measured rather than reasoned about: a heartbeat counts how many slices the
+    loop hands out while one model call is in flight. On the loop the answer is
+    zero.
+
+    Known-bad: `self.client.chat.completions.create(...)` called directly in
+    `run` instead of being handed to a thread. This test then counts 0 ticks.
+    """
+    blocking_seconds = 0.30
+    tick_seconds = 0.01
+
+    class BlockingModel(ScriptedModel):
+        """Stands in for a real request: it occupies the caller, not an await."""
+
+        def _create(self, kwargs: dict):
+            time.sleep(blocking_seconds)
+            return super()._create(kwargs)
+
+    mcp = ScriptedMCP()
+    model = BlockingModel([assistant_answer("done")])
+
+    ticks = 0
+
+    async def heartbeat() -> None:
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(tick_seconds)
+            ticks += 1
+
+    beat = asyncio.create_task(heartbeat())
+    try:
+        out = await run_task(mcp, "t", client=model, model="m")
+    finally:
+        beat.cancel()
+
+    assert out == "done"
+    assert ticks >= 5, (
+        "the loop got %d slices during a %.2fs model call, so the call is "
+        "running ON the event loop: while the model thinks, the stop route, "
+        "the event stream and the frame pump are all unreachable"
+        % (ticks, blocking_seconds))
+
+
+async def test_a_task_that_answers_on_its_second_turn_returns_there():
+    """The short case still works, which is the other half of removing a cap:
+    nothing about a run that finishes quickly changed.
+
+    Known-bad: a loop that keeps asking after the model stopped calling tools,
+    which would spend forever on a task that was already answered.
+    """
     mcp = ScriptedMCP(tools=tools_result(tool("browser_navigate")))
     model = ScriptedModel([
         assistant_tool_calls(("c1", "browser_navigate", '{"url": "http://127.0.0.1"}')),
         assistant_answer("finished on turn two"),
     ])
 
-    out = await run_task(mcp, "t", client=model, model="m", max_turns=2)
+    out = await run_task(mcp, "t", client=model, model="m")
     assert out == "finished on turn two"
 
 
-async def test_max_turns_zero_asks_the_model_nothing_and_raises():
-    """Known-bad: an off-by-one that grants one free turn to a caller who asked
-    for none."""
-    mcp = ScriptedMCP()
-    model = ScriptedModel([assistant_answer("should never be reached")])
+def test_no_turn_budget_is_exposed_anywhere_in_the_loop():
+    """Structural pin: the parameter is gone, not defaulted to something large.
 
-    with pytest.raises(RuntimeError) as excinfo:
-        await run_task(mcp, "t", client=model, model="m", max_turns=0)
+    Known-bad: `max_turns: int = 1000`, which reads as "no limit" to whoever
+    added it and is still a wall a long task can hit in front of a user.
 
-    assert "max_turns=0" in str(excinfo.value)
-    assert model.requests == []
+    Read from the AST and not from the text. The first version of this test
+    searched the source for the string and failed on the comment in agent.py
+    that quotes the error the ceiling used to raise - a check tripped by the
+    prose explaining the code rather than by the code, which is the defect this
+    project writes down most often.
+    """
+    assert "max_turns" not in inspect.signature(run_task).parameters
+    assert "max_turns" not in inspect.signature(Conversation.__init__).parameters
 
-
-def test_the_shipped_default_turn_budget_is_25():
-    """The CLI never passes max_turns, so this default is the cap every real run
-    gets. Known-bad: lowering it to a number that cannot finish a multi-page
-    task, which would only show up as a RuntimeError in front of a user."""
-    assert inspect.signature(run_task).parameters["max_turns"].default == 25
+    tree = ast.parse(pathlib.Path(agent_module.__file__).read_text(encoding="utf-8"))
+    named = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.arg):
+            named.add(node.arg)
+        elif isinstance(node, ast.Attribute):
+            named.add(node.attr)
+        elif isinstance(node, ast.Name):
+            named.add(node.id)
+        elif isinstance(node, ast.keyword) and node.arg:
+            named.add(node.arg)
+    assert "max_turns" not in named
 
 
 async def test_empty_tool_arguments_become_an_empty_dict():

--- a/tests/test_cli_surface.py
+++ b/tests/test_cli_surface.py
@@ -51,15 +51,30 @@ def key_leaked(text: str) -> bool:
 
 
 @pytest.fixture(autouse=True)
-def clean_provider_env(monkeypatch):
-    """No provider variable may reach a test from the developer's own shell.
+def clean_provider_env(monkeypatch, tmp_path):
+    """No key may reach a test from the developer's machine, by either road.
 
     Known-bad this guards: a machine that happens to export OPENROUTER_API_KEY
     would turn the "no key anywhere" test green while the CLI was broken.
+
+    ⛔ AND THE ENVIRONMENT IS ONLY ONE OF THE TWO ROADS. `ui` also reads a
+    `.env` from the directory it runs in, which is the way this project's own
+    README tells people to supply the key, and `.env` is git-ignored precisely
+    so it can sit in a checkout. Measured 2026-09-08: with one there,
+    `test_no_key_anywhere_is_refused_and_points_at_the_library` and
+    `test_an_openai_key_in_the_environment_is_not_accepted` both fail, saying
+    the browser was launched before the refusal - a red that appears only on a
+    developer's machine and never in CI, where no `.env` exists. The fixture
+    scrubbed the variables and never thought about the file.
+
+    So the working directory moves to an empty one for the duration. That also
+    keeps every test in this file honest about a second thing: none of them may
+    depend on being run from inside the repository.
     """
     for name in ("OPENROUTER_API_KEY", "AIHAWK_MODEL", "OPENAI_API_KEY",
                  "ANTHROPIC_API_KEY"):
         monkeypatch.delenv(name, raising=False)
+    monkeypatch.chdir(tmp_path)
 
 
 class _Stop(Exception):

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -18,7 +18,7 @@ import json
 
 import pytest
 
-from aihawk.web import ChatService, build_app
+from aihawk.web import PAGE, ChatService, build_app
 
 pytestmark = pytest.mark.asyncio
 
@@ -245,6 +245,40 @@ async def test_the_app_exposes_exactly_the_routes_the_page_calls():
     paths = {r.path for r in build_app(FakeLink(), svc).routes}
     assert paths == {"/", "/chat/send", "/chat/stop", "/chat/events",
                      "/live/frame", "/live/tabs", "/live/select"}
+
+
+async def test_the_stop_control_is_its_own_button_and_follows_the_run():
+    """The stop button must not be a mode of the send button.
+
+    It was one, and the mode was `busyNow && !typed`: the moment somebody typed
+    into the composer while the agent worked, the same control became "queue for
+    the next turn" and there was no way to stop from the page at all. That was
+    survivable while the loop stopped itself at twenty-five turns. It is not
+    survivable now: the loop has no ceiling, so this button is the only thing
+    that ends a run that will not converge.
+
+    ⛔ WHAT THIS DOES AND DOES NOT PROVE. It reads the markup and the script the
+    page ships, so it catches the button being deleted, renamed, or folded back
+    into `#go`. It does NOT execute the script, so it cannot prove the button is
+    reachable, visible or wired on a rendered page - that needs a browser, and
+    it was done by hand against a running interface.
+
+    Known-bad, all three caught here: removing the `#halt` element; painting it
+    from anything other than `busyNow`; giving `#go` back a `data-mode` stop.
+    """
+    page = PAGE
+
+    assert 'id="halt"' in page, "the dedicated stop button is gone"
+    assert "halt.onclick" in page and "'/chat/stop'" in page, \
+        "the stop button no longer posts to the stop route"
+
+    # Painted from the run and from nothing else. `!busyNow` is the whole
+    # condition: any `typed` in it is the old mode logic coming back.
+    assert "halt.hidden = !busyNow;" in page, \
+        "the stop button is no longer tied to the run alone"
+
+    assert 'data-mode' not in page, \
+        "the send button has a mode again, which is how stop went missing before"
 
 
 async def test_the_live_view_asks_for_nothing_until_an_instruction_has_been_given():


### PR DESCRIPTION
The loop stopped itself at twenty-five turns and raised `task did not finish within max_turns=25`. What that did in practice was end long tasks that were going fine, one step before they might have answered, with the transcript at its largest and every step already paid for. A number cannot tell a loop that is stuck from a task that is simply long.

The ceiling is removed, not raised. There is no `max_turns` parameter left anywhere to set.

What ends a run now is the person watching it, so the two things that made that unreliable are fixed here as well.

## The stop control is its own button

It was a mode of the send button, under the condition `busyNow && !typed`, so it vanished the moment somebody typed while the agent worked - and the composer is exactly where a person's hands are. It now follows the run and nothing else. Queueing a follow-up still works next to it.

Verified in a browser against a running interface, not only in tests: with text in the composer the stop button stays on screen, and pressing it mid-task ends the run with `stopped` and clears the busy state.

## The model request runs in a thread

It is a synchronous HTTP call and it sat on the event loop. Measured: **zero scheduler slices during a 300 ms call**, so `/chat/stop` could not be served, no event reached the page, and the live pane did not repaint for as long as the model was thinking - which is exactly when somebody reaches for stop. `asyncio.to_thread` also makes it a cancellation point, so a stop lands promptly instead of after the step in flight.

It does not unsend a request already made: that reply finishes in its thread, is dropped, and is still paid for. The code says so where it happens.

## Tests

Four tests pinned the ceiling and are replaced by three that pin its absence: a long run that goes forty steps and returns, the short case unchanged, and a structural one reading the **AST** rather than the source text - so the comment quoting the old error message does not count as a reintroduction while `max_turns: int = 1000` still would.

New: a test that measures the event loop is free during a model call (the heartbeat above), and one that pins the stop button as its own element painted from `busyNow` alone.

Unrelated but found on the way: the CLI tests scrubbed provider environment variables and never considered the `.env` file the README tells people to write. Two of them failed on any machine that had one, and passed in CI, which has none. The fixture now runs them from an empty directory.

## Docs

Seven wiki pages described the cap, three of them resting advice on it. They now describe what actually bounds a run, and say plainly that a stop only works while somebody is looking. The batching advice kept its shape and changed its reason: cost grows with the transcript, and a long unattended run writes many wrong rows before anyone reads the log.

## Test plan

- [x] `pytest -q`: 342 passed, 3 xfailed unchanged
- [x] known-bad mutations killed: reinstating the cap turns the two turn tests red; tying the stop button back to the composer turns its test red; both restored byte-identical
- [x] the loop-blocking test measured 0 slices before the fix and passes after
- [x] `AIHAWK_CHECK_VERSION=1` and `AIHAWK_CHECK_RELEASES=1` gates green
- [x] `check_english_only.py`, `check_content.py`: clean
- [x] driven by hand in a browser: stop with text typed, stop mid-task, run resumes to a normal finish otherwise
