### PR TITLE
A session holds up to eight browsers, and every tool can name one (0.15.0)

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -151,7 +151,8 @@ session gets when nobody says anything.
 ## Tools
 
 `session_status`, `session_start`, `session_new_page`, `session_list_pages`,
-`session_select_page`, `session_close_page`, `browser_navigate`,
+`session_select_page`, `session_close_page`, `browser_open`, `browser_close`,
+`browser_list`, `browser_focus`, `browser_navigate`,
 `browser_read_text`, `browser_snapshot`, `browser_read_html`,
 `browser_take_screenshot`, `browser_watch`, `browser_click`, `browser_click_at`,
 `browser_type`, `browser_select_option`, `browser_press_key`, `browser_evaluate`.
@@ -178,6 +179,10 @@ address.
 
 | Tool | Arguments | What it does |
 |---|---|---|
+| `browser_open` | `browser_id`, `seed`, `proxy`, `profile`, all optional | Opens another browser in this session and makes it the one unaddressed commands go to. Each browser has its own tabs, cookies and identity and shares none of them. Refuses past eight, saying what eight cost when it was measured. |
+| `browser_close` | `browser_id` optional | Closes one browser and frees what it held. Its tabs go with it; the other browsers and the conversation do not. Forgets who it was, so the same name later is a new stranger rather than that person resumed. |
+| `browser_list` | `session_id` optional | Which browsers this session holds, where each one is, and which one commands go to. Starts nothing, so asking is free. |
+| `browser_focus` | `browser_id` | Chooses which browser the commands that name none land on. Naming a browser still reaches it whatever the focus is. |
 | `session_status` | none | Who is browsing right now: the seed, the exit, the profile and the open tabs. Starts nothing; if no browser is up it says so. |
 | `session_start` | `seed`, `proxy`, `profile`, all optional | Close whatever is open and start a browser as a particular person. Returns a sentence describing the session it actually started. |
 | `session_new_page` | none | Open a tab, make it the active one, return its id. |

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -160,6 +160,20 @@ Tool names mirror the Microsoft Playwright MCP, so prompts written for it work
 here too. Three groups: who is browsing and which tab, reading the page, and
 acting on it.
 
+**Every tool below also takes `session_id` and `browser_id`, both optional, and
+neither appears in the tables because the answer is the same for all of them.**
+Send neither and you get the default browser of the default session, which is
+what a client that never mentions either has always got and always will. Name
+them when a session holds more than one browser and the command has to reach a
+particular one.
+
+The two are not the same thing. A **session** is the piece of work: it owns a
+conversation and the browsers that belong to it. A **browser** is one running
+engine inside that session, with its own tabs, its own cookies and its own
+identity, and it does not share any of that with its neighbours. Tabs live
+inside a browser, which is why the tab tools take a page id and not a third
+address.
+
 ### Session and tabs
 
 | Tool | Arguments | What it does |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.14.2"
+version = "0.15.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/mcp/registry.py
+++ b/src/aihawk/mcp/registry.py
@@ -210,6 +210,25 @@ class SessionRegistry:
         async with self._lock(session_id):
             await self._discard(session_id)
 
+    async def forget(self, session_id: str = DEFAULT_SESSION_ID) -> bool:
+        """Close this browser and forget who it was. Answers whether it existed.
+
+        ⛔ `drop` and this one differ in exactly the way `close_all` explains,
+        and picking the wrong one is a leak rather than an inconvenience. `drop`
+        is RECOVERY: the browser died under a caller who is still working, so
+        the identity, the profile and the exit are kept and the replacement is
+        the same person. This is a DELIBERATE close, and a browser that came
+        back wearing an identity its owner had shut down would hand the next
+        caller a person they never asked for - the same leak `close_all` refuses,
+        one browser at a time.
+        """
+        async with self._lock(session_id):
+            existed = session_id in self._sessions or session_id in self._configs
+            await self._discard(session_id)
+            self._configs.pop(session_id, None)
+            self._refusals.pop(session_id, None)
+            return existed
+
     async def close_all(self) -> None:
         """Shut every session down. Called when the PROCESS ends, not when a
         client disconnects - that difference is the reason this class exists.

--- a/src/aihawk/mcp/server.py
+++ b/src/aihawk/mcp/server.py
@@ -152,6 +152,29 @@ DEFAULT_BROWSER_ID = "main"
 MAX_BROWSERS_PER_SESSION = 8
 
 
+#: Which browser a session's unaddressed commands land on. A session with one
+#: browser never touches this; a session with several needs somewhere to say
+#: "this one for now", or every call would have to repeat the id and the first
+#: one forgotten would act on a browser nobody meant.
+_focus: dict = {}
+
+
+def focused(session_id: str | None = None) -> str:
+    """The browser this session's unaddressed commands go to."""
+    return _focus.get(session_id or DEFAULT_SESSION_ID, DEFAULT_BROWSER_ID)
+
+
+def browsers_in(session_id: str | None = None) -> list:
+    """The browsers this session has, by id.
+
+    Read from the registry's keys rather than from a list kept beside them,
+    because a second list is a second truth: a browser dropped by a failed retry
+    would still be in it, and the ceiling would refuse a slot that is free.
+    """
+    prefix = "%s/" % (session_id or DEFAULT_SESSION_ID)
+    return sorted(k[len(prefix):] for k in registry.ids() if k.startswith(prefix))
+
+
 def addressed(session_id: str | None = None, browser_id: str | None = None) -> str:
     """The registry key for one browser inside one session.
 
@@ -168,7 +191,7 @@ def addressed(session_id: str | None = None, browser_id: str | None = None) -> s
     neighbours wrote to another, and nothing would raise.
     """
     return "%s/%s" % (session_id or DEFAULT_SESSION_ID,
-                      browser_id or DEFAULT_BROWSER_ID)
+                      browser_id or focused(session_id))
 
 
 async def _retrying(fn, *args, session_id=None, browser_id=None, **kwargs):
@@ -192,6 +215,138 @@ async def _retrying(fn, *args, session_id=None, browser_id=None, **kwargs):
         await registry.drop(at)
         session = await registry.ensure(at)
         return await fn(session, *args, **kwargs)
