### PR TITLE
The live pane showed 4.6 of the 10 frames a second it was being sent (0.13.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.13.1"
+version = "0.13.2"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -611,12 +611,23 @@ async function tick(){
     else { say('error'); }
   } catch(err){ say('offline'); }
   /* Ask for the next frame only once this one has landed, or a browser slower
-     than the interval accumulates requests it can never serve. A frame is one
-     JPEG the server already holds, not a paint, so five a second cost the pipe
-     almost nothing; the engine produces ten, and asking faster than that would
-     only show the same frame twice. Actions share this pipe and wait at most
-     one frame. */
-  setTimeout(tick, 200);
+     than the interval accumulates requests it can never serve.
+
+     The pause used to be 200 ms, under a comment that knew the engine produces
+     ten frames a second and asked for five anyway, reasoning that asking faster
+     "would only show the same frame twice". Below the source rate that is
+     backwards: half the frames were made, held, and thrown away. Measured on
+     an animating page, same browser, interleaved rounds: 200 ms delivered
+     4.6 fps to the pane, 60 ms delivers 10.0, which is everything the capture
+     produces (9.6 fps measured at its own callback).
+
+     60 and not 0: a frame costs one round trip of about 22 ms on the pipe that
+     ACTIONS also use, so the cycle is roughly 82 ms and asks about 13 times a
+     second for 10 frames - a little waste to keep the picture whole, against
+     the 46 a second an unpaced loop would ask, which would spend the pipe on
+     duplicates and make every click queue behind them. An action still waits
+     at most one frame. */
+  setTimeout(tick, 60);
 }
 
 /* Built from elements with textContent and never innerHTML: this string comes

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -429,6 +429,38 @@ async def _first_events(resp, want=4, each=1.0):
     return seen
 
 
+async def test_the_frame_pause_is_shorter_than_the_capture_produces():
+    """Asking slower than the source means frames are made and thrown away.
+
+    The capture pushes about ten frames a second (measured 9.6 at its own
+    callback), and a frame costs roughly 22 ms on the pipe, so a pause of P ms
+    makes a cycle of about P + 22. For the pane to show every frame the source
+    makes, that cycle has to fit inside the ~100 ms between frames.
+
+    It did not: the pause was 200 ms, and the pane ran at 4.6 fps against a
+    source giving 10. The comment above it had both halves of the fact - "the
+    engine produces ten" and "five a second" - and drew the wrong conclusion
+    from them.
+
+    Known-bad: putting it back to 200, or to anything that leaves no room for
+    the round trip.
+    """
+    import re
+
+    m = re.search(r"setTimeout\(tick,\s*(\d+)\)", PAGE)
+    assert m, "the frame pump no longer paces itself with setTimeout(tick, ...)"
+    pause_ms = int(m.group(1))
+
+    round_trip_ms = 22    # measured against the running interface
+    source_period_ms = 100  # 10 fps out of the capture
+
+    assert pause_ms + round_trip_ms <= source_period_ms, (
+        "a %d ms pause makes a %d ms cycle against a source that produces one "
+        "frame every %d ms, so the pane would show about %.1f of the 10 fps it "
+        "is being sent" % (pause_ms, pause_ms + round_trip_ms, source_period_ms,
+                           1000 / (pause_ms + round_trip_ms)))
+
+
 async def test_a_page_that_joins_a_run_in_flight_is_told_the_run_is_in_flight():
     """Reload during a run and the stop button has to still be there.
 


### PR DESCRIPTION
The live pane polls the window capture and paused 200 ms between frames, under a comment that knew the engine produces ten a second, asked for five, and reasoned that asking faster "would only show the same frame twice". Below the source rate that is backwards: the other half were captured, held, and thrown away.

## Measured, not reasoned

Against the running interface, on a page with continuous motion, same browser, interleaved rounds:

| pause | frames reaching the pane |
|---|---|
| 200 ms (before) | **4.6 fps** |
| 60 ms (after) | **10.0 fps** |

10.0 is everything the capture makes: measured at the `on_frame` callback it delivers 9.6 fps, and a poll loop asking faster than that returns the same JPEG again (at 59 requests a second only 80 of 471 were new).

## Why 60 and not 0

A frame is one round trip of about 22 ms, so a 60 ms pause makes a cycle near 82 ms and asks about 13 times a second for 10 frames. Some waste, to lose none of them.

The pipe carries actions too, which was the reason to be careful, so it was measured instead of assumed:

| frame pump | action latency (median) |
|---|---|
| idle | 20 ms |
| ~10 fps (this change) | 20 ms |
| ~24 fps | 18 ms |

The pump is not what an action waits for.

## Lag

The picture was up to 100 ms old at the capture plus up to 222 ms of waiting. It is now up to 100 plus 82.

## Test

The test reads the pause out of the page and refuses one that leaves no room for the round trip inside the source period, so 200 cannot come back quietly. Its known-bad is exactly that: putting 200 back turns it red.

## Not in this change

The capture itself is asked for 10 fps by `invisible-playwright`, which hardcodes it and offers the caller no say, while the engine takes an `fps` parameter and juggler's own default is 25. Measured here: asking for 25 delivers 24.0 fps at 629 KB/s against 257. That is a change in the other package and is left for its own release.

## Test plan

- [x] `pytest -q`: 345 passed, 3 xfailed unchanged
- [x] known-bad: pause back to 200 turns the new test red
- [x] measured on the running interface after the change: the page makes 13.8 requests a second with 8 ms median latency, which is the whole source
- [x] `check_english_only.py`, `check_content.py`: clean
