### PR TITLE
The answer showed its own asterisks: Markdown to nodes, never to HTML (0.14.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.14.1"
+version = "0.14.2"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -427,6 +427,46 @@ const $ = id => document.getElementById(id);
 const el = (t,c,x) => { const e = document.createElement(t);
                         if(c) e.className = c; if(x != null) e.textContent = x; return e; };
 
+/* Markdown to NODES, never to a string of HTML.
+   The model answered `The main heading says **"Example Domain"**` and the page
+   drew the asterisks, because everything here is built with textContent - and
+   that invariant is not an oversight to correct, it is the reason this pane is
+   safe. The text arriving here was written by a model that has just read
+   arbitrary web pages, so it is chosen by whoever wrote the last page it
+   visited. Putting it through innerHTML is the documented road to exfiltration
+   by injected image, and no amount of sanitising makes that road shorter than
+   this one.
+   So: the marks become elements, built by hand, and the text between them stays
+   text. A `<script>` in the answer is still drawn as the characters of a
+   script, because it never stops being a text node.
+   Deliberately absent: images, which are the exfiltration vector itself, and
+   links, which this pane has no reason to make clickable when the browser it
+   drives is right there. */
+function inline(text, into){
+  for(const part of text.split(/(\*\*[^*\n]+\*\*|`[^`\n]+`|\*[^*\n]+\*)/)){
+    if(!part) continue;
+    const two = part.length > 4 && part.startsWith('**') && part.endsWith('**');
+    const tick = part.length > 2 && part.startsWith('`') && part.endsWith('`');
+    const one = part.length > 2 && !two && part.startsWith('*') && part.endsWith('*');
+    if(two)       into.appendChild(el('strong', null, part.slice(2, -2)));
+    else if(tick) into.appendChild(el('code', null, part.slice(1, -1)));
+    else if(one)  into.appendChild(el('em', null, part.slice(1, -1)));
+    else          into.appendChild(document.createTextNode(part));
+  }
+}
+
+function rich(text){
+  const frag = document.createDocumentFragment();
+  /* An odd number of fences means the last block never closed, which is what a
+     half-written answer looks like. It is still shown as code: the alternative
+     is prose that changes shape when the closing fence arrives. */
+  text.split('```').forEach((block, i) => {
+    if(i % 2) frag.appendChild(el('pre','out', block.replace(/^[a-z]*\n/i, '')));
+    else if(block) inline(block, frag);
+  });
+  return frag;
+}
+
 /* Raw tool names read as the machine's word order. One table, two tenses. */
 const VERB = {
   browser_navigate:['Navigating','Navigated'], browser_click:['Clicking','Clicked'],
@@ -465,7 +505,9 @@ function flush(asAnswer, replay){
   if(hold === null) return;
   const text = hold.replace(LEAD,'').replace(/^\w/, c => c.toUpperCase());
   hold = null;
-  put(el('div', asAnswer ? 'answer' : 'say', text), replay);
+  const box = el('div', asAnswer ? 'answer' : 'say');
+  box.appendChild(rich(text));
+  put(box, replay);
 }
 
 function step(text, replay){

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -544,6 +544,40 @@ async def test_the_frame_pause_is_shorter_than_the_capture_produces():
                            1000 / (pause_ms + round_trip_ms)))
 
 
+async def test_the_answer_is_built_from_nodes_and_never_from_html():
+    """The model's Markdown is drawn, and it is drawn without `innerHTML`.
+
+    The answer `The main heading says **"Example Domain"**` used to reach the
+    screen with its asterisks, because everything in this page is built with
+    `textContent`. That invariant is not the oversight - it is why the pane is
+    safe: the text was written by a model that had just read arbitrary web
+    pages, so its content is chosen by whoever wrote the last page it visited.
+
+    ⛔ THE INVARIANT IS THE TEST. `innerHTML` must not appear in the page at
+    all, and the renderer must build elements instead. Known-bad, and the whole
+    reason this test exists: someone reaching for a Markdown library that
+    returns an HTML string and assigning it, which is the documented road to
+    exfiltration through an injected image.
+    """
+    # The ASSIGNMENT and not the word: both this file and the page discuss
+    # `innerHTML` in prose precisely because neither may use it, and a check
+    # tripped by the sentence explaining the rule is the defect this project
+    # writes down most often.
+    import re
+
+    assert not re.search(r"innerHTML\s*=", PAGE), \
+        "something assigns HTML now, and the text it assigns comes from the web"
+    assert "insertAdjacentHTML" not in PAGE and "document.write" not in PAGE, \
+        "another way into the parser was opened"
+    assert "function rich(" in PAGE and "createTextNode" in PAGE, \
+        "the answer is no longer built from nodes"
+    # The two marks the model actually emits, and the fence.
+    assert "el('strong'" in PAGE and "el('code'" in PAGE and "el('em'" in PAGE
+    # Never built from model text: one is the exfiltration vector, the other has
+    # no reason to be clickable next to a browser this page is already driving.
+    assert "el('img'" not in PAGE and "el('a'" not in PAGE
+
+
 async def test_a_reconnection_resumes_instead_of_replaying_the_whole_thing():
     """`EventSource` reconnects by itself after any drop, and the page has no
     de-duplication, so a server that answers every reconnection with the whole


### PR DESCRIPTION
The model answered `The main heading says **"Example Domain"**` and the page drew the asterisks.

Everything in this page is built with `textContent`, and that is not the oversight to correct: it is the reason the pane is safe. The text arriving in it was written by a model that had just read arbitrary web pages, so its content is chosen by whoever wrote the last page it visited. Putting that through the HTML parser is the documented road to exfiltration by injected image, and no amount of sanitising makes that road shorter than building the nodes by hand.

## What it does

The marks become elements and everything between them stays text: bold, italic, inline code, fenced blocks. An unclosed fence is still shown as code, because the alternative is prose that changes shape when the closing fence arrives.

Deliberately absent: **images**, which are the exfiltration vector itself, and **links**, which this pane has no reason to make clickable when the browser it drives is sitting right next to it.

## Verified, not asserted

Against the real model in a browser: the answer comes back with two rendered bold spans and no literal asterisks.

Fed a hostile string by hand, the renderer produced `strong`, `em`, `code` and `pre`, and **zero** `img`, `a` or `script` elements, with the script tag surviving as literal characters because it never stops being a text node.

The test asserts the invariant rather than the output: no assignment to the HTML property, no `insertAdjacentHTML`, no `document.write`, and no `img` or `a` constructed anywhere. It checks the assignment and not the word, because both the page and the test discuss that property in prose precisely because neither may use it - a check tripped by the sentence explaining the rule is the defect this project writes down most often.

## Test plan

- [x] `pytest -q`: 361 passed, 3 xfailed unchanged
- [x] the renderer driven by hand against a hostile string: 0 img, 0 a, 0 script, the tag stays text
- [x] end to end with the real model: 2 bold spans rendered, 0 literal asterisks
- [x] version, english and content gates clean