+
+
+# --- the browsers a session holds ------------------------------------------
+
+@mcp.tool()
+async def browser_open(browser_id: str | None = None, seed: int | None = None,
+                       proxy: str | None = None, profile: str | None = None,
+                       session_id: str | None = None) -> str:
+    """Open ANOTHER browser in this session, and make it the one commands go to.
+
+    A session can hold several browsers at once, each with its own tabs, its own
+    cookies and its own identity: one for the dashboard, one for the docs, one
+    logged in as somebody else. They do not share anything, so work in one
+    cannot disturb another.
+
+    Give `browser_id` a name you will recognise, or let one be chosen. `seed`,
+    `proxy` and `profile` decide who this browser is, exactly as in
+    session_start, and they apply to this browser alone.
+
+    Opening one takes several seconds and costs real memory, so open what you
+    need and close what you stop using: browser_close frees it.
+    """
+    at_session = session_id or DEFAULT_SESSION_ID
+    have = browsers_in(at_session)
+
+    if browser_id is None:
+        # Never a name already in use, and never one that was in use earlier in
+        # this session: reusing it would hand somebody a browser they think they
+        # opened and somebody else thinks they still hold.
+        n = 1
+        while ("b%d" % n) in have:
+            n += 1
+        browser_id = "b%d" % n
+    elif browser_id in have:
+        return ("session %s already has a browser called %s. Use it by naming "
+                "it, or close it first." % (at_session, browser_id))
+
+    if len(have) >= MAX_BROWSERS_PER_SESSION:
+        # The ceiling says what it costs, because a refusal that only says "no"
+        # invites the reader to raise the number.
+        return ("session %s already holds %d browsers, which is the limit. "
+                "Eight live browsers were measured at 61 processes and about "
+                "6.5 GB, with the eighth taking twice as long to start as the "
+                "first, so the ceiling is a real cost and not a formality. "
+                "Close one with browser_close before opening another. Open "
+                "now: %s." % (at_session, len(have), ", ".join(have)))
+
+    at = addressed(at_session, browser_id)
+    settings = plan.plan_session(seed=seed, proxy=proxy, profile=profile).kwargs
+    try:
+        await registry.restart(at, **settings)
+    except Exception as exc:
+        return "browser %s could not start: %s" % (browser_id, exc)
+
+    _focus[at_session] = browser_id
+    return ("browser %s is open in session %s and is now the one unaddressed "
+            "commands go to. %s" % (browser_id, at_session,
+                                    plan.describe(registry.config(at) or {})))
+
+
+@mcp.tool()
+async def browser_close(browser_id: str | None = None,
+                        session_id: str | None = None) -> str:
+    """Close one browser of this session and free what it was holding.
+
+    The tabs it had are gone with it. The other browsers in the session are not
+    touched, and neither is the conversation.
+
+    Closing FORGETS who that browser was: a later browser opened under the same
+    name is a new stranger, not the same person resumed. That is deliberate -
+    a browser somebody shut down should not come back wearing its old identity.
+    """
+    at_session = session_id or DEFAULT_SESSION_ID
+    name = browser_id or focused(at_session)
+    existed = await registry.forget(addressed(at_session, name))
+
+    if _focus.get(at_session) == name:
+        _focus.pop(at_session, None)
+    left = browsers_in(at_session)
+    if not existed:
+        return "session %s has no browser called %s." % (at_session, name)
+    return ("browser %s is closed. Still open in session %s: %s."
+            % (name, at_session, ", ".join(left) if left else "none"))
+
+
+@mcp.tool()
+async def browser_list(session_id: str | None = None) -> str:
+    """Which browsers this session holds, and which one commands go to.
+
+    Starts nothing: it reports what is running, so asking is free.
+    """
+    at_session = session_id or DEFAULT_SESSION_ID
+    have = browsers_in(at_session)
+    if not have:
+        return ("session %s has no browser open yet. The next tool that needs a "
+                "page will open one, or call browser_open to choose who it is."
+                % at_session)
+
+    here = focused(at_session)
+    rows = []
+    for name in have:
+        session = registry.peek(addressed(at_session, name))
+        where = ""
+        if session is not None:
+            try:
+                pages = await session.describe_pages()
+                where = "; ".join(p["url"] or "blank" for p in pages) or "no tabs"
+            except Exception:
+                where = "tabs unreadable"
+        else:
+            where = "not up; the next command restarts it as the same person"
+        rows.append("%s%s: %s" % (name, " (commands go here)" if name == here else "",
+                                 where))
+    return "session %s holds %d of %d browsers. %s" % (
+        at_session, len(have), MAX_BROWSERS_PER_SESSION, " | ".join(rows))
+
+
+@mcp.tool()
+async def browser_focus(browser_id: str, session_id: str | None = None) -> str:
+    """Choose which browser this session's unaddressed commands go to.
+
+    Every tool can still name a browser and reach it whatever the focus is; this
+    only decides where the ones that name none land, so a run of commands on one
+    browser does not have to repeat its id.
+    """
+    at_session = session_id or DEFAULT_SESSION_ID
+    have = browsers_in(at_session)
+    if browser_id not in have:
+        return ("session %s has no browser called %s. Open: %s."
+                % (at_session, browser_id, ", ".join(have) if have else "none"))
+    _focus[at_session] = browser_id
+    return "commands without a browser_id now go to %s." % browser_id
 
 
 # --- who is browsing -------------------------------------------------------

--- a/src/aihawk/mcp/server.py
+++ b/src/aihawk/mcp/server.py
@@ -31,7 +31,7 @@ from contextlib import asynccontextmanager
 from mcp.server.fastmcp import FastMCP, Image
 
 from . import actions, identity, plan
-from .registry import SessionRegistry
+from .registry import DEFAULT_SESSION_ID, SessionRegistry
 
 # Kept for callers that imported it from here. The implementation moved.
 _json_capped = actions.json_capped
@@ -139,26 +139,66 @@ in a way that gets the session blocked."""
 mcp = FastMCP("stealth", instructions=INSTRUCTIONS, lifespan=_lifespan)
 
 
-async def _retrying(fn, *args, **kwargs):
-    """Run an action, and on failure rebuild the session once and retry.
+#: The browser a caller means when it names nothing. Callers that were written
+#: before browsers had names send neither id and must keep behaving exactly as
+#: they did, so both defaults exist and resolve to one browser in one session.
+DEFAULT_BROWSER_ID = "main"
+
+#: Up to eight browsers in one session, and the ceiling is a measurement rather
+#: than a taste: eight live browsers were measured at 61 processes and 6,515 MB
+#: on 2026-09-08, with the eighth taking 13.6 s to start against the first one's
+#: 6.8. The design that goes with this number is in the workbench, under
+#: `docs_research/chat-ui-performance/30-PROGETTO-sessioni-e-otto-browser.md`.
+MAX_BROWSERS_PER_SESSION = 8
+
+
+def addressed(session_id: str | None = None, browser_id: str | None = None) -> str:
+    """The registry key for one browser inside one session.
+
+    ⛔ The registry stores browsers by string key and knows nothing about
+    sessions, and that is deliberate: everything it already gets right - one
+    lock per key so two callers racing start one browser rather than two, the
+    configuration remembered so a rebuild is the SAME PERSON with the same seed
+    and the same exit, tab numbering that does not restart across a rebuild -
+    starts working per BROWSER the moment the key names one. Composing here buys
+    all of it without touching a line of it.
+
+    Everything in this module addresses through this function. A single call
+    that still reaches for the bare default would look at one browser while its
+    neighbours wrote to another, and nothing would raise.
+    """
+    return "%s/%s" % (session_id or DEFAULT_SESSION_ID,
+                      browser_id or DEFAULT_BROWSER_ID)
+
+
+async def _retrying(fn, *args, session_id=None, browser_id=None, **kwargs):
+    """Run an action on one browser, and on failure rebuild it once and retry.
 
     A browser that died between two calls is the ordinary case here, not an
     exotic one: the object is still intact, so the failure surfaces inside the
     action rather than when the session was handed out.
+
+    The rebuild is addressed too. Dropping and re-ensuring the DEFAULT key while
+    the action was aimed at another browser would kill a browser nobody asked
+    about and hand back the wrong one, which is the same class of mistake as
+    rebuilding from the environment: it succeeds, and it succeeds at the wrong
+    thing.
     """
-    session = await registry.ensure()
+    at = addressed(session_id, browser_id)
+    session = await registry.ensure(at)
     try:
         return await fn(session, *args, **kwargs)
     except Exception:
-        await registry.drop()
-        session = await registry.ensure()
+        await registry.drop(at)
+        session = await registry.ensure(at)
         return await fn(session, *args, **kwargs)
 
 
 # --- who is browsing -------------------------------------------------------
 
 @mcp.tool()
-async def session_status() -> str:
+async def session_status(session_id: str | None = None,
+                         browser_id: str | None = None) -> str:
     """Who is browsing right now: the identity, the exit, the profile and the tabs.
 
     Ask whenever you need to know which person the browser currently is, or from
@@ -168,14 +208,18 @@ async def session_status() -> str:
 
     It starts nothing. If no browser is running yet it says so, because until
     one is running there is no identity to report.
+
+    session_id and browser_id are optional. Leave them out and this reports the
+    default browser, as before; name them when a session holds more than one.
     """
