### PR TITLE
A page joining a run in flight is told so, or it has no stop button (0.13.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.13.0"
+version = "0.13.1"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -699,6 +699,16 @@ class ChatService:
         for q in list(self._listeners):
             q.put_nowait(event)
 
+    @property
+    def busy(self) -> bool:
+        """Whether an instruction is in flight, for a listener joining now.
+
+        The lock and not the task handle: the lock is held for exactly as long
+        as `send` runs, which is the span the page draws as busy, while the
+        handle survives its own task and would answer for a run that ended.
+        """
+        return self._busy.locked()
+
     def start(self, text: str) -> None:
         """Run an instruction detached, keeping the handle so it can be stopped.
 
@@ -764,6 +774,9 @@ def build_app(link: Link, service: ChatService) -> Starlette:
         # starts `stream` later, so taking this snapshot inside it would let an
         # intervening event appear in both history and the listener's queue.
         replay = list(service.history)
+        # Taken with the snapshot, for the same reason: whether a run is in
+        # flight is part of the state this listener is joining.
+        joining_a_run = service.busy
 
         async def stream() -> AsyncIterator[bytes]:
             try:
@@ -774,6 +787,18 @@ def build_app(link: Link, service: ChatService) -> Starlette:
                 # before this listener existed.
                 for past in replay:
                     yield b"data: " + json.dumps({**past, "replay": True}).encode() + b"\n\n"
+                # And then the CURRENT state, which the replay above cannot
+                # carry: `emit` keeps `busy` out of the history on purpose, so a
+                # page opened long after a run would not show a spinner for work
+                # that ended an hour ago. That is right for a finished run and
+                # wrong for one still going - the page would show a transcript
+                # growing under a composer that says nothing is happening, and
+                # with no turn ceiling the stop button is the only thing that
+                # ends such a run. So it is sent as what it is, the present, and
+                # only when true: a page starts out believing it is idle.
+                if joining_a_run:
+                    yield b"data: " + json.dumps(
+                        {"kind": "busy", "text": "1"}).encode() + b"\n\n"
                 while True:
                     event = await q.get()
                     yield b"data: " + json.dumps(event).encode() + b"\n\n"

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -404,6 +404,87 @@ async def test_a_capture_that_cannot_answer_says_why_instead_of_looking_idle():
     assert "page.screencast" in json.loads(resp.body)["error"]
 
 
+class _Req:
+    """The events route ignores its request; this is enough to call it."""
+    query_params: dict = {}
+
+
+async def _first_events(resp, want=4, each=1.0):
+    """Read up to `want` events, giving up when the stream goes quiet.
+
+    Bounded on purpose. The stream stays open forever by design, so an
+    unbounded read turns "the event never came" into a suite that hangs
+    instead of a test that fails, and a gate that hangs has no verdict. This
+    was not hypothetical: the first version of the test below hung under its
+    own known-bad mutation rather than going red.
+    """
+    seen = []
+    it = resp.body_iterator.__aiter__()
+    try:
+        while len(seen) < want:
+            chunk = await asyncio.wait_for(it.__anext__(), each)
+            seen.append(json.loads(chunk.decode().removeprefix("data: ").strip()))
+    except (asyncio.TimeoutError, StopAsyncIteration):
+        pass
+    return seen
+
+
+async def test_a_page_that_joins_a_run_in_flight_is_told_the_run_is_in_flight():
+    """Reload during a run and the stop button has to still be there.
+
+    ⛔ MEASURED BY HAND 2026-09-08, against a running interface, and it was the
+    turn ceiling that had been hiding it. `emit` keeps `busy` out of the history
+    on purpose - replaying it would show a spinner for work that ended an hour
+    ago - but nothing then told a NEW listener the state of now. So a reload
+    mid-run replayed the transcript and left the page believing it was idle:
+    steps kept arriving and appending, under a composer that said nothing was
+    happening, with no stop button. With the ceiling gone that run had no other
+    end, so the page offered no way to stop what it was showing.
+
+    The history stays free of state. What is sent is the present, once, at
+    subscribe time, and only when true.
+
+    Known-bad: dropping the current-state event from the events route. The
+    listener below then never sees a `busy` event at all.
+    """
+    brain = HangingBrain()
+    svc = ChatService(FakeLink(), brain)
+    app = build_app(FakeLink(), svc)
+    events = [r for r in app.routes if r.path == "/chat/events"][0]
+
+    svc.start("something long")
+    await asyncio.wait_for(brain.started.wait(), 2)
+    assert svc.busy, "the service does not consider itself busy while a run runs"
+
+    # A listener arriving now, which is what a reload is.
+    resp = await events.endpoint(_Req())
+    seen = await _first_events(resp)
+
+    busy = [e for e in seen if e["kind"] == "busy"]
+    assert busy, "a page joining a run in flight was never told a run is in flight: %r" % seen
+    assert busy[0]["text"] == "1"
+    assert not busy[0].get("replay"), "the run is happening now, not being replayed"
+
+    svc.stop()
+
+
+async def test_a_page_that_joins_an_idle_service_is_not_told_anything_about_busy():
+    """The other side, and the reason the event is conditional: a page starts
+    out believing it is idle, so saying so again is noise, and the page's own
+    handler treats `busy 0` as the end of a turn it never saw begin.
+
+    Known-bad: sending the state unconditionally.
+    """
+    svc = ChatService(FakeLink(), SilentBrain())
+    app = build_app(FakeLink(), svc)
+    events = [r for r in app.routes if r.path == "/chat/events"][0]
+
+    resp = await events.endpoint(_Req())
+    seen = await _first_events(resp)
+
+    assert [e for e in seen if e["kind"] == "busy"] == []
+
+
 # --------------------------------------------------------------------------
 # the tab strip, which only became possible when the tool stopped lying
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Reload the interface while the agent is working and the page came back believing it was idle. The transcript replayed and then kept growing, step after step, under a composer that said nothing was happening - and with no stop button anywhere.

With the turn ceiling removed in 0.13.0 that run had no other end, so the one thing that could stop it was missing at exactly the moment somebody had come back to look for it.

## The cause

A correct rule applied one case too widely. `emit` keeps `busy` out of the history on purpose: replaying it would show a spinner for work that finished an hour ago. That is right for a run that has ended. But nothing then told a **new** listener the state of the present, so "do not replay stale state" had quietly become "never say what is happening now".

## The fix

The history still carries no state. A listener is sent the current state at subscribe time instead:

- **once**, taken with the same snapshot that freezes the replay boundary
- **unflagged**, because it describes the present rather than the past
- **only when a run is in flight**, because a page starts out believing it is idle, and telling it so again drives its own handler to end a turn it never saw begin

`ChatService.busy` reads the lock, held for exactly as long as `send` runs, rather than the task handle, which outlives its own task and would answer for a run that already ended.

## How it was found, and the test that hung

By hand, against a running interface, doing what a person does: start a long run, leave the page, come back. Not by a test - there was none for this, and the turn ceiling had been hiding the consequence.

There are two now: a listener joining a run in flight, and a listener joining an idle service. The first one **hung** under its own known-bad mutation instead of failing, because the event stream stays open by design and the event that never comes never ends the read. A gate with no verdict is not a gate, so the read is bounded and the mutation now turns it red in three seconds.

## Test plan

- [x] `pytest -q`: 344 passed, 3 xfailed unchanged
- [x] known-bad mutation (`if False:` in place of the state send) turns the joining test red, not hanging; restored byte-identical, CRLF intact
- [x] `AIHAWK_CHECK_VERSION=1` and `AIHAWK_CHECK_RELEASES=1` gates green
- [x] `check_english_only.py`, `check_content.py`: clean; zero em/en-dashes added
- [x] verified by hand in a browser on the fixed build: reload mid-run now shows the stop button, and pressing it from that reloaded page ends the run with `stopped`
