### PR TITLE
A reconnection resumed nothing: it replayed the whole conversation again (0.14.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.14.0"
+version = "0.14.1"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 from typing import AsyncIterator, Dict, List, Optional
 
 from starlette.applications import Starlette
@@ -642,6 +643,11 @@ function wipe(){
   turn = null; live = null; hold = null; n = 0;
   clearInterval(timer);
   $('tok').hidden = true;
+  /* Idle until told otherwise. On a reconnection the server sends this wipe
+     first and the run state after it, so a page that reconnects to a RESTARTED
+     process stops believing in a run that died with the old one - which
+     otherwise left the composer saying "queue for next turn" forever. */
+  busyNow = false;
   queued = null; paint();
 }
 fresh.onclick = () => fetch('/chat/fresh', {method:'POST'});
@@ -792,6 +798,13 @@ class ChatService:
         self.model_label = model_label
         self._busy = asyncio.Lock()
         self._task: Optional[asyncio.Task] = None
+        #: Which conversation the history belongs to. A reconnecting page says
+        #: how far it got with `Last-Event-ID`, and that position only means
+        #: something inside one conversation: after a reset, or after the
+        #: process restarts, the same number points at a different transcript.
+        #: Counted from the clock so a restart cannot collide with the run
+        #: before it.
+        self._epoch = str(int(time.time() * 1000))
 
     def subscribe(self) -> asyncio.Queue:
         q: asyncio.Queue = asyncio.Queue()
@@ -838,7 +851,23 @@ class ChatService:
         if callable(forget):
             forget()
         self.history.clear()
+        self._epoch = str(int(time.time() * 1000))
         return True
+
+    @property
+    def epoch(self) -> str:
+        """Which transcript the history positions belong to."""
+        return self._epoch
+
+    @property
+    def usage(self) -> dict:
+        """What the meter would show right now, for a listener joining late.
+
+        Read through the brain rather than kept here: the brain owns the
+        transcript, so it owns what the transcript has cost.
+        """
+        got = getattr(self._brain, "usage", None)
+        return dict(got) if isinstance(got, dict) else {}
 
     @property
     def busy(self) -> bool:
@@ -917,25 +946,56 @@ def build_app(link: Link, service: ChatService) -> Starlette:
             await service.emit("fresh", "1")
         return JSONResponse({"fresh": done})
 
-    async def events(_request: Request) -> StreamingResponse:
+    async def events(request: Request) -> StreamingResponse:
         q = service.subscribe()
         # Freeze the replay/live boundary while subscribing. StreamingResponse
         # starts `stream` later, so taking this snapshot inside it would let an
         # intervening event appear in both history and the listener's queue.
-        replay = list(service.history)
+        history = list(service.history)
         # Taken with the snapshot, for the same reason: whether a run is in
         # flight is part of the state this listener is joining.
         joining_a_run = service.busy
+        current_usage = service.usage
+
+        # ⛔ WHERE THIS LISTENER GOT TO, AND WHETHER IT IS EVEN THE SAME
+        # CONVERSATION. `EventSource` reconnects by itself after any drop, and
+        # until this was read the server answered every reconnection with the
+        # whole transcript again, while the page - which has no de-duplication
+        # and had never been given an id to resume from - appended a second
+        # copy of everything. Measured: three consecutive subscriptions each
+        # received all 21 events of the same conversation.
+        #
+        # The epoch is the other half. A position only means something inside
+        # one transcript: after a reset, or after the process restarts, the
+        # same number points at something else entirely, so a mismatch replays
+        # from the beginning - and says `fresh` first, so a page holding the
+        # previous conversation drops it instead of growing a chimera.
+        resume_from, same_conversation = 0, False
+        marker = request.headers.get("last-event-id") or ""
+        if ":" in marker:
+            epoch, _, index = marker.partition(":")
+            if epoch == service.epoch and index.isdigit():
+                resume_from = int(index) + 1
+                same_conversation = True
+        replay = history[resume_from:] if same_conversation else history
 
         async def stream() -> AsyncIterator[bytes]:
             try:
                 yield b"data: " + json.dumps(
                     {"kind": "model", "text": service.model_label}).encode() + b"\n\n"
+                if not same_conversation and marker:
+                    # It reconnected carrying a position from another
+                    # transcript, so what it is still showing is not this one.
+                    yield b"data: " + json.dumps(
+                        {"kind": "fresh", "text": "1"}).encode() + b"\n\n"
                 # Flagged as replay so the page does not animate forty rows at
                 # once and does not start a stopwatch on work that finished
-                # before this listener existed.
-                for past in replay:
-                    yield b"data: " + json.dumps({**past, "replay": True}).encode() + b"\n\n"
+                # before this listener existed. Numbered so the next
+                # reconnection can say where it got to instead of starting over.
+                for offset, past in enumerate(replay):
+                    yield (b"id: " + ("%s:%d" % (service.epoch, resume_from + offset)).encode()
+                           + b"\ndata: " + json.dumps({**past, "replay": True}).encode()
+                           + b"\n\n")
                 # And then the CURRENT state, which the replay above cannot
                 # carry: `emit` keeps `busy` out of the history on purpose, so a
                 # page opened long after a run would not show a spinner for work
@@ -948,9 +1008,25 @@ def build_app(link: Link, service: ChatService) -> Starlette:
                 if joining_a_run:
                     yield b"data: " + json.dumps(
                         {"kind": "busy", "text": "1"}).encode() + b"\n\n"
+                # The meter is state too, and it was silent for exactly the
+                # same reason: a page joining after a turn ended showed no
+                # context size at all, on the one screen whose whole job is to
+                # say how big the transcript has become.
+                if current_usage.get("calls"):
+                    yield b"data: " + json.dumps(
+                        {"kind": "usage", "text": json.dumps(current_usage)}).encode() + b"\n\n"
                 while True:
                     event = await q.get()
-                    yield b"data: " + json.dumps(event).encode() + b"\n\n"
+                    # Only what the history keeps is numbered: an id moves the
+                    # resume point, and `busy` or `usage` are not places to
+                    # resume from. Leaving the field out keeps the last one,
+                    # which is what the spec says and what is wanted here.
+                    if event["kind"] in ("busy", "usage", "fresh"):
+                        yield b"data: " + json.dumps(event).encode() + b"\n\n"
+                    else:
+                        yield (b"id: " + ("%s:%d" % (service.epoch,
+                                                     len(service.history) - 1)).encode()
+                               + b"\ndata: " + json.dumps(event).encode() + b"\n\n")
             finally:
                 service.unsubscribe(q)
 

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -55,6 +55,7 @@ from .link import Link, image_of, text_of
 # backslashes through a shell heredoc: nothing errors, the text is just no
 # longer the text that was written.
 PAGE = r"""<!doctype html>
+<html lang="en">
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>AIHawk</title>
@@ -252,7 +253,11 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
 #i{ flex:1; background:transparent; border:0; outline:none; resize:none; color:var(--fg);
     font:var(--t-body)/1.55 var(--sans); min-height:24px; max-height:200px;
     overflow-y:hidden; padding:0; caret-color:var(--accent) }
-#i::placeholder{ color:var(--fg-4) }
+/* --fg-3 and not --fg-4: the placeholder is the only hint the composer gives,
+   so it is text that has to be read, and --fg-4 sits at 2.2:1 against 4.5:1.
+   The step numbers keep --fg-4, which is what it was picked for: decoration
+   beside a label that carries the meaning. */
+#i::placeholder{ color:var(--fg-3) }
 #go, #halt{ width:32px; height:32px; flex:none; border:0; border-radius:50%; display:grid;
      place-items:center; cursor:pointer; background:var(--accent);
      box-shadow:inset 0 1px 0 rgba(255,255,255,.22);
@@ -375,8 +380,9 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
   </div>
   <button id="jump" hidden type="button">jump to latest</button>
   <form id="f" autocomplete="off">
-    <span id="chip" hidden>1 message queued <span aria-hidden="true">&#9998;</span></span>
+    <button id="chip" type="button" hidden>1 message queued <span aria-hidden="true">&#9998;</span></button>
     <div class="composer">
+      <label class="sr" for="i">What should the agent do?</label>
       <textarea id="i" rows="1" placeholder="What should the agent do?"></textarea>
       <button id="go" type="submit" aria-label="Send" disabled>
         <svg width="14" height="14" viewBox="0 0 14 14" fill="none"

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -158,13 +158,17 @@ async def test_an_event_after_subscription_is_delivered_once_as_live():
 
     class Req:
         query_params = {}
+        headers: dict = {}
 
     response = await route.endpoint(Req())
     await svc.emit("said", "only once")
     body = response.body_iterator
 
     def payload(chunk):
-        return json.loads(chunk.removeprefix(b"data: ").strip())
+        # A replayable event carries an `id:` line before its data, so a
+        # reconnection can say where it got to. State events do not.
+        line = [l for l in chunk.split(b"\n") if l.startswith(b"data: ")][0]
+        return json.loads(line.removeprefix(b"data: ").strip())
 
     assert payload(await anext(body))["kind"] == "model"
     delivered = [payload(await anext(body))]
@@ -296,6 +300,7 @@ async def test_the_live_view_asks_for_nothing_until_an_instruction_has_been_give
 
     class Req:
         query_params = {}
+        headers: dict = {}
 
     resp = await frame.endpoint(Req())
     assert resp.status_code == 204
@@ -479,8 +484,11 @@ async def test_the_page_shows_the_wait_and_ties_it_to_the_run():
 
 
 class _Req:
-    """The events route ignores its request; this is enough to call it."""
+    """Enough of a request for the events route: it reads one header."""
     query_params: dict = {}
+
+    def __init__(self, last_event_id: str = ""):
+        self.headers = {"last-event-id": last_event_id} if last_event_id else {}
 
 
 async def _first_events(resp, want=4, each=1.0):
@@ -497,7 +505,8 @@ async def _first_events(resp, want=4, each=1.0):
     try:
         while len(seen) < want:
             chunk = await asyncio.wait_for(it.__anext__(), each)
-            seen.append(json.loads(chunk.decode().removeprefix("data: ").strip()))
+            line = [l for l in chunk.decode().split("\n") if l.startswith("data: ")][0]
+            seen.append(json.loads(line.removeprefix("data: ").strip()))
     except (asyncio.TimeoutError, StopAsyncIteration):
         pass
     return seen
@@ -533,6 +542,63 @@ async def test_the_frame_pause_is_shorter_than_the_capture_produces():
         "frame every %d ms, so the pane would show about %.1f of the 10 fps it "
         "is being sent" % (pause_ms, pause_ms + round_trip_ms, source_period_ms,
                            1000 / (pause_ms + round_trip_ms)))
+
+
+async def test_a_reconnection_resumes_instead_of_replaying_the_whole_thing():
+    """`EventSource` reconnects by itself after any drop, and the page has no
+    de-duplication, so a server that answers every reconnection with the whole
+    transcript makes it appear twice.
+
+    ⛔ MEASURED 2026-09-08 against the running interface, before the fix: three
+    consecutive subscriptions each received all 21 events of the same
+    conversation, and no event ever carried an `id:`, so the browser had
+    nothing to resume from and the page nothing to skip.
+
+    Known-bad: dropping the `id:` line, or ignoring `Last-Event-ID`. The second
+    listener below then receives the whole history again.
+    """
+    svc = ChatService(FakeLink(), SilentBrain())
+    app = build_app(FakeLink(), svc)
+    events = [r for r in app.routes if r.path == "/chat/events"][0]
+
+    for text in ("first", "second", "third"):
+        await svc.emit("said", text)
+
+    fresh_eyes = await _first_events(await events.endpoint(_Req()), want=6)
+    said = [e for e in fresh_eyes if e["kind"] == "said"]
+    assert [e["text"] for e in said] == ["first", "second", "third"]
+
+    # What the browser would send back on a reconnection: the id of the last
+    # event it actually saw.
+    marker = "%s:%d" % (svc.epoch, len(svc.history) - 1)
+    again = await _first_events(await events.endpoint(_Req(marker)), want=4)
+
+    assert [e for e in again if e["kind"] == "said"] == [], \
+        "the whole conversation was replayed to a listener that already had it"
+    assert [e for e in again if e["kind"] == "fresh"] == [], \
+        "a resume inside the same conversation must not tell the page to wipe"
+
+
+async def test_a_reconnection_carrying_another_conversation_is_told_to_wipe():
+    """A position only means something inside one transcript. After a reset, or
+    after the process restarts, the same number points at something else, and
+    replaying from there would graft the new conversation onto the old one.
+
+    Known-bad: comparing only the index and ignoring the epoch.
+    """
+    svc = ChatService(FakeLink(), SilentBrain())
+    app = build_app(FakeLink(), svc)
+    events = [r for r in app.routes if r.path == "/chat/events"][0]
+    await svc.emit("said", "from the conversation that is gone")
+
+    stale = await _first_events(await events.endpoint(_Req("999999999999:0")), want=5)
+
+    kinds = [e["kind"] for e in stale]
+    assert "fresh" in kinds, "a page holding another transcript was not told to drop it"
+    assert kinds.index("fresh") < kinds.index("said"), \
+        "the wipe has to arrive before what replaces it"
+    assert [e["text"] for e in stale if e["kind"] == "said"] == \
+        ["from the conversation that is gone"]
 
 
 async def test_a_page_that_joins_a_run_in_flight_is_told_the_run_is_in_flight():


### PR DESCRIPTION
`EventSource` reconnects by itself after any drop, and the server answered every reconnection with the entire transcript. The page has no de-duplication and had never been given an id to resume from, so it appended a second copy of the whole conversation.

## Measured before the fix

Three consecutive subscriptions against the running interface, each one standing in for a reconnection:

```
prima iscrizione        eventi 21  (di cui replay 20)
seconda, subito dopo    eventi 21  (di cui replay 20)
terza, subito dopo      eventi 21  (di cui replay 20)
```

And not one event carried an `id:` line, so there was nothing for the browser to send back and nothing for the server to resume from.

## The fix

Events that go into the history are numbered, and a reconnection carrying `Last-Event-ID` is answered from where it got to.

State events are deliberately left **unnumbered**. An id moves the resume point, and `busy` or `usage` are not places to resume from; per the SSE spec, omitting the field keeps the previous one, which is exactly what is wanted.

## The number alone is not enough

A position only means something inside one transcript. After a reset, or after the process restarts, the same index points at something else entirely, so the id carries an **epoch** and a mismatch replays from the beginning - preceded by `fresh`, so a page still holding the previous conversation drops it instead of growing a chimera of the two.

## Two more of the same family

Found by reading, not by a failure, and both are the same mistake as the one fixed in 0.13.1: history is not state.

- The **token meter** never reached a listener that arrived after a turn ended, on the one screen whose whole job is to say how big the transcript has become. The current reading is now sent at subscribe time, the way the run state already was.
- A page reconnecting to a **restarted** process kept believing in the run that died with the old one, leaving the composer saying "queue for next turn" forever. The wipe now clears that, and the truth arrives right after it.

## Test plan

- [x] `pytest -q`: 360 passed, 3 xfailed unchanged
- [x] new tests: a resume inside one conversation replays nothing and does not tell the page to wipe; a reconnection carrying another conversation is told to wipe, and the wipe arrives before what replaces it
- [x] known-bad: ignoring `Last-Event-ID` turns the first red; comparing only the index and ignoring the epoch is what the second exists for
- [x] restored byte-identical after the mutation, CRLF intact
- [x] `check_english_only.py`, `check_content.py`, version gate: clean