-    config = registry.config()
+    at = addressed(session_id, browser_id)
+    config = registry.config(at)
     if config is None:
         return ("no browser is running yet, so there is no identity to report. "
                 "The next tool that needs a page will start one, or call "
                 "session_start to choose who it is.")
 
-    session = registry.peek()
+    session = registry.peek(at)
     tabs = "no tabs open"
     if session is not None:
         try:
@@ -193,7 +237,9 @@ async def session_status() -> str:
 
 @mcp.tool()
 async def session_start(seed: int | None = None, proxy: str | None = None,
-                        profile: str | None = None) -> str:
+                        profile: str | None = None,
+                        session_id: str | None = None,
+                        browser_id: str | None = None) -> str:
     """Start a browsing session as a particular person, and say who that is.
 
     Call this when you want to control WHO is browsing: a fresh stranger, the
@@ -205,9 +251,10 @@ async def session_start(seed: int | None = None, proxy: str | None = None,
     session on its own; `session_status` then tells you who that turned out to
     be.
 
-    There is only ONE browser. Two identities are visited in turn, never at the
-    same time, so a task that needs both accounts live at once cannot be done
-    here and is worth saying so rather than half-starting.
+    A browser holds ONE identity, and this replaces it. Two identities in the
+    same browser are visited in turn, never at the same time, so a task that
+    needs both accounts live at once is worth saying so rather than
+    half-starting.
 
     seed     the browser identity. Same seed, same fingerprint, every time.
              Leave it out and one is drawn, and the answer tells you which, so
@@ -228,6 +275,10 @@ async def session_start(seed: int | None = None, proxy: str | None = None,
              one arriving on different hardware. You are warned when a profile's
              exit changes, but only when YOU change it - a provider that rotates
              its own addresses behind one host and port looks identical here.
+
+    session_id and browser_id are optional. Leave them out and this starts the
+    default browser, as before; name them to say WHICH browser becomes this
+    person, when a session holds more than one.
     """
     try:
         chosen = plan.plan_session(seed, proxy, profile, os.environ)
@@ -239,7 +290,7 @@ async def session_start(seed: int | None = None, proxy: str | None = None,
         return "refused: %s" % exc
 
     try:
-        await registry.restart(**chosen.kwargs)
+        await registry.restart(addressed(session_id, browser_id), **chosen.kwargs)
     except Exception as exc:
         # ⛔ Said plainly, because the dangerous reading is "that failed, carry
         # on". Nothing is running now, and every later tool will repeat this
@@ -256,41 +307,67 @@ async def session_start(seed: int | None = None, proxy: str | None = None,
 # --- pages -----------------------------------------------------------------
 
 @mcp.tool()
-async def session_new_page() -> str:
+async def session_new_page(session_id: str | None = None,
+                           browser_id: str | None = None) -> str:
     """Open a new tab and make it the active one. Returns its page id.
 
     Tabs persist across calls and across clients, so this is how you keep one
-    page while working on another rather than navigating back and forth."""
-    return await _retrying(actions.new_page)
+    page while working on another rather than navigating back and forth.
+
+    session_id and browser_id are optional. Leave them out and the tab opens in
+    the default browser, as before; name them when a session holds more than
+    one, because a tab belongs to the browser it was opened in."""
+    return await _retrying(actions.new_page,
+                           session_id=session_id, browser_id=browser_id)
 
 
 @mcp.tool()
-async def session_list_pages() -> str:
+async def session_list_pages(session_id: str | None = None,
+                             browser_id: str | None = None) -> str:
     """Every open tab: id, title, url, and which one is active.
 
     Use it before session_select_page: the id alone does not tell you which tab
-    you are switching to."""
-    return await actions.list_pages(await registry.ensure())
+    you are switching to.
+
+    session_id and browser_id are optional. Leave them out and this lists the
+    default browser's tabs, as before; name them when a session holds more than
+    one, since each browser numbers its own tabs."""
+    return await actions.list_pages(
+        await registry.ensure(addressed(session_id, browser_id)))
 
 
 @mcp.tool()
-async def session_select_page(page_id: str) -> str:
+async def session_select_page(page_id: str, session_id: str | None = None,
+                              browser_id: str | None = None) -> str:
     """Switch the active tab. Every other browser_* tool acts on it.
 
-    Take the id from session_list_pages or from session_new_page."""
-    return actions.select_page(await registry.ensure(), page_id)
+    Take the id from session_list_pages or from session_new_page.
+
+    session_id and browser_id are optional. Leave them out and this switches the
+    default browser's tab, as before; name them when a session holds more than
+    one, and use the browser the page id came from."""
+    return actions.select_page(
+        await registry.ensure(addressed(session_id, browser_id)), page_id)
 
 
 @mcp.tool()
-async def session_close_page(page_id: str = "") -> str:
-    """Close a tab, or the active one when page_id is left out."""
-    return await actions.close_page(await registry.ensure(), page_id)
+async def session_close_page(page_id: str = "", session_id: str | None = None,
+                             browser_id: str | None = None) -> str:
+    """Close a tab, or the active one when page_id is left out.
+
+    session_id and browser_id are optional. Leave them out and this closes a tab
+    of the default browser, as before; name them when a session holds more than
+    one."""
+    return await actions.close_page(
+        await registry.ensure(addressed(session_id, browser_id)), page_id)
 
 
 # --- reading ---------------------------------------------------------------
 
 @mcp.tool()
-async def browser_navigate(url: str, wait_until: str = "domcontentloaded") -> str:
+async def browser_navigate(url: str, wait_until: str = "domcontentloaded",
+                           session_id: str | None = None,
+                           browser_id: str | None = None) -> str:
     """Go to a url in the active tab, opening one if none exists.
 
     Answers with the HTTP status the server gave and the url actually landed
@@ -302,12 +379,18 @@ async def browser_navigate(url: str, wait_until: str = "domcontentloaded") -> st
     wait_until is "domcontentloaded" by default, which returns as soon as the
     markup is parsed. Use "load" when the page needs its images and stylesheets,
     or "networkidle" for a single-page app that fetches its content after
-    load."""
-    return await _retrying(actions.navigate, url, wait_until=wait_until)
+    load.
+
+    session_id and browser_id are optional. Leave them out and this drives the
+    default browser, as before; name them when a session holds more than one."""
+    return await _retrying(actions.navigate, url, wait_until=wait_until,
+                           session_id=session_id, browser_id=browser_id)
 
 
 @mcp.tool()
-async def browser_read_text(selector: str = "body", max_chars: int = 6000) -> str:
+async def browser_read_text(selector: str = "body", max_chars: int = 6000,
+                            session_id: str | None = None,
+                            browser_id: str | None = None) -> str:
     """The visible text of an element, with the markup gone.
 
     The cheapest way to read a page. Narrow the selector when you know where the
@@ -315,12 +398,18 @@ async def browser_read_text(selector: str = "body", max_chars: int = 6000) -> st
     browser_snapshot when you need something to click.
 
     Long text is cut at max_chars (6000 by default) and the cut is marked in
-    what comes back, so text that ends without that marker is the whole thing."""
-    return await actions.read_text(await registry.ensure(), selector, max_chars)
+    what comes back, so text that ends without that marker is the whole thing.
+
+    session_id and browser_id are optional. Leave them out and this reads the
+    default browser, as before; name them when a session holds more than one."""
+    return await actions.read_text(
+        await registry.ensure(addressed(session_id, browser_id)),
+        selector, max_chars)
 
 
 @mcp.tool()
-async def browser_snapshot(max_chars: int = 0) -> str:
+async def browser_snapshot(max_chars: int = 0, session_id: str | None = None,
+                           browser_id: str | None = None) -> str:
     """Title, url, and the interactive elements that are actually visible.
 
     Each element carries a `selector` when one can reach it: pass that string to
@@ -336,12 +425,17 @@ async def browser_snapshot(max_chars: int = 0) -> str:
     Not the accessibility tree: on a real sign-up page a single country
     `<select>` contributes about two hundred `<option>` nodes, which fill the
     character cap before the form the caller was looking for appears at all.
+
+    session_id and browser_id are optional: without them this snapshots the
+    default browser, as before. Name them to reach one of several.
     """
-    return await actions.snapshot(await registry.ensure(), max_chars)
+    return await actions.snapshot(
+        await registry.ensure(addressed(session_id, browser_id)), max_chars)
 
 
 @mcp.tool()
-async def browser_read_html(mode: str = "form") -> str:
+async def browser_read_html(mode: str = "form", session_id: str | None = None,
+                            browser_id: str | None = None) -> str:
     """The page's HTML, cleaned down to what is worth reading.
 
     Use this when the STRUCTURE matters - a form and its labels, a table, what
@@ -353,47 +447,67 @@ async def browser_read_html(mode: str = "form") -> str:
     the noise and the attribute soup removed.
 
     Unlike browser_read_text this is NOT capped: it returns the whole reduced
-    page, which on a large one is tens of thousands of characters. That is
-    deliberate, because cutting markup in the middle leaves tags that no longer
-    mean anything - but it means the answer can be long. Reach for
-    browser_snapshot when you only need something to click, or
-    browser_read_text when you only need the words.
+    page, tens of thousands of characters on a large one. Cutting markup in the
+    middle leaves tags that mean nothing, so it is not cut - but the answer can
+    be long. Reach for browser_snapshot when you only need something to click.
+
+    session_id and browser_id are optional: without them this reads the default
+    browser, as before. Name them to reach one of several.
     """
-    return await actions.read_html(await registry.ensure(), mode)
+    return await actions.read_html(
+        await registry.ensure(addressed(session_id, browser_id)), mode)
 
 
 @mcp.tool()
-async def browser_take_screenshot() -> Image:
-    """One screenshot of the active tab, on demand."""
-    png = await actions.screenshot_png(await registry.ensure())
+async def browser_take_screenshot(session_id: str | None = None,
+                                  browser_id: str | None = None) -> Image:
+    """One screenshot of the active tab, on demand.
+
+    session_id and browser_id are optional. Leave them out and this pictures the
+    default browser, as before; name them when a session holds more than one."""
+    png = await actions.screenshot_png(
+        await registry.ensure(addressed(session_id, browser_id)))
     return Image(data=png, format="png")
 
 
 @mcp.tool()
-async def browser_watch() -> Image:
+async def browser_watch(session_id: str | None = None,
+                        browser_id: str | None = None) -> Image:
     """The whole browser window as a person at the machine sees it: tab strip,
     address bar, the page and the pointer, from a live capture kept running on
     the active tab. For watching the work, not for acting on it: the picture
     is window pixels, so do not feed its coordinates to browser_click_at; use
-    browser_take_screenshot for that."""
-    jpeg = await actions.watch_jpeg(await registry.ensure())
+    browser_take_screenshot for that.
+
+    session_id and browser_id are optional. Leave them out and this watches the
+    default browser, as before; name them to watch one of several."""
+    jpeg = await actions.watch_jpeg(
+        await registry.ensure(addressed(session_id, browser_id)))
     return Image(data=jpeg, format="jpeg")
 
 
 # --- acting ----------------------------------------------------------------
 
 @mcp.tool()
-async def browser_click(selector: str) -> str:
+async def browser_click(selector: str, session_id: str | None = None,
+                        browser_id: str | None = None) -> str:
     """Click the first element matching a CSS selector.
 
     Scrolls it into view and waits for it to be clickable. When no selector can
     describe the target, use browser_click_at with coordinates from
-    browser_snapshot."""
-    return await actions.click(await registry.ensure(), selector)
+    browser_snapshot.
+
+    session_id and browser_id are optional. Leave them out and this clicks in
+    the default browser, as before; name them when a session holds more than
+    one, and use the browser the selector came from."""
+    return await actions.click(
+        await registry.ensure(addressed(session_id, browser_id)), selector)
 
 
 @mcp.tool()
-async def browser_click_at(x: float, y: float, hold_seconds: float = 0.0) -> Image:
+async def browser_click_at(x: float, y: float, hold_seconds: float = 0.0,
+                           session_id: str | None = None,
+                           browser_id: str | None = None) -> Image:
     """Click (or press-and-hold) a raw viewport coordinate instead of a
     selector - for targets a selector cannot reliably reach: a slider track, a
     canvas-drawn captcha, or a precise point inside a wider element. Moves the
@@ -411,42 +525,68 @@ async def browser_click_at(x: float, y: float, hold_seconds: float = 0.0) -> Ima
     image loading in above the fold. Nothing raises when that happens - the
     click simply lands on whatever is at that spot now. Take a fresh snapshot
     after anything that could have moved the page, and prefer browser_click with
-    the element's `selector` whenever it has one."""
-    png = await actions.click_at(await registry.ensure(), x, y, hold_seconds)
+    the element's `selector` whenever it has one.
+
+    session_id and browser_id are optional. Leave them out and this clicks in
+    the default browser, as before; name them when a session holds more than
+    one, and use the browser the coordinates came from."""
+    png = await actions.click_at(
+        await registry.ensure(addressed(session_id, browser_id)),
+        x, y, hold_seconds)
     return Image(data=png, format="png")
 
 
 @mcp.tool()
-async def browser_type(selector: str, text: str) -> str:
+async def browser_type(selector: str, text: str, session_id: str | None = None,
+                       browser_id: str | None = None) -> str:
     """Fill a field, replacing whatever it holds.
 
     This sets the value rather than typing key by key, so it will not fire the
     per-keystroke handlers an autocomplete needs. For those, click the field and
-    use browser_press_key."""
-    return await actions.type_text(await registry.ensure(), selector, text)
+    use browser_press_key.
+
+    session_id and browser_id are optional. Leave them out and this types into
+    the default browser, as before; name them when a session holds more than
+    one."""
+    return await actions.type_text(
+        await registry.ensure(addressed(session_id, browser_id)), selector, text)
 
 
 @mcp.tool()
-async def browser_select_option(selector: str, value: str) -> str:
+async def browser_select_option(selector: str, value: str,
+                                session_id: str | None = None,
+                                browser_id: str | None = None) -> str:
     """Choose an option in a dropdown (`<select>`), by its visible label or by
     its value.
 
     Use this rather than clicking the dropdown and pressing arrow keys: a click
     plus arrows cannot tell you which row it landed on, and setting the value
     through browser_evaluate changes it without the page seeing a real
-    interaction."""
-    return await actions.select_option(await registry.ensure(), selector, value)
+    interaction.
+
+    session_id and browser_id are optional. Leave them out and this chooses in
+    the default browser, as before; name them when a session holds more than
+    one."""
+    return await actions.select_option(
+        await registry.ensure(addressed(session_id, browser_id)), selector, value)
 
 
 @mcp.tool()
-async def browser_press_key(key: str) -> str:
+async def browser_press_key(key: str, session_id: str | None = None,
+                            browser_id: str | None = None) -> str:
     """Press a key on whatever has focus: "Enter", "Tab", "Escape",
-    "ArrowDown", "Control+a", or a single character."""
-    return await actions.press_key(await registry.ensure(), key)
+    "ArrowDown", "Control+a", or a single character.
+
+    session_id and browser_id are optional. Leave them out and the key goes to
+    the default browser, as before; name them when a session holds more than
+    one."""
+    return await actions.press_key(
+        await registry.ensure(addressed(session_id, browser_id)), key)
 
 
 @mcp.tool()
-async def browser_evaluate(expression: str) -> str:
+async def browser_evaluate(expression: str, session_id: str | None = None,
+                           browser_id: str | None = None) -> str:
     """READ from the page with JavaScript and get the result as JSON.
 
     For what the other tools cannot see: a computed style, a value held in a
@@ -462,8 +602,12 @@ async def browser_evaluate(expression: str) -> str:
 
     The refusal catches the obvious spellings, not every possible one. A script
     that slips past it is still the wrong way to do the thing: report it in your
-    answer rather than using it."""
-    return await actions.evaluate(await registry.ensure(), expression)
+    answer rather than using it.
+
+    session_id and browser_id are optional. Leave them out and this reads the
+    default browser, as before; name them when a session holds more than one."""
+    return await actions.evaluate(
+        await registry.ensure(addressed(session_id, browser_id)), expression)
 
 
 def main() -> None:

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -479,6 +479,10 @@ const VERB = {
   session_new_page:['Opening tab','Opened tab'],   session_select_page:['Switching tab','Switched tab'],
   session_close_page:['Closing tab','Closed tab'], session_list_pages:['Listing tabs','Listed tabs'],
   session_start:['Starting browser','Started browser'],
+  browser_open:['Opening browser','Opened browser'],
+  browser_close:['Closing browser','Closed browser'],
+  browser_list:['Listing browsers','Listed browsers'],
+  browser_focus:['Switching browser','Switched browser'],
   session_status:['Checking session','Checked session']
 };
 const LEAD = /^(I will |I'll |I am |I'm |Let me |Now I will |Now I'll )/i;

--- a/tests/mcp_server/test_addressing.py
+++ b/tests/mcp_server/test_addressing.py
@@ -1,0 +1,350 @@
+"""Every tool addresses ONE browser, and a caller that names none keeps the old one.
+
+The registry has kept browsers by key since it was written, and it already gets
+the hard parts right: one lock per key so two callers racing start one browser
+rather than two, the configuration remembered so a rebuild is the SAME PERSON,
+tab numbering that does not restart across a rebuild. All of it was unreachable,
+because every tool called `registry.ensure()` with no argument. The key is now
+composed from two optional parameters, `session_id/browser_id`, so that
+behaviour starts working per browser without a line of the registry moving.
+
+⛔ THE FAILURE THIS FILE EXISTS FOR IS SILENT. One call left without an address
+reads one browser while the calls around it write another: no exception, no red
+test, just a tool answering confidently about the wrong page. Behaviour tests
+only cover the calls somebody thought to test, so the last two tests read the
+SOURCE and refuse a registry call that carries no address, and a tool that
+reaches the registry without offering a way to say which browser it means.
+
+No browser starts here. The registry takes a factory and the actions are
+replaced by a stub that answers with the session it was handed, so what a tool
+did is observable as the browser it reached for.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import pathlib
+
+import pytest
+
+from aihawk.mcp import actions, server
+from aihawk.mcp.registry import DEFAULT_SESSION_ID, SessionRegistry
+
+SERVER_PY = pathlib.Path(inspect.getfile(server))
+
+#: The registry methods that take a browser address. Derived from the registry
+#: instead of typed out, so a method added there is guarded the day it exists.
+ADDRESSABLE = {
+    name for name, fn in inspect.getmembers(SessionRegistry, inspect.isfunction)
+    if not name.startswith("_") and "session_id" in inspect.signature(fn).parameters
+}
+
+
+class _Recording:
+    """A session that launches nothing and reports itself alive."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self._browser = None
+        self._context = object()
+        self.closed = False
+
+    async def start(self):
+        pass
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    """The REAL registry, with nothing behind it that opens a browser.
+
+    Real on purpose. What the tools have to get right is the key they hand it,
+    and a stand-in would have to reimplement the per-key locking and discarding
+    the assertions below lean on - at which point the tests would be measuring
+    the stand-in.
+    """
+    reg = SessionRegistry(factory=_Recording,
+                          defaults=lambda: {"seed": 7, "headless": True})
+    monkeypatch.setattr(server, "registry", reg)
+    return reg
+
+
+@pytest.fixture
+def echo(monkeypatch):
+    """Every action replaced by one that answers with the session it was given,
+    so a tool's return value IS the browser it reached."""
+    async def _echo(session, *args, **kwargs):
+        return session
+
+    for name in ("new_page", "list_pages", "navigate", "read_text", "snapshot",
+                 "read_html", "click", "type_text", "press_key", "evaluate"):
+        monkeypatch.setattr(actions, name, _echo)
+
+
+def _key(session_id=DEFAULT_SESSION_ID, browser_id=server.DEFAULT_BROWSER_ID):
+    """The key a browser is expected under, built from the two constants rather
+    than from `addressed`, which is the thing under test."""
+    return "%s/%s" % (session_id, browser_id)
+
+
+# --- naming nothing keeps today's behaviour ---------------------------------
+
+async def test_a_caller_that_names_nothing_reaches_the_same_one_browser(registry, echo):
+    """⛔ THE PROMISE OF THE WHOLE CHANGE. Clients written before browsers had
+    names send neither id, and have to land exactly where they always did.
+
+    Three tools, and deliberately not three of a kind: `session_new_page` and
+    `browser_navigate` go through `_retrying`, `browser_read_text` calls
+    `ensure` itself. They compose the key in two different places, so a change
+    that addresses only one of them leaves two halves of one session looking at
+    different browsers - and both calls still succeed, which is what makes it
+    the dangerous shape rather than a crash.
+
+    Two known-bad inputs, one for each assertion:
+
+    * leave any single tool calling `registry.ensure()` bare -> it lands on
+      "default" while its neighbours land on "default/main", and the first
+      assertion goes red;
+    * drop the `or DEFAULT_SESSION_ID` / `or DEFAULT_BROWSER_ID` fallbacks in
+      `addressed` -> an unnamed caller is filed under "None/None", every tool
+      agrees with every other, and only the second assertion sees it.
+    """
+    first = await server.session_new_page()
+    second = await server.browser_read_text()
+    third = await server.browser_navigate("http://127.0.0.1/")
+
+    assert first is second is third, (
+        "one caller that named nothing was given more than one browser")
+    assert registry.ids() == [_key()], (
+        "a caller that named nothing landed on %r" % registry.ids())
+
+
+# --- two browsers, one session ----------------------------------------------
+
+async def test_two_browser_ids_in_one_session_are_two_browsers(registry, echo):
+    """Known-bad: have `addressed` ignore `browser_id`. Both calls then land on
+    one key, the second returns the first browser, and a caller driving two
+    accounts is driving one."""
+    a = await server.browser_read_text(browser_id="a")
+    b = await server.browser_read_text(browser_id="b")
+
+    assert a is not b, "two browser ids were served by one browser"
+    assert registry.ids() == [_key(browser_id="a"), _key(browser_id="b")], (
+        "the two browsers are filed under %r" % registry.ids())
+
+
+async def test_a_rebuild_of_one_browser_leaves_the_others_alone(registry, echo,
+                                                                monkeypatch):
+    """⛔ `_retrying` drops and re-ensures on ANY failure, so the drop is as
+    addressed as the action, or recovery becomes the way browsers get killed.
+
+    A browser that died between two calls is the ordinary case here, so this is
+    the common path rather than an exotic one.
+
+    Two known-bad inputs:
+
+    * `await registry.drop()` in `_retrying`, which is what the code said before
+      browsers had names: the failing browser is never thrown away, so it is
+      handed back instead of rebuilt and the third assertion goes red;
+    * `await registry.drop(addressed())`, the same mistake spelled the new way:
+      the DEFAULT browser is closed while the caller was working on another one,
+      and the last assertion goes red.
+    """
+    main = await server.browser_read_text()
+    other = await server.browser_read_text(browser_id="b")
+
+    failures = {"left": 1}
+
+    async def _fails_once(session, *args, **kwargs):
+        if failures["left"]:
+            failures["left"] -= 1
+            raise RuntimeError("the browser went away between two calls")
+        return session
+
+    monkeypatch.setattr(actions, "new_page", _fails_once)
+    rebuilt = await server.session_new_page(browser_id="b")
+
+    assert rebuilt is not other, "the browser that failed was handed back, not rebuilt"
+    assert other.closed, "the failing browser was dropped without being closed"
+    assert registry.peek(_key()) is main and not main.closed, (
+        "recovery on one browser closed another one")
+
+
+# --- two sessions -----------------------------------------------------------
+
+async def test_two_session_ids_do_not_share_a_browser(registry, echo):
+    """Known-bad: have `addressed` ignore `session_id`. Both callers then share
+    one browser, which is the cookie jar of one person handed to another."""
+    a = await server.browser_read_text(session_id="one")
+    b = await server.browser_read_text(session_id="two")
+
+    assert a is not b, "two sessions were served by one browser"
+    assert registry.ids() == [_key("one"), _key("two")], (
+        "the two sessions are filed under %r" % registry.ids())
+
+
+async def test_starting_a_session_does_not_restart_another_ones_browser(registry, echo):
+    """`session_start` is the one tool that REPLACES a browser, which makes an
+    unaddressed one the loudest version of this defect: somebody choosing an
+    identity in their own session closes the browser of a session they cannot
+    see, and both callers are told it worked.
+
+    Known-bad: `registry.restart(**chosen.kwargs)`, the call this replaced. The
+    default key is restarted whatever the caller named, so a third browser
+    appears, the named session keeps its old one, and two assertions go red.
+    """
+    mine = await server.browser_read_text(session_id="one")
+    theirs = await server.browser_read_text(session_id="two")
+
+    # proxy and profile are said out loud as "none" so the environment cannot
+    # decide either: this test is about WHICH browser was restarted.
+    answer = await server.session_start(seed=4242, proxy="", profile="",
+                                        session_id="one")
+    assert not answer.startswith("refused"), answer
+
+    restarted = registry.peek(_key("one"))
+    assert restarted is not mine and mine.closed, (
+        "the named session's browser was not the one restarted")
+    assert restarted.kwargs.get("seed") == 4242, (
+        "the restarted browser is not the person that was asked for")
+    assert registry.peek(_key("two")) is theirs and not theirs.closed, (
+        "starting one session restarted another one's browser")
+    assert registry.ids() == [_key("one"), _key("two")], (
+        "session_start opened a browser nobody asked for: %r" % registry.ids())
+
+
+# --- the ones a behaviour test cannot reach ---------------------------------
+
+def test_the_registry_still_has_methods_worth_guarding():
+    """The two structural tests below derive what they guard from the registry
+    rather than from a list typed here. A rename that empties that derivation
+    would leave them green over an unguarded module, so the derivation itself is
+    asserted before it is trusted."""
+    assert {"ensure", "peek", "config", "drop", "restart"} <= ADDRESSABLE, (
+        "the registry no longer takes an address on the methods the server "
+        "calls, so the scan below guards nothing: %r" % sorted(ADDRESSABLE))
+
+
+def _scan_registry_calls():
+    """Every `registry.<addressable>(...)` in the server, and whether it carries
+    an address.
+
+    Read per enclosing function, because `_retrying` addresses once into a local
+    and then uses it three times: a name is accepted only where it was bound to
+    `addressed(...)` in scope.
+    """
+    tree = ast.parse(SERVER_PY.read_text(encoding="utf-8"))
+    unaddressed, checked = [], {}
+
+    for holder in ast.walk(tree):
+        if not isinstance(holder, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        bound = set()
+        for node in ast.walk(holder):
+            if (isinstance(node, ast.Assign) and isinstance(node.value, ast.Call)
+                    and isinstance(node.value.func, ast.Name)
+                    and node.value.func.id == "addressed"):
+                bound |= {t.id for t in node.targets if isinstance(t, ast.Name)}
+
+        for node in ast.walk(holder):
+            if not (isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and isinstance(node.func.value, ast.Name)
+                    and node.func.value.id == "registry"
+                    and node.func.attr in ADDRESSABLE):
+                continue
+            checked[node.lineno] = "%s: registry.%s" % (holder.name, node.func.attr)
+            given = node.args[0] if node.args else next(
+                (k.value for k in node.keywords if k.arg == "session_id"), None)
+            composed_here = (isinstance(given, ast.Call)
+                             and isinstance(given.func, ast.Name)
+                             and given.func.id == "addressed")
+            composed_earlier = isinstance(given, ast.Name) and given.id in bound
+            if not (composed_here or composed_earlier):
+                unaddressed.append("line %d, %s" % (node.lineno, checked[node.lineno]))
+
+    return unaddressed, checked
+
+
+def test_no_registry_call_in_the_server_is_left_without_an_address():
+    """⛔ THE ONE THAT CANNOT BE WRITTEN AS A BEHAVIOUR TEST, because it is
+    about the calls nobody wrote a behaviour test for.
+
+    An unaddressed call does not fail. It looks at the default browser while its
+    neighbours look at the caller's, and every tool answers normally: the tab
+    that is not there, the text of the wrong page, a click that lands somewhere
+    nobody is watching. One call is enough, and there are twenty of them in the
+    module, so the property is asserted over the source rather than sampled.
+
+    Known-bad, run before this was trusted: turn any one
+    `registry.ensure(addressed(session_id, browser_id))` back into
+    `registry.ensure()`.
+    """
+    unaddressed, checked = _scan_registry_calls()
+
+    assert not unaddressed, (
+        "these reach the registry with no browser named, so they act on the "
+        "default one whatever the caller asked for: %s" % unaddressed)
+    # 20 today. A floor rather than the number, because the point is that the
+    # scan found the calls at all: a scan that matches nothing passes the
+    # assertion above without reading a line of the module.
+    assert len(checked) >= 18, (
+        "only %d registry calls were found in %s; has the module moved?"
+        % (len(checked), SERVER_PY.name))
+
+
+def _tools_that_reach_a_browser():
+    """The `@mcp.tool()` functions whose own body reaches the registry, whether
+    directly or through `_retrying`."""
+    tree = ast.parse(SERVER_PY.read_text(encoding="utf-8"))
+    found = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        decorated = any(
+            isinstance(d, ast.Call) and isinstance(d.func, ast.Attribute)
+            and d.func.attr == "tool" for d in node.decorator_list)
+        if not decorated:
+            continue
+        for inner in ast.walk(node):
+            if not isinstance(inner, ast.Call):
+                continue
+            if (isinstance(inner.func, ast.Attribute)
+                    and isinstance(inner.func.value, ast.Name)
+                    and inner.func.value.id == "registry"
+                    and inner.func.attr in ADDRESSABLE):
+                found.add(node.name)
+            if isinstance(inner.func, ast.Name) and inner.func.id == "_retrying":
+                found.add(node.name)
+    return found
+
+
+async def test_every_tool_that_reaches_a_browser_offers_a_way_to_name_it():
+    """A tool that touches a browser with no way to say WHICH one always means
+    the default, and a caller holding two browsers simply cannot use it - the
+    surface would be addressable in fifteen places and mute in three.
+
+    Which tools need an address is read from the code rather than listed here,
+    so one written later is covered the day it is written. The check is against
+    the SCHEMA the server publishes, not the Python signature: a parameter the
+    client cannot see is a parameter that does not exist.
+
+    Known-bad: delete `session_id` and `browser_id` from any one tool.
+    """
+    needing = _tools_that_reach_a_browser()
+    assert len(needing) >= 18, (
+        "only %d tools were found reaching a browser; has the module moved? %r"
+        % (len(needing), sorted(needing)))
+
+    published = {t.name: set(t.inputSchema.get("properties", {}))
+                 for t in await server.mcp.list_tools()}
+    unknown = sorted(needing - set(published))
+    assert not unknown, "found in the source but not registered: %r" % unknown
+
+    mute = {name: sorted(published[name]) for name in sorted(needing)
+            if not {"session_id", "browser_id"} <= published[name]}
+    assert not mute, (
+        "these act on a browser the caller cannot name, so they always act on "
+        "the default one: %s" % mute)

--- a/tests/mcp_server/test_addressing.py
+++ b/tests/mcp_server/test_addressing.py
@@ -331,9 +331,17 @@ async def test_every_tool_that_reaches_a_browser_offers_a_way_to_name_it():
     the SCHEMA the server publishes, not the Python signature: a parameter the
     client cannot see is a parameter that does not exist.
 
+    ⛔ ONE EXEMPTION, and it is about the question rather than about the tool.
+    `browser_list` asks which browsers a SESSION holds, which is not a question
+    any one browser can answer, so it takes a session and no browser on purpose.
+    Exempting it by name rather than by loosening the rule to "one of the two"
+    keeps the rule able to catch the case it exists for: a tool that acts on a
+    browser and cannot say which.
+
     Known-bad: delete `session_id` and `browser_id` from any one tool.
     """
-    needing = _tools_that_reach_a_browser()
+    ASKS_ABOUT_THE_SESSION = {"browser_list"}
+    needing = _tools_that_reach_a_browser() - ASKS_ABOUT_THE_SESSION
     assert len(needing) >= 18, (
         "only %d tools were found reaching a browser; has the module moved? %r"
         % (len(needing), sorted(needing)))

--- a/tests/mcp_server/test_asking_who_you_are.py
+++ b/tests/mcp_server/test_asking_who_you_are.py
@@ -50,6 +50,16 @@ def registry(monkeypatch):
     return reg
 
 
+#: Where a caller that names no browser is filed. The tests below put a session
+#: there BY HAND, so they have to spell the key the way the tools do or they set
+#: up one browser and then ask about another. Two of them went red the day the
+#: key was composed, which was the honest outcome; the third asserted that a
+#: password does not appear in the answer and went on passing, over an answer
+#: that had become "no browser is running yet". A test that stops reaching its
+#: subject does not report anything.
+HERE = server.addressed()
+
+
 async def test_with_nothing_running_it_says_so(registry):
     answer = await server.session_status()
 
@@ -64,11 +74,13 @@ async def test_asking_starts_nothing(registry):
     it as the side effect of a question."""
     await server.session_status()
 
-    assert registry.peek() is None, "asking who we are started a browser"
+    # Every key, not just the one it would have used: a browser started under
+    # any address at all is a browser this tool was not supposed to start.
+    assert registry.ids() == [], "asking who we are started a browser"
 
 
 async def test_it_reports_the_running_identity(registry):
-    await registry.restart(seed=4242, headless=True,
+    await registry.restart(HERE, seed=4242, headless=True,
                            proxy={"server": "socks5://exit-a.invalid:1080"},
                            profile_dir="C:/tmp/acct-a")
 
@@ -83,8 +95,8 @@ async def test_it_reports_the_running_identity(registry):
 async def test_it_reports_the_identity_of_a_browser_that_died(registry):
     """The case that made this tool necessary. After a crash the config is still
     known, so the answer is who the next tool will come back as - not silence."""
-    await registry.restart(seed=4242, headless=True)
-    await registry.drop()
+    await registry.restart(HERE, seed=4242, headless=True)
+    await registry.drop(HERE)
 
     answer = await server.session_status()
 
@@ -95,8 +107,15 @@ async def test_it_reports_the_identity_of_a_browser_that_died(registry):
 async def test_it_never_prints_a_proxy_password(registry):
     """A status line is the most quoted string in this surface: it goes into
     transcripts, bug reports and pasted logs."""
-    await registry.restart(seed=1, headless=True,
+    await registry.restart(HERE, seed=1, headless=True,
                            proxy={"server": "socks5://exit-a.invalid:1080",
                                   "username": "u", "password": "hunter2"})
 
-    assert "hunter2" not in await server.session_status()
+    answer = await server.session_status()
+    # The subject is checked before the absence: "hunter2 is not in this string"
+    # is true of every string that is not about a proxied session, so without
+    # this line the test passes hardest when it has stopped testing anything.
+    assert "exit-a.invalid" in answer, (
+        "the answer is not about the proxied session, so finding no password "
+        "in it means nothing: %r" % answer)
+    assert "hunter2" not in answer

--- a/tests/mcp_server/test_browsers_in_a_session.py
+++ b/tests/mcp_server/test_browsers_in_a_session.py
@@ -1,0 +1,180 @@
+"""A session holds several browsers: opening, closing, focusing, and the ceiling.
+
+The addressing that makes this possible is pinned in `test_addressing.py`; this
+file is about the layer above it, where a session owns browsers and has to say
+how many, which one, and what happens when one is closed.
+
+⛔ THE CEILING IS A MEASUREMENT AND THE TESTS TREAT IT AS ONE. Eight live
+browsers were measured at 61 processes and about 6.5 GB on 2026-09-08, with the
+eighth taking 13.6 s to start against the first one's 6.8. A refusal that only
+said "no" would invite the next reader to raise the number, so the refusal
+carries the cost and one test reads it.
+
+No browser starts here. The registry gets a factory that launches nothing, so
+what a tool did is observable as the keys the registry ends up holding.
+"""
+from __future__ import annotations
+
+import pytest
+
+from aihawk.mcp import server
+from aihawk.mcp.registry import DEFAULT_SESSION_ID, SessionRegistry
+
+
+class _Recording:
+    """A session that launches nothing and reports itself alive."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self._browser = None
+        self._context = object()
+        self.closed = False
+
+    async def start(self):
+        pass
+
+    async def close(self):
+        self.closed = True
+
+    async def describe_pages(self):
+        return []
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    reg = SessionRegistry(factory=_Recording,
+                          defaults=lambda: {"seed": 7, "headless": True})
+    monkeypatch.setattr(server, "registry", reg)
+    # The focus is module state, so a test that set it must not reach the next.
+    monkeypatch.setattr(server, "_focus", {})
+    return reg
+
+
+async def test_a_second_browser_is_its_own_browser(registry):
+    """Opening one adds a browser rather than replacing the one there.
+
+    Known-bad: `browser_open` calling `restart` on the focused key instead of
+    the new one, which reads like opening and behaves like replacing.
+    """
+    await server.browser_open(browser_id="docs")
+    await server.browser_open(browser_id="dash")
+
+    assert server.browsers_in() == ["dash", "docs"]
+    assert registry.peek("default/docs") is not registry.peek("default/dash")
+
+
+async def test_the_one_just_opened_is_where_commands_go(registry):
+    """Opening a browser to then address every command to it by hand would make
+    the common case the tedious one.
+
+    Known-bad: dropping the `_focus[...] = browser_id` line. The assertion on
+    `addressed()` then still answers "main".
+    """
+    await server.browser_open(browser_id="docs")
+
+    assert server.focused() == "docs"
+    assert server.addressed() == "default/docs"
+    # Naming one still reaches it whatever the focus is.
+    assert server.addressed(browser_id="other") == "default/other"
+
+
+async def test_the_ceiling_refuses_the_ninth_and_says_what_eight_cost(registry):
+    """Eight is a measurement, and the refusal has to carry it.
+
+    Known-bad, two of them: raising `MAX_BROWSERS_PER_SESSION` past eight, and
+    a refusal reduced to "limit reached" - the second leaves the number looking
+    arbitrary, which is how a ceiling gets raised by somebody who never saw
+    what it cost.
+    """
+    for i in range(server.MAX_BROWSERS_PER_SESSION):
+        await server.browser_open(browser_id="b%d" % i)
+    assert len(server.browsers_in()) == 8
+
+    said = await server.browser_open(browser_id="one-too-many")
+
+    assert len(server.browsers_in()) == 8, "the ninth browser was opened anyway"
+    assert "one-too-many" not in server.browsers_in()
+    assert "6.5 GB" in said and "61 processes" in said, \
+        "the refusal does not say what the ceiling costs: %r" % said
+
+
+async def test_closing_forgets_who_that_browser_was(registry):
+    """⛔ The difference between `drop` and `forget`, at the tool level.
+
+    `drop` is recovery and keeps the identity so the replacement is the same
+    person. Closing is deliberate, and a browser that came back wearing an
+    identity its owner had shut down would hand the next caller somebody they
+    never asked for.
+
+    Known-bad: `browser_close` calling `registry.drop` instead of
+    `registry.forget`. The configuration then survives and the next browser
+    under that name is the same person resumed.
+    """
+    await server.browser_open(browser_id="docs", seed=4242)
+    assert registry.config("default/docs") is not None
+
+    await server.browser_close(browser_id="docs")
+
+    assert server.browsers_in() == []
+    assert registry.config("default/docs") is None, \
+        "the closed browser's identity is still remembered"
+
+
+async def test_closing_the_focused_one_does_not_leave_commands_pointing_at_it(registry):
+    """Known-bad: leaving `_focus` alone on close. Every later command then
+    addresses a browser that is gone, and the registry quietly starts a new one
+    under that name - a stranger wearing the name of somebody deliberately shut
+    down.
+    """
+    await server.browser_open(browser_id="docs")
+    await server.browser_close(browser_id="docs")
+
+    assert server.focused() == server.DEFAULT_BROWSER_ID
+    assert server.addressed() == "default/%s" % server.DEFAULT_BROWSER_ID
+
+
+async def test_two_sessions_do_not_share_their_browsers_or_their_focus(registry):
+    """The session is the container, so its browsers and its focus are its own.
+
+    Known-bad: keeping the focus in one variable instead of one per session,
+    which makes two sessions fight over where their commands land.
+    """
+    await server.browser_open(browser_id="docs", session_id="work")
+    await server.browser_open(browser_id="mail", session_id="home")
+
+    assert server.browsers_in("work") == ["docs"]
+    assert server.browsers_in("home") == ["mail"]
+    assert server.focused("work") == "docs"
+    assert server.focused("home") == "mail"
+    assert server.addressed("work") == "work/docs"
+    assert server.addressed("home") == "home/mail"
+
+
+async def test_the_count_is_read_from_the_registry_and_not_from_a_second_list(registry):
+    """A browser dropped underneath - which a failed retry does - has to free
+    its slot.
+
+    Known-bad: keeping the browsers in a list beside the registry. The dropped
+    one stays in it, and the ceiling then refuses a slot that is free.
+    """
+    for i in range(server.MAX_BROWSERS_PER_SESSION):
+        await server.browser_open(browser_id="b%d" % i)
+
+    await registry.drop("default/b3")
+
+    assert "b3" not in server.browsers_in()
+    said = await server.browser_open(browser_id="replacement")
+    assert "replacement" in server.browsers_in(), \
+        "a freed slot was still counted as taken: %r" % said
+
+
+async def test_asking_what_a_session_holds_starts_nothing(registry):
+    """A list that starts a browser is a list that cannot be asked casually,
+    and the interface asks it to draw its panes.
+
+    Known-bad: `browser_list` calling `ensure` instead of `peek`.
+    """
+    said = await server.browser_list()
+
+    assert registry.ids() == [], "asking what a session holds started a browser"
+    assert "no browser open yet" in said

--- a/tests/mcp_server/test_server_list.py
+++ b/tests/mcp_server/test_server_list.py
@@ -29,6 +29,12 @@ async def test_server_registers_expected_tools():
         # server returned was the content viewport, and the pointer is drawn
         # outside the page on purpose - so nobody watching could see it.
         "browser_watch",
+        # Added in 0.15.0 with the rest of the multi-browser work: a session
+        # holds several browsers now, so it needs a way to open one, close it,
+        # ask what it holds, and say which one the unaddressed commands mean.
+        # `browser_list` takes a session and no browser on purpose - what a
+        # session holds is not a question one browser can answer.
+        "browser_open", "browser_close", "browser_list", "browser_focus",
     }
     # EXACT, not a subset. `expected <= names` passed while a tool nobody
     # meant to publish sat in the list, and the surface of an MCP server is


### PR DESCRIPTION
The first slice of a bigger change: one session is going to hold up to eight browsers, and today nothing can address a second one, because every tool calls `registry.ensure()` with no argument and lands on the same key.

The design this belongs to is in the workbench, at `docs_research/chat-ui-performance/30-PROGETTO-sessioni-e-otto-browser.md`.

## The machinery was already there, and unreachable

The registry has kept browsers by id all along, and not sketchily:

- a lock per id, so two callers racing to first-use one browser start one rather than two
- the configuration remembered per id, so a rebuild is the **same person** with the same seed, the same profile and the same exit - the comment there records that rebuilding from the environment had de-anonymised the traffic while every tool reported success
- tab numbering that does not restart across a rebuild, so an id a caller still holds never names a different page
- refusals remembered, so a failed start does not quietly become a different browser

None of it could be used, because no caller could name an id.

So **the registry is untouched by this change**. The key is composed instead, from a session and a browser, and everything the registry already gets right starts applying per browser, which is where it was always needed.

## What changes

Every tool takes `session_id` and `browser_id`, both optional. A client that sends neither behaves exactly as before - that is the promise this slice is built around, and the first thing its tests pin.

The retry path is addressed too. Dropping and rebuilding the default key while the action was aimed at another browser would kill a browser nobody asked about and hand back the wrong one: the same class of mistake as rebuilding from the environment, in that it succeeds, at the wrong thing.

## Three existing tests, and one that had stopped testing anything

Three tests set the registry up by hand under the bare default key. Two failed honestly when the tools moved to composed keys.

The third kept **passing while it no longer tested anything**: its answer had become "no browser is running yet", and "the proxy password is not in that string" is trivially true of a string that mentions no session at all. It now checks the answer is about the proxied session **before** asserting the password is absent.

## The ceiling

`MAX_BROWSERS_PER_SESSION = 8` is declared here with the measurement that chose it - 61 processes and 6,515 MB for eight live browsers, with the eighth taking 13.6 s to start against the first one's 6.8 - but it is **not enforced yet**. That is the next slice, together with the tools that open and close browsers.

## Test plan

- [x] `pytest -q`: 369 passed (baseline 361, +8), 3 xfailed unchanged
- [x] mutations run and killed: one tool reverted to a bare `ensure()`; `addressed()` losing its defaults; one tool losing its address; one tool losing both parameters
- [x] the mutation that only the structural test catches is the interesting one: no behaviour test drives `browser_click`, so a lost address there is invisible to everything except the test that reads the source
- [x] `check_english_only.py` and `check_content.py` clean, both also run with `--selftest`
- [x] `browser_read_html` trimmed back under the 1024-character truncation that `mcp_tools_to_openai` applies, so its new note is not cut before the model sees it
