### PR TITLE
Sessions survive the process: what a session holds is written down (0.16.0)

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -143,6 +143,7 @@ between what the browser says it is and where it appears to be.
 | `STEALTHFOX_MCP_TRANSPORT` | `http` to serve over streamable HTTP instead of stdio. Default is stdio, which is what MCP clients expect. |
 | `STEALTHFOX_MCP_HOST` | Bind address for the HTTP transport. Default `127.0.0.1`. |
 | `STEALTHFOX_MCP_PORT` | Port for the HTTP transport. Default `8765`, which is also the AIHawk interface's default: change one of the two if you run both. |
+| `AIHAWK_HOME` | Where saved sessions are kept. Defaults to `%APPDATA%ihawk` on Windows, `~/Library/Application Support/aihawk` on macOS and `$XDG_DATA_HOME/aihawk` on Linux. Set it to put them on another disk. |
 
 Anything a tool call says wins over these. `session_start` can pick another
 seed, another exit or another profile for one session; the variables are what a
@@ -150,7 +151,8 @@ session gets when nobody says anything.
 
 ## Tools
 
-`session_status`, `session_start`, `session_new_page`, `session_list_pages`,
+`session_list`, `session_forget`, `session_status`, `session_start`,
+`session_new_page`, `session_list_pages`,
 `session_select_page`, `session_close_page`, `browser_open`, `browser_close`,
 `browser_list`, `browser_focus`, `browser_navigate`,
 `browser_read_text`, `browser_snapshot`, `browser_read_html`,
@@ -183,6 +185,8 @@ address.
 | `browser_close` | `browser_id` optional | Closes one browser and frees what it held. Its tabs go with it; the other browsers and the conversation do not. Forgets who it was, so the same name later is a new stranger rather than that person resumed. |
 | `browser_list` | `session_id` optional | Which browsers this session holds, where each one is, and which one commands go to. Starts nothing, so asking is free. |
 | `browser_focus` | `browser_id` | Chooses which browser the commands that name none land on. Naming a browser still reaches it whatever the focus is. |
+| `session_list` | none | Every saved session and what each one holds. Sessions survive the server, so this is how you find the one you were in. Starts nothing. |
+| `session_forget` | `session_id` | Delete a saved session: its browsers are closed and it stops being listed. Not the same as closing browsers, which frees the engines and keeps the session. |
 | `session_status` | none | Who is browsing right now: the seed, the exit, the profile and the open tabs. Starts nothing; if no browser is up it says so. |
 | `session_start` | `seed`, `proxy`, `profile`, all optional | Close whatever is open and start a browser as a particular person. Returns a sentence describing the session it actually started. |
 | `session_new_page` | none | Open a tab, make it the active one, return its id. |
@@ -192,8 +196,17 @@ address.
 
 You can ignore `session_start` entirely: the first tool that needs a page starts
 a session on its own, as a different stranger every time, which is the right
-default. There is one browser, so two identities are visited in turn, never at
-once; a task that needs two accounts live at the same time cannot be done here.
+default. A session holds up to eight browsers, so two accounts CAN be live at
+the same time: open a second browser with `browser_open` and address commands to
+whichever one you mean. `session_start` still replaces the browser you are in
+rather than adding one, which is the difference between the two.
+
+Sessions are written down as soon as one holds a browser, and what is written is
+the DECLARATION - which browsers a session has, who each one is, and where its
+tabs were pointing - not eight running engines. Reopening one gives the
+identities back immediately; each engine starts when a command is aimed at it,
+as the right person. Cookies and logins come back only where a browser had a
+`profile`, which is the mechanism that already exists for that.
 
 - **`seed`** is the identity. Same seed, same fingerprint, every time. Leave it
   out and one is drawn; the answer says which, so a session worth repeating can

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.15.0"
+version = "0.16.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/mcp/registry.py
+++ b/src/aihawk/mcp/registry.py
@@ -48,9 +48,13 @@ def _is_usable(session) -> bool:
 class SessionRegistry:
     """Sessions by id, created on demand, closed on request or at shutdown."""
 
-    def __init__(self, factory=StealthSession, defaults=None) -> None:
+    def __init__(self, factory=StealthSession, defaults=None,
+                 on_change=None) -> None:
         self._factory = factory
         self._defaults = defaults
+        #: Called with a key whenever WHO that key is has changed - gained an
+        #: identity or lost one. See `_changed`.
+        self.on_change = on_change
         self._sessions: Dict[str, StealthSession] = {}
         #: What each id was last STARTED with, kept across the death of the
         #: session object so a rebuild can be the same person. See `ensure`.
@@ -75,6 +79,36 @@ class SessionRegistry:
     def config(self, session_id: str = DEFAULT_SESSION_ID) -> Optional[dict]:
         """What this id was started with, for callers that have to report it."""
         return self._configs.get(session_id)
+
+    def _changed(self, session_id: str) -> None:
+        """Say that this key's identity was gained or lost.
+
+        ⛔ THIS EXISTS SO THE SERVER DOES NOT HAVE TO REMEMBER TO REMEMBER. The
+        first version of persistence wrote the session down after `browser_open`,
+        `browser_close` and `browser_focus`, and that is three of the five places
+        a browser gets an identity: `session_start` was missed, and so was the
+        lazy auto-start every existing client uses - so the ONE session almost
+        everybody has was the one never written down. Adding the fourth and fifth
+        call would leave the same defect one refactor away, because the thing
+        that knows a browser became somebody is this class, not its callers.
+
+        Fired only where `_configs` actually gains or loses an entry, which is
+        rare: a browser starting or being deliberately forgotten. Not on `drop`,
+        which keeps the identity so the same person comes back, and not on
+        `close_all`, where every identity is discarded at once because the
+        PROCESS is ending - writing then would erase every saved session at
+        shutdown, which is the opposite of what saving them is for.
+
+        A callback that raises must not cost the caller their browser: the
+        browser is already built and correct, and failing to write a file down
+        is not a reason to hand back an error instead of it.
+        """
+        if self.on_change is None:
+            return
+        try:
+            self.on_change(session_id)
+        except Exception:
+            pass
 
     def _lock(self, session_id: str) -> asyncio.Lock:
         # One lock per id, so two clients racing to first-use the same session
@@ -119,6 +153,10 @@ class SessionRegistry:
         signal is a failure, not a pass, and failing loudly beats succeeding
         from the wrong address.
         """
+        # Whether this call is what gave the key an identity. Read after the
+        # lock is released, so the callback - which writes a file - runs with
+        # nobody waiting behind it.
+        became = False
         async with self._lock(session_id):
             existing = self._sessions.get(session_id)
             if existing is not None and not _is_usable(existing):
@@ -137,8 +175,12 @@ class SessionRegistry:
                 await session.start()
                 self._sessions[session_id] = session
                 self._configs[session_id] = config
-                return session
-            return existing
+                became = True
+            else:
+                session = existing
+        if became:
+            self._changed(session_id)
+        return session
 
     async def restart(self, session_id: str = DEFAULT_SESSION_ID,
                       **kwargs) -> StealthSession:
@@ -183,7 +225,8 @@ class SessionRegistry:
             # refused or failed start leaves the previous identity in place
             # rather than arming recovery with settings that do not launch.
             self._configs[session_id] = dict(kwargs)
-            return session
+        self._changed(session_id)
+        return session
 
     def _adopt_numbering(self, session_id: str, session) -> None:
         """Continue this id's tab numbering in the session replacing it."""
@@ -210,6 +253,33 @@ class SessionRegistry:
         async with self._lock(session_id):
             await self._discard(session_id)
 
+    def declare(self, session_id: str, config: dict) -> None:
+        """Say who a browser WILL be, without starting it.
+
+        ⛔ This is what makes reopening a saved session cheap. A browser costs
+        about 800 MB and seven to fourteen seconds to start, measured, so
+        reopening a session that declared eight of them must not start eight of
+        them: they are declared here, and the first command aimed at one is what
+        actually launches it - as the right person, because the config is
+        already remembered.
+
+        It writes `_configs` and nothing else, which is the same memory `ensure`
+        already consults and `drop` already preserves. A declared browser is
+        therefore indistinguishable from one whose browser died a moment ago,
+        and that is the point: the recovery path was already correct.
+
+        It does NOT fire `_changed`. This is how a session is READ BACK, and
+        reporting a change here would write straight back out what was just read
+        in - harmless, but it would make the hook mean "something happened"
+        instead of "somebody became somebody", which is the distinction the hook
+        exists to carry.
+        """
+        self._configs[session_id] = dict(config)
+
+    def declared(self) -> list:
+        """Every browser this registry knows of, running or only declared."""
+        return sorted(set(self._sessions) | set(self._configs))
+
     async def forget(self, session_id: str = DEFAULT_SESSION_ID) -> bool:
         """Close this browser and forget who it was. Answers whether it existed.
 
@@ -227,7 +297,9 @@ class SessionRegistry:
             await self._discard(session_id)
             self._configs.pop(session_id, None)
             self._refusals.pop(session_id, None)
-            return existed
+        if existed:
+            self._changed(session_id)
+        return existed
 
     async def close_all(self) -> None:
         """Shut every session down. Called when the PROCESS ends, not when a

--- a/src/aihawk/mcp/server.py
+++ b/src/aihawk/mcp/server.py
@@ -30,13 +30,28 @@ from contextlib import asynccontextmanager
 
 from mcp.server.fastmcp import FastMCP, Image
 
-from . import actions, identity, plan
+from . import actions, identity, plan, store
 from .registry import DEFAULT_SESSION_ID, SessionRegistry
 
 # Kept for callers that imported it from here. The implementation moved.
 _json_capped = actions.json_capped
 
-registry = SessionRegistry()
+def new_registry(**kwargs) -> SessionRegistry:
+    """A registry wired to write its sessions down.
+
+    ⛔ ONE CONSTRUCTOR, USED BY THE SERVER AND BY THE TESTS. A test that builds
+    a bare `SessionRegistry` is testing a registry the product does not have,
+    and the wiring below - the thing that makes a session survive the process -
+    would be exercised by nothing. It is a function rather than a line because
+    the tests need to build one with a factory that launches no browser, and
+    the alternative was each of them repeating the wiring or, more likely, not.
+    """
+    reg = SessionRegistry(**kwargs)
+    reg.on_change = lambda key: remember(key.split("/")[0])
+    return reg
+
+
+registry = new_registry()
 
 
 #: Set by main(). Over stdio the SDK enters the lifespan once per process, so
@@ -159,20 +174,132 @@ MAX_BROWSERS_PER_SESSION = 8
 _focus: dict = {}
 
 
+def in_session(session_id: str | None = None) -> str:
+    """The session a caller means, with whatever was saved of it read back in.
+
+    ⛔ TWO DUPLICATIONS COLLAPSED INTO ONE FUNCTION, AND THE SECOND ONE WAS A
+    DEFECT. Every entry point wrote `session_id or DEFAULT_SESSION_ID`, and
+    exactly one of them - `browsers_in` - also read the saved session first. So
+    a server that had just restarted gave back the right browsers to a client
+    that asked what the session HELD, and a brand new stranger to one that
+    simply navigated, which is what every existing client does. Nothing raised:
+    the browser worked, it was just somebody else, in a session whose real
+    identities sat unread on disk.
+
+    Reading is idempotent and guarded by `_loaded`, so putting it here costs a
+    set lookup on the calls that have already read theirs.
+    """
+    at_session = session_id or DEFAULT_SESSION_ID
+    restore(at_session)
+    return at_session
+
+
 def focused(session_id: str | None = None) -> str:
     """The browser this session's unaddressed commands go to."""
-    return _focus.get(session_id or DEFAULT_SESSION_ID, DEFAULT_BROWSER_ID)
+    return _focus.get(in_session(session_id), DEFAULT_BROWSER_ID)
+
+
+#: The launch settings that say WHO a browser is, and so the ones a saved
+#: session carries. Everything else in the launch kwargs describes the machine
+#: it ran on, and writing those down would restore a session onto the wrong one.
+#:
+#: ⛔ THESE ARE THE LAUNCH KWARGS' OWN NAMES, NOT THE TOOL ARGUMENTS' NAMES, and
+#: the difference is not cosmetic. This list said `profile` for its first day,
+#: which is what `browser_open` and `session_start` call it; the launch kwarg is
+#: `profile_dir`, so the filter matched nothing and the profile was the one
+#: field never saved - the one field that carries the cookies and the logins a
+#: reopened session is FOR. Nothing failed: every browser came back with the
+#: right seed and the right exit, logged out.
+#:
+#: `binary_path` is deliberately absent. It is a path on this machine, and a
+#: session reopened where that path means nothing must resolve an engine rather
+#: than insist on one that is not there.
+WHO_A_BROWSER_IS = ("seed", "proxy", "profile_dir", "headless")
+
+#: Sessions whose saved file has already been read into the registry. Loading
+#: is idempotent but not free, and a session that was loaded and then had a
+#: browser closed must not be re-loaded back into having it.
+_loaded: set = set()
 
 
 def browsers_in(session_id: str | None = None) -> list:
-    """The browsers this session has, by id.
+    """The browsers this session has, by id, running or only declared.
 
-    Read from the registry's keys rather than from a list kept beside them,
+    Read from the registry's own memory rather than from a list kept beside it,
     because a second list is a second truth: a browser dropped by a failed retry
     would still be in it, and the ceiling would refuse a slot that is free.
+
+    Declared counts. A browser restored from a saved session has not started
+    yet - it starts when something is aimed at it - but it holds a slot and it
+    is one of the session's browsers, so it is one here too.
     """
-    prefix = "%s/" % (session_id or DEFAULT_SESSION_ID)
-    return sorted(k[len(prefix):] for k in registry.ids() if k.startswith(prefix))
+    at_session = in_session(session_id)
+    prefix = "%s/" % at_session
+    return sorted(k[len(prefix):] for k in registry.declared()
+                  if k.startswith(prefix))
+
+
+def remember(session_id: str | None = None) -> None:
+    """Write this session down as it stands now.
+
+    Called after anything that changes what the session HOLDS rather than on a
+    timer, so the file on disk is never a version of the session that existed
+    only between two ticks. Two kinds of caller, and they cover different halves:
+
+    * the REGISTRY, through `new_registry`, whenever a browser gains or loses an
+      identity. That is every way a browser comes to exist, including the lazy
+      auto-start that clients which never call `browser_open` use, which is why
+      it is hooked there rather than listed here;
+    * the TOOLS, when the FOCUS moves. The registry cannot see that - the focus
+      is which browser unaddressed commands mean, and it lives in this module -
+      and it has to be written after the move, which is also why the tools call
+      this again after an open or a close rather than leaving it to the hook.
+
+    ⛔ A WRITE THAT FAILS COSTS THE SAVED SESSION AND NOTHING ELSE. By the time
+    this runs the browser is already built and correct, so a full disk or a home
+    directory somebody made read-only must not turn a working `browser_open`
+    into an error. Guarded here rather than at the call sites because this is
+    the only function that writes: a guard at the callers would be one per
+    caller, and the next caller would be the one without it.
+    """
+    at_session = session_id or DEFAULT_SESSION_ID
+    prefix = "%s/" % at_session
+    browsers = {}
+    for key in registry.declared():
+        if not key.startswith(prefix):
+            continue
+        config = registry.config(key) or {}
+        browsers[key[len(prefix):]] = {
+            k: v for k, v in config.items() if k in WHO_A_BROWSER_IS
+        }
+    try:
+        if not browsers:
+            store.erase(at_session)
+            return
+        store.save(at_session, browsers, focus=_focus.get(at_session))
+    except Exception:
+        pass
+
+
+def restore(session_id: str | None = None) -> bool:
+    """Read a saved session back, if there is one and it has not been read yet.
+
+    Declares its browsers rather than starting them: the identities come back
+    immediately and cost nothing, and the engines come back one at a time, when
+    something is actually aimed at one. Answers whether anything was read.
+    """
+    at_session = session_id or DEFAULT_SESSION_ID
+    if at_session in _loaded:
+        return False
+    _loaded.add(at_session)
+    saved = store.load(at_session)
+    if not saved:
+        return False
+    for name, config in (saved.get("browsers") or {}).items():
+        registry.declare("%s/%s" % (at_session, name), config)
+    if saved.get("focus"):
+        _focus[at_session] = saved["focus"]
+    return True
 
 
 def addressed(session_id: str | None = None, browser_id: str | None = None) -> str:
@@ -190,8 +317,8 @@ def addressed(session_id: str | None = None, browser_id: str | None = None) -> s
     that still reaches for the bare default would look at one browser while its
     neighbours wrote to another, and nothing would raise.
     """
-    return "%s/%s" % (session_id or DEFAULT_SESSION_ID,
-                      browser_id or focused(session_id))
+    at_session = in_session(session_id)
+    return "%s/%s" % (at_session, browser_id or focused(at_session))
 
 
 async def _retrying(fn, *args, session_id=None, browser_id=None, **kwargs):
@@ -217,6 +344,50 @@ async def _retrying(fn, *args, session_id=None, browser_id=None, **kwargs):
         return await fn(session, *args, **kwargs)
 
 
+# --- the sessions themselves -----------------------------------------------
+
+@mcp.tool()
+async def session_list() -> str:
+    """The saved sessions, and what each one holds.
+
+    A session is the piece of work: it owns browsers, and each browser owns its
+    own tabs, cookies and identity. They survive the server, so this is how you
+    find the one you were in.
+
+    Starts nothing, and opens no browser: a saved browser is a declaration of
+    who it will be, and it comes back when something is aimed at it.
+    """
+    saved = store.known()
+    if not saved:
+        return ("no saved sessions yet. Any session that opens a browser is "
+                "saved from that moment, and session_list finds it again.")
+    rows = []
+    for s in saved:
+        names = sorted((s.get("browsers") or {}))
+        rows.append("%s (%s): %s%s" % (
+            s.get("name") or s["id"], s["id"],
+            ", ".join(names) if names else "no browsers",
+            ", saved %s" % s["saved"] if s.get("saved") else ""))
+    return "%d saved session(s). %s" % (len(saved), " | ".join(rows))
+
+
+@mcp.tool()
+async def session_forget(session_id: str) -> str:
+    """Delete a saved session: its browsers are closed and it stops being listed.
+
+    This is not the same as closing browsers. Closing frees the engines and
+    keeps the session; this removes the session itself, so nothing about it
+    comes back.
+    """
+    restore(session_id)
+    for name in browsers_in(session_id):
+        await registry.forget(addressed(session_id, name))
+    _focus.pop(session_id, None)
+    existed = store.erase(session_id)
+    return ("session %s is gone." % session_id if existed
+            else "there is no saved session called %s." % session_id)
+
+
 # --- the browsers a session holds ------------------------------------------
 
 @mcp.tool()
@@ -237,7 +408,7 @@ async def browser_open(browser_id: str | None = None, seed: int | None = None,
     Opening one takes several seconds and costs real memory, so open what you
     need and close what you stop using: browser_close frees it.
     """
-    at_session = session_id or DEFAULT_SESSION_ID
+    at_session = in_session(session_id)
     have = browsers_in(at_session)
 
     if browser_id is None:
@@ -270,6 +441,7 @@ async def browser_open(browser_id: str | None = None, seed: int | None = None,
         return "browser %s could not start: %s" % (browser_id, exc)
 
     _focus[at_session] = browser_id
+    remember(at_session)
     return ("browser %s is open in session %s and is now the one unaddressed "
             "commands go to. %s" % (browser_id, at_session,
                                     plan.describe(registry.config(at) or {})))
@@ -287,13 +459,14 @@ async def browser_close(browser_id: str | None = None,
     name is a new stranger, not the same person resumed. That is deliberate -
     a browser somebody shut down should not come back wearing its old identity.
     """
-    at_session = session_id or DEFAULT_SESSION_ID
+    at_session = in_session(session_id)
     name = browser_id or focused(at_session)
     existed = await registry.forget(addressed(at_session, name))
 
     if _focus.get(at_session) == name:
         _focus.pop(at_session, None)
     left = browsers_in(at_session)
+    remember(at_session)
     if not existed:
         return "session %s has no browser called %s." % (at_session, name)
     return ("browser %s is closed. Still open in session %s: %s."
@@ -306,7 +479,7 @@ async def browser_list(session_id: str | None = None) -> str:
 
     Starts nothing: it reports what is running, so asking is free.
     """
-    at_session = session_id or DEFAULT_SESSION_ID
+    at_session = in_session(session_id)
     have = browsers_in(at_session)
     if not have:
         return ("session %s has no browser open yet. The next tool that needs a "
@@ -340,12 +513,13 @@ async def browser_focus(browser_id: str, session_id: str | None = None) -> str:
     only decides where the ones that name none land, so a run of commands on one
     browser does not have to repeat its id.
     """
-    at_session = session_id or DEFAULT_SESSION_ID
+    at_session = in_session(session_id)
     have = browsers_in(at_session)
     if browser_id not in have:
         return ("session %s has no browser called %s. Open: %s."
                 % (at_session, browser_id, ", ".join(have) if have else "none"))
     _focus[at_session] = browser_id
+    remember(at_session)
     return "commands without a browser_id now go to %s." % browser_id
 
 

--- a/src/aihawk/mcp/store.py
+++ b/src/aihawk/mcp/store.py
@@ -1,0 +1,141 @@
+"""What a session is, written down so it survives the process.
+
+A session is the piece of work: it owns browsers, and each browser owns tabs.
+Until this file existed all three lived in dictionaries that died with the
+server, so "reopen the session I was working in" meant nothing.
+
+⛔ WHAT IS PROMISED, AND WHAT IS NOT. What is saved is the DECLARATION: which
+browsers a session has, who each one is (seed, exit, profile), which one had the
+focus, and where its tabs were pointing. Reopening restores that declaration -
+not eight live browsers. Eight of those were measured at 61 processes and about
+6.5 GB, with the eighth taking 13.6 s to start, so a reopen that launched them
+all would take a minute and most of the machine's memory to give back something
+nobody asked for yet. They start when a command is aimed at one, as the right
+person, because the identity was written down.
+
+Cookies and logins survive only where a browser had a `profile` directory, which
+is the mechanism that already exists for exactly that. Saying otherwise would be
+promising that a browser's live state is a thing this file can hold, and it is
+not.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+def home() -> Path:
+    """Where sessions are kept.
+
+    `AIHAWK_HOME` wins, which is what the tests use and what lets somebody put
+    this on another disk. Otherwise the place each system expects, so a person
+    finds it where they would look for it rather than in a dotfile invented
+    here.
+    """
+    override = os.environ.get("AIHAWK_HOME")
+    if override:
+        return Path(override).expanduser()
+    if sys.platform == "win32":
+        base = os.environ.get("APPDATA") or (Path.home() / "AppData" / "Roaming")
+        return Path(base) / "aihawk"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / "aihawk"
+    base = os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share")
+    return Path(base) / "aihawk"
+
+
+def _sessions_dir() -> Path:
+    return home() / "sessions"
+
+
+def _safe(session_id: str) -> str:
+    """A session id as a file name, without letting one escape the directory.
+
+    Ids reach this from a tool argument, so a caller could send `../../etc` or a
+    colon that Windows refuses. Anything outside the allowed set becomes an
+    underscore rather than being rejected: a session should not become
+    unreachable because of the name somebody gave it.
+    """
+    allowed = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
+    cleaned = "".join(c if c in allowed else "_" for c in session_id)
+    return cleaned[:120] or "_"
+
+
+def path_of(session_id: str) -> Path:
+    return _sessions_dir() / ("%s.json" % _safe(session_id))
+
+
+def save(session_id: str, browsers: Dict[str, dict],
+         focus: Optional[str] = None, name: Optional[str] = None) -> Path:
+    """Write one session down. Returns where it went.
+
+    ⛔ `write_bytes`, never `write_text`. On Windows the text form translates
+    every newline on the way out, which in this project has already turned a
+    twenty-line change into a fifteen-thousand-line one. JSON does not care, but
+    the habit is what keeps the next file that does care safe.
+
+    Written to a temporary neighbour and moved into place, so a process that
+    dies mid-write leaves the previous session intact rather than half of a new
+    one. A session file that will not parse is worse than an old one.
+    """
+    where = path_of(session_id)
+    where.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "id": session_id,
+        "name": name or session_id,
+        "saved": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "focus": focus,
+        "browsers": browsers,
+    }
+    blob = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+    beside = where.with_suffix(".json.writing")
+    beside.write_bytes(blob)
+    os.replace(beside, where)
+    return where
+
+
+def load(session_id: str) -> Optional[dict]:
+    """One session as it was written, or None if there is nothing to read.
+
+    A file that will not parse answers None as well. The alternative is raising
+    on a server's first call because something once wrote a broken byte, and a
+    session that cannot be read is exactly as usable as one that was never
+    saved.
+    """
+    where = path_of(session_id)
+    try:
+        return json.loads(where.read_bytes().decode("utf-8"))
+    except Exception:
+        return None
+
+
+def known() -> List[dict]:
+    """Every saved session, newest first, without opening a browser."""
+    out = []
+    try:
+        files = sorted(_sessions_dir().glob("*.json"))
+    except Exception:
+        return out
+    for f in files:
+        try:
+            out.append(json.loads(f.read_bytes().decode("utf-8")))
+        except Exception:
+            continue
+    out.sort(key=lambda s: s.get("saved") or "", reverse=True)
+    return out
+
+
+def erase(session_id: str) -> bool:
+    """Forget a saved session. Answers whether there was one."""
+    where = path_of(session_id)
+    try:
+        where.unlink()
+        return True
+    except FileNotFoundError:
+        return False
+    except Exception:
+        return False

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -483,6 +483,8 @@ const VERB = {
   browser_close:['Closing browser','Closed browser'],
   browser_list:['Listing browsers','Listed browsers'],
   browser_focus:['Switching browser','Switched browser'],
+  session_list:['Listing sessions','Listed sessions'],
+  session_forget:['Deleting session','Deleted session'],
   session_status:['Checking session','Checked session']
 };
 const LEAD = /^(I will |I'll |I am |I'm |Let me |Now I will |Now I'll )/i;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""No test writes into the real machine's aihawk directory.
+
+⛔ MEASURED, BY DOING IT. Sessions became persistent on 2026-09-08, and the
+first run of the tests that exercise them wrote three real files into
+`%APPDATA%\\aihawk\\sessions` on the developer's machine - and then the next
+test read them back, so tests began contaminating each other through a
+directory none of them had mentioned. One of them failed with six browsers it
+never opened.
+
+Redirected here rather than in each test for the reason the pollution happened
+at all: the tests that touch this were written by somebody who knew about it,
+and the ones written next year will not be. `AIHAWK_HOME` is the single knob
+`store.home()` reads first, so pointing it at a temporary directory for every
+test closes the whole class rather than the two cases somebody remembered.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _aihawk_home_is_disposable(tmp_path, monkeypatch):
+    monkeypatch.setenv("AIHAWK_HOME", str(tmp_path / "aihawk-home"))

--- a/tests/mcp_server/test_a_session_survives_the_process.py
+++ b/tests/mcp_server/test_a_session_survives_the_process.py
@@ -1,0 +1,399 @@
+"""A session outlives the server: what it held is written down and read back.
+
+Until this, a session was a dictionary that died with the process. "Reopen the
+one I was working in" meant nothing, and the identity a session had spent an
+hour building - the seed, the exit, the profile with the logins in it - was
+gone the moment the server stopped.
+
+⛔ WHAT IS PROMISED IS THE DECLARATION, NOT EIGHT LIVE BROWSERS. Eight of those
+were measured at 61 processes and about 6.5 GB, the eighth taking 13.6 s to
+start, so a reopen that launched them all would spend a minute and most of the
+machine to hand back something nobody has asked for yet. A reopened browser is
+a promise about WHO it will be; the engine starts when a command is aimed at it.
+Three tests below hold that line, because it is the kind of thing a later reader
+"fixes" into eagerly starting them.
+
+No browser starts here. The registry is built by the server's own constructor -
+so the wiring that writes sessions down is the wiring under test - with a
+factory that launches nothing.
+
+`tests/conftest.py` points `AIHAWK_HOME` at a temporary directory for every
+test in the package. Without it these write into the developer's real
+`%APPDATA%`, which is not a hypothetical: they did, on the first run.
+"""
+from __future__ import annotations
+
+import pytest
+
+from aihawk.mcp import actions, server, store
+
+
+class _Recording:
+    """A session that launches nothing and reports itself alive."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self._browser = None
+        self._context = object()
+        self.closed = False
+
+    async def start(self):
+        pass
+
+    async def close(self):
+        self.closed = True
+
+    async def describe_pages(self):
+        return []
+
+
+def _fresh(monkeypatch, **kwargs):
+    """A server with no memory of any session, as after a restart."""
+    reg = server.new_registry(
+        factory=_Recording,
+        defaults=lambda: dict({"seed": 7, "headless": True}, **kwargs))
+    monkeypatch.setattr(server, "registry", reg)
+    monkeypatch.setattr(server, "_focus", {})
+    monkeypatch.setattr(server, "_loaded", set())
+    return reg
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    return _fresh(monkeypatch)
+
+
+@pytest.fixture
+def restarted(monkeypatch):
+    """Restart the server: everything in memory goes, the disk stays."""
+    return lambda **kw: _fresh(monkeypatch, **kw)
+
+
+# --- what gets written ------------------------------------------------------
+
+async def test_opening_a_browser_writes_the_session_down_immediately(registry):
+    """Not on a timer and not at shutdown. A server that is killed - which is
+    how a stdio server usually ends - never reaches its own shutdown, so a
+    session saved there is a session saved never.
+
+    Known-bad: move the save into the lifespan exit. Everything still passes
+    that closes cleanly, and nothing that is killed.
+    """
+    await server.browser_open(browser_id="docs", seed=4242)
+
+    saved = store.load("default")
+    assert saved is not None, "opening a browser did not write the session down"
+    assert sorted(saved["browsers"]) == ["docs"]
+    assert saved["browsers"]["docs"]["seed"] == 4242
+    assert saved["focus"] == "docs"
+
+
+async def test_the_session_nobody_opened_a_browser_in_is_written_down_too(registry,
+                                                                         monkeypatch):
+    """⛔ THE ONE THE FIRST VERSION MISSED, AND IT IS THE COMMON CASE. Every
+    client written before browsers had names opens none: the first tool that
+    needs a page starts one lazily. Persistence hooked `browser_open`,
+    `browser_close` and `browser_focus`, so the ONE session almost everybody
+    has was the only one never saved.
+
+    The identity is real and worth saving - a lazily started browser draws a
+    concrete seed, so coming back to it is coming back to that person.
+
+    Known-bad: drop the `on_change` line from `server.new_registry`. Every other
+    test in this file still passes, because they all go through a tool that
+    remembers by hand.
+    """
+    async def _nothing(session, *args, **kwargs):
+        return "ok"
+
+    monkeypatch.setattr(actions, "new_page", _nothing)
+    await server.session_new_page()
+
+    saved = store.load("default")
+    assert saved is not None, (
+        "a session whose browser started lazily was never written down, so the "
+        "session almost every client has cannot be reopened")
+    assert saved["browsers"]["main"]["seed"] == 7
+
+
+async def test_a_profile_is_saved_because_it_is_what_carries_the_logins(registry,
+                                                                       tmp_path):
+    """⛔ MEASURED BY GETTING IT WRONG. The saved fields were named from the
+    TOOL's vocabulary - `seed`, `proxy`, `profile` - and the launch kwarg is
+    `profile_dir`, so the filter matched nothing and the profile was the single
+    field never written. Nothing failed: every browser came back with the right
+    seed and the right exit, and logged out, which is the one thing a person
+    reopens a session for.
+
+    Known-bad: put `profile` back in `WHO_A_BROWSER_IS` in place of
+    `profile_dir`.
+    """
+    await server.browser_open(browser_id="mail", seed=11,
+                              profile=str(tmp_path / "prof"))
+
+    saved = store.load("default")
+    assert saved["browsers"]["mail"].get("profile_dir"), (
+        "the profile was not saved, so the reopened browser keeps the identity "
+        "and loses the logins: %r" % saved["browsers"]["mail"])
+
+
+async def test_the_saved_fields_are_the_launch_kwargs_and_not_a_second_vocabulary(
+        registry, tmp_path):
+    """The class the bug above belongs to, closed rather than the one case.
+
+    A name in `WHO_A_BROWSER_IS` that no launch kwarg answers to filters nothing
+    and says nothing, and a launch kwarg that describes this machine must not be
+    written into a file another machine reads. So the list is checked against
+    what the planner actually produces, in both directions.
+
+    Known-bad, two: add `"profile"` to `WHO_A_BROWSER_IS`, and add
+    `"binary_path"`.
+    """
+    from aihawk.mcp import plan
+
+    produced = set(plan.plan_session(seed=1, proxy="socks5://127.0.0.1:1",
+                                     profile=str(tmp_path / "prof")).kwargs)
+    invented = sorted(set(server.WHO_A_BROWSER_IS) - produced)
+    assert not invented, (
+        "these are saved but no launch kwarg is called that, so they filter "
+        "nothing: %r. The launch names are %r" % (invented, sorted(produced)))
+
+    #: What is deliberately NOT saved, and why, so this test fails on a new
+    #: kwarg instead of silently ignoring it.
+    THIS_MACHINE = {"binary_path"}
+    unclassified = sorted(produced - set(server.WHO_A_BROWSER_IS) - THIS_MACHINE)
+    assert not unclassified, (
+        "the planner produces settings this file has never decided about: %r. "
+        "Either they say who a browser is, and belong in WHO_A_BROWSER_IS, or "
+        "they describe this machine, and belong in THIS_MACHINE with a reason."
+        % unclassified)
+
+
+async def test_moving_the_focus_is_written_down(registry):
+    """The focus is which browser unaddressed commands mean, and it is the
+    registry's one blind spot: it lives in the server, so nothing the registry
+    does can save it.
+
+    Known-bad: delete the `remember(at_session)` from `browser_focus`. Every
+    browser still comes back; the commands land on the wrong one.
+    """
+    await server.browser_open(browser_id="docs")
+    await server.browser_open(browser_id="dash")
+    await server.browser_focus(browser_id="docs")
+
+    assert store.load("default")["focus"] == "docs"
+
+
+# --- what gets read back ----------------------------------------------------
+
+async def test_reopening_gives_the_browsers_back_without_starting_one(registry,
+                                                                     restarted):
+    """⛔ THE WHOLE SHAPE OF THE FEATURE, IN ONE ASSERTION PAIR. The browsers are
+    there and the engines are not.
+
+    Known-bad: make `restore` call `ensure` instead of `declare`. The first
+    assertion still passes, the second reports eight browsers nobody asked to
+    start - which on the real factory is 61 processes and about 6.5 GB.
+    """
+    await server.browser_open(browser_id="docs", seed=4242)
+    await server.browser_open(browser_id="dash", seed=99)
+
+    reg = restarted()
+    assert reg.ids() == [], "a browser was running before anything was reopened"
+
+    assert server.browsers_in() == ["dash", "docs"], (
+        "the session came back without its browsers")
+    assert reg.ids() == [], (
+        "reopening a session STARTED its browsers: %r" % reg.ids())
+
+
+async def test_a_reopened_browser_comes_back_as_the_person_it_was(registry, restarted):
+    """A declaration that did not carry the identity would be a list of names.
+
+    Known-bad, two: have `restore` declare `{}` instead of the saved config, and
+    take the `in_session` out of `addressed` so the saved session is never read
+    by a client that simply navigates.
+    """
+    await server.browser_open(browser_id="docs", seed=4242)
+
+    reg = restarted(seed=1234)  # the environment would give a different person
+    session = await reg.ensure(server.addressed(browser_id="docs"))
+
+    assert session.kwargs["seed"] == 4242, (
+        "the reopened browser was built from the environment instead of from "
+        "who it was: %r" % session.kwargs)
+
+
+async def test_the_focus_comes_back_with_the_session(registry, restarted):
+    """Known-bad: drop the `_focus[at_session] = saved["focus"]` line in
+    `restore`. The browsers come back and every unaddressed command goes to
+    `main`, which is a browser this session may not even have.
+    """
+    await server.browser_open(browser_id="docs")
+    await server.browser_open(browser_id="dash")
+    await server.browser_focus(browser_id="docs")
+
+    restarted()
+    assert server.browsers_in() == ["dash", "docs"]
+    assert server.focused() == "docs"
+    assert server.addressed() == "default/docs"
+
+
+async def test_two_saved_sessions_come_back_as_two(registry, restarted):
+    """Known-bad: key the store by anything but the session id - a single file,
+    say. One session then overwrites the other and the second one to be saved is
+    the only one that exists.
+    """
+    await server.browser_open(browser_id="docs", session_id="work", seed=1)
+    await server.browser_open(browser_id="mail", session_id="home", seed=2)
+
+    restarted()
+    assert server.browsers_in("work") == ["docs"]
+    assert server.browsers_in("home") == ["mail"]
+
+    listed = await server.session_list()
+    assert "work" in listed and "home" in listed, listed
+
+
+async def test_a_session_is_read_from_disk_once_and_not_on_every_command(registry,
+                                                                        restarted,
+                                                                        monkeypatch):
+    """⛔ THE FIRST VERSION OF THIS TEST NAMED THE WRONG KNOWN-BAD, AND SAYING SO
+    IS THE POINT. It claimed that without the `_loaded` guard a closed browser
+    would come back on the next call. Run with the guard removed, it stayed
+    green: every change is written down before the next read, so the file the
+    re-read finds already agrees with memory. The guard was real and the test
+    was measuring something else.
+
+    What the guard actually holds is both halves below. `restore` runs from
+    `in_session`, which every tool reaches, so without it the server reads a
+    file from disk on every single command; and a session this server has
+    already loaded must not be re-read from underneath, or a browser it
+    deliberately closed comes back because something else wrote the file.
+
+    Known-bad: drop the `if at_session in _loaded: return False` from `restore`.
+    """
+    await server.browser_open(browser_id="docs")
+    await server.browser_open(browser_id="dash")
+
+    restarted()
+    reads = []
+    real_load = store.load
+    monkeypatch.setattr(store, "load",
+                        lambda sid: (reads.append(sid), real_load(sid))[1])
+
+    assert server.browsers_in() == ["dash", "docs"]
+    for _ in range(5):
+        server.browsers_in()
+        server.addressed()
+    assert len(reads) == 1, (
+        "the saved session was read from disk %d times; `restore` runs from "
+        "`in_session`, so that is once per command" % len(reads))
+
+    # And a session already loaded is this server's to decide, not the file's.
+    await server.browser_close(browser_id="docs")
+    store.save("default", {"docs": {"seed": 1}, "dash": {"seed": 2}})
+
+    assert server.browsers_in() == ["dash"], (
+        "a browser this server closed came back because the file was read again")
+
+
+# --- what must NOT get written ----------------------------------------------
+
+async def test_shutting_the_process_down_does_not_erase_the_saved_sessions(registry):
+    """⛔ THE ONE THAT WOULD DESTROY THE FEATURE WHILE LOOKING LIKE HOUSEKEEPING.
+    `close_all` forgets every identity, on purpose, because the process is
+    ending. If forgetting wrote the session down, every session would be saved
+    as empty at shutdown - and `remember` erases a session with no browsers, so
+    the last act of every server would be to delete everything it had saved.
+
+    Known-bad: fire `_changed` from `close_all` too.
+    """
+    await server.browser_open(browser_id="docs", seed=4242)
+    assert store.load("default") is not None
+
+    await registry.close_all()
+
+    saved = store.load("default")
+    assert saved is not None, (
+        "shutting down deleted the saved session, so nothing survives the "
+        "process the persistence exists to survive")
+    assert sorted(saved["browsers"]) == ["docs"]
+
+
+async def test_a_browser_that_died_underneath_is_still_a_browser_of_the_session(registry):
+    """`drop` is recovery, not a close: the engine is gone, the person is not.
+    Writing the session down without it would lose an identity every time a
+    retry failed.
+
+    Known-bad: fire `_changed` from `drop`.
+    """
+    await server.browser_open(browser_id="docs", seed=4242)
+
+    await registry.drop(server.addressed(browser_id="docs"))
+
+    assert store.load("default")["browsers"]["docs"]["seed"] == 4242
+
+
+async def test_a_write_that_fails_does_not_cost_the_caller_the_browser(registry,
+                                                                      monkeypatch):
+    """The browser is built and correct by the time anything is written. A full
+    disk, or a home directory somebody made read-only, must cost a saved session
+    and nothing else.
+
+    Known-bad: remove the try/except from `remember`.
+    """
+    def _explode(*args, **kwargs):
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(store, "save", _explode)
+
+    said = await server.browser_open(browser_id="docs", seed=4242)
+
+    assert "could not start" not in said, said
+    assert server.browsers_in() == ["docs"]
+
+
+# --- forgetting one on purpose ----------------------------------------------
+
+async def test_forgetting_a_session_closes_its_browsers_and_unlists_it(registry):
+    """Known-bad: have `session_forget` erase the file without closing the
+    browsers. They stay running, holding their memory and their profiles, with
+    nothing left that names them - the leak being unreachable engines rather
+    than a wrong answer.
+    """
+    await server.browser_open(browser_id="docs", session_id="work")
+    running = registry.peek("work/docs")
+
+    said = await server.session_forget(session_id="work")
+
+    assert running.closed, "the session was forgotten with its browser still up"
+    assert store.load("work") is None
+    assert "work" in said
+    assert server.browsers_in("work") == []
+
+
+async def test_forgetting_a_session_that_was_never_saved_says_so(registry):
+    """A tool that answers "done" to a session that never existed teaches a
+    model that the name it used was right.
+
+    Known-bad: return the same sentence in both branches.
+    """
+    said = await server.session_forget(session_id="never-existed")
+    assert "no saved session" in said, said
+
+
+async def test_closing_the_last_browser_stops_the_session_being_listed(registry):
+    """A session here IS its browsers, so one with none left has nothing to
+    reopen, and leaving it listed offers a reopen that gives back nothing.
+
+    Known-bad: drop the `store.erase` from `remember`'s empty branch. The
+    session list then fills with names that restore to nothing.
+    """
+    await server.browser_open(browser_id="docs")
+    assert store.load("default") is not None
+
+    await server.browser_close(browser_id="docs")
+
+    assert store.load("default") is None
+    assert "no saved sessions yet" in await server.session_list()

--- a/tests/mcp_server/test_addressing.py
+++ b/tests/mcp_server/test_addressing.py
@@ -60,13 +60,15 @@ class _Recording:
 def registry(monkeypatch):
     """The REAL registry, with nothing behind it that opens a browser.
 
-    Real on purpose. What the tools have to get right is the key they hand it,
-    and a stand-in would have to reimplement the per-key locking and discarding
-    the assertions below lean on - at which point the tests would be measuring
-    the stand-in.
+    Real on purpose, and built by the server's own constructor. What the tools
+    have to get right is the key they hand it, and a stand-in would have to
+    reimplement the per-key locking and discarding the assertions below lean on -
+    at which point the tests would be measuring the stand-in. `new_registry`
+    rather than `SessionRegistry` for the same reason one step further out: the
+    product's registry writes its sessions down, and a bare one does not.
     """
-    reg = SessionRegistry(factory=_Recording,
-                          defaults=lambda: {"seed": 7, "headless": True})
+    reg = server.new_registry(factory=_Recording,
+                              defaults=lambda: {"seed": 7, "headless": True})
     monkeypatch.setattr(server, "registry", reg)
     return reg
 
@@ -227,6 +229,37 @@ def test_the_registry_still_has_methods_worth_guarding():
         "calls, so the scan below guards nothing: %r" % sorted(ADDRESSABLE))
 
 
+def test_the_exempted_helpers_are_still_the_ones_they_name():
+    """An exemption that names nothing exempts nothing, and reads as though it
+    does - which is worse than no exemption at all, because the next reader
+    takes it for a description of the module.
+    """
+    absent = sorted(n for n in WALK_KEYS_THE_REGISTRY_ALREADY_HOLDS
+                    if not callable(getattr(server, n, None)))
+    assert not absent, (
+        "exempted from the address scan but no longer in the server: %r. "
+        "Either the function was renamed, in which case rename it here, or it "
+        "is gone, in which case delete the exemption." % absent)
+
+
+#: The two functions that walk keys the registry ALREADY holds, rather than
+#: composing one for a caller.
+#:
+#: ⛔ EXEMPTED BY NAME, for the same reason `browser_list` is exempted below:
+#: loosening the rule would cost it the case it exists for. `remember` iterates
+#: `registry.declared()`, whose entries are composed keys by construction, and
+#: asks `registry.config(key)` about each; `restore` writes one back with
+#: `registry.declare("%s/%s" % ...)`. Neither is answering a caller who named a
+#: browser - they are the persistence of the whole session - so `addressed()`
+#: has nothing to compose from, and requiring it there would mean writing a call
+#: that means nothing to satisfy a scanner.
+#:
+#: The names are asserted to still exist before they are trusted: an exemption
+#: that has rotted into a name nothing matches protects nothing while reading as
+#: though it does.
+WALK_KEYS_THE_REGISTRY_ALREADY_HOLDS = {"remember", "restore"}
+
+
 def _scan_registry_calls():
     """Every `registry.<addressable>(...)` in the server, and whether it carries
     an address.
@@ -239,6 +272,9 @@ def _scan_registry_calls():
     unaddressed, checked = [], {}
 
     for holder in ast.walk(tree):
+        if (isinstance(holder, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and holder.name in WALK_KEYS_THE_REGISTRY_ALREADY_HOLDS):
+            continue
         if not isinstance(holder, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
         bound = set()
@@ -331,16 +367,21 @@ async def test_every_tool_that_reaches_a_browser_offers_a_way_to_name_it():
     the SCHEMA the server publishes, not the Python signature: a parameter the
     client cannot see is a parameter that does not exist.
 
-    ⛔ ONE EXEMPTION, and it is about the question rather than about the tool.
-    `browser_list` asks which browsers a SESSION holds, which is not a question
-    any one browser can answer, so it takes a session and no browser on purpose.
-    Exempting it by name rather than by loosening the rule to "one of the two"
+    ⛔ TWO EXEMPTIONS, and both are about the QUESTION rather than about the
+    tool. `browser_list` asks which browsers a SESSION holds and `session_forget`
+    deletes a whole session, closing every browser in it; neither is a question
+    one browser can answer, so both take a session and no browser on purpose.
+    They reach the registry per browser - that is what makes the scan find them -
+    but the browsers are the ones the session already has, not one a caller
+    named.
+
+    Exempting them by name rather than by loosening the rule to "one of the two"
     keeps the rule able to catch the case it exists for: a tool that acts on a
     browser and cannot say which.
 
     Known-bad: delete `session_id` and `browser_id` from any one tool.
     """
-    ASKS_ABOUT_THE_SESSION = {"browser_list"}
+    ASKS_ABOUT_THE_SESSION = {"browser_list", "session_forget"}
     needing = _tools_that_reach_a_browser() - ASKS_ABOUT_THE_SESSION
     assert len(needing) >= 18, (
         "only %d tools were found reaching a browser; has the module moved? %r"
@@ -348,6 +389,10 @@ async def test_every_tool_that_reaches_a_browser_offers_a_way_to_name_it():
 
     published = {t.name: set(t.inputSchema.get("properties", {}))
                  for t in await server.mcp.list_tools()}
+    gone = sorted(ASKS_ABOUT_THE_SESSION - set(published))
+    assert not gone, (
+        "exempted from needing a browser id, but the server no longer offers "
+        "them: %r. An exemption that names nothing exempts nothing." % gone)
     unknown = sorted(needing - set(published))
     assert not unknown, "found in the source but not registered: %r" % unknown
 

--- a/tests/mcp_server/test_browsers_in_a_session.py
+++ b/tests/mcp_server/test_browsers_in_a_session.py
@@ -151,16 +151,35 @@ async def test_two_sessions_do_not_share_their_browsers_or_their_focus(registry)
 
 
 async def test_the_count_is_read_from_the_registry_and_not_from_a_second_list(registry):
-    """A browser dropped underneath - which a failed retry does - has to free
-    its slot.
+    """What frees a slot is the registry forgetting a browser, and nothing else.
 
-    Known-bad: keeping the browsers in a list beside the registry. The dropped
-    one stays in it, and the ceiling then refuses a slot that is free.
+    ⛔ THE TWO HALVES ARE THE `drop`/`forget` DISTINCTION, COUNTED. A `drop` is
+    what a failed retry does: the engine is gone, the person is not, and the
+    next command aimed at that name brings the SAME browser back with its seed,
+    its exit and its profile. So it still holds its slot - eight slots that a
+    dead engine vacated would let a session own nine identities and call it
+    eight. Only `forget`, which is what closing a browser does, gives the slot
+    back, because after it there is nobody left to come back.
+
+    Known-bad, and it is the reason this test is phrased about the source of
+    the count rather than about either verb: keep the browsers in a list beside
+    the registry. The list has no idea what `forget` did, so the second half
+    goes red - a slot whose owner was deliberately closed stays taken forever.
     """
     for i in range(server.MAX_BROWSERS_PER_SESSION):
         await server.browser_open(browser_id="b%d" % i)
 
     await registry.drop("default/b3")
+
+    assert "b3" in server.browsers_in(), (
+        "a browser whose engine died stopped being one of the session's "
+        "browsers, so the identity it comes back as is now nobody's")
+    refused = await server.browser_open(browser_id="one-too-many")
+    assert "one-too-many" not in server.browsers_in(), (
+        "a dead engine handed its slot away while its owner still had it: %r"
+        % refused)
+
+    await registry.forget("default/b3")
 
     assert "b3" not in server.browsers_in()
     said = await server.browser_open(browser_id="replacement")

--- a/tests/mcp_server/test_registry.py
+++ b/tests/mcp_server/test_registry.py
@@ -158,3 +158,70 @@ async def test_close_all_closes_every_session():
 
 async def _noop():
     return None
+
+
+@pytest.mark.asyncio
+async def test_the_change_hook_fires_where_who_a_browser_is_actually_changes():
+    """The hook is how a session gets written down without every caller having
+    to remember to write it down. Which calls fire it is the whole contract, and
+    the two that must NOT fire are the ones that would do damage.
+
+    `drop` is recovery - the engine died, the person did not - so firing there
+    would record a browser as gone while its owner still holds it. `close_all`
+    discards every identity because the PROCESS is ending, and firing there
+    would write every session down as empty at shutdown, which for the server's
+    hook means erasing every saved session as its last act.
+
+    Known-bad: fire from `drop`, and fire from `close_all`.
+    """
+    fired = []
+    reg = SessionRegistry(factory=_Healthy, on_change=fired.append)
+
+    await reg.ensure("one")
+    assert fired == ["one"], "a browser gained an identity and nothing said so"
+
+    await reg.ensure("one")
+    assert fired == ["one"], "a browser that was already up fired the hook again"
+
+    await reg.restart("two", seed=1)
+    assert fired == ["one", "two"]
+
+    await reg.drop("two")
+    assert fired == ["one", "two"], (
+        "a browser whose engine died was reported as changed, but `drop` keeps "
+        "the identity so the same person comes back")
+
+    await reg.forget("two")
+    assert fired == ["one", "two", "two"], "forgetting an identity said nothing"
+
+    await reg.forget("never-existed")
+    assert fired == ["one", "two", "two"], "forgetting nothing fired the hook"
+
+    await reg.close_all()
+    assert fired == ["one", "two", "two"], (
+        "shutdown reported every session as changed; for the server's hook that "
+        "erases every saved session as the process ends")
+
+
+@pytest.mark.asyncio
+async def test_a_hook_that_raises_does_not_cost_the_caller_the_browser():
+    """By the time the hook runs the browser is built and correct. Whatever the
+    hook does - writing a file, on the server - failing at it must cost that and
+    nothing else.
+
+    â THIS IS NOT COVERED BY THE SERVER'S OWN TESTS, and that was measured: the
+    server's `remember` guards its own write, so removing this try/except left
+    every persistence test green. A guard nothing exercises is a guard nobody
+    knows is gone, and `on_change` is public - the next caller to set one need
+    not be as careful as this one.
+
+    Known-bad: remove the try/except from `SessionRegistry._changed`.
+    """
+    def _explode(_key):
+        raise OSError("no space left on device")
+
+    reg = SessionRegistry(factory=_Healthy, on_change=_explode)
+
+    session = await reg.ensure("one")
+    assert session is not None
+    assert reg.ids() == ["one"]

--- a/tests/mcp_server/test_server_list.py
+++ b/tests/mcp_server/test_server_list.py
@@ -35,6 +35,12 @@ async def test_server_registers_expected_tools():
         # `browser_list` takes a session and no browser on purpose - what a
         # session holds is not a question one browser can answer.
         "browser_open", "browser_close", "browser_list", "browser_focus",
+        # Added in 0.16.0, when sessions started surviving the process. Without
+        # these two a saved session could be reopened only by knowing its id
+        # already, and could never be deleted at all - so the directory of them
+        # grew forever with no way to see it or empty it from the surface that
+        # fills it.
+        "session_list", "session_forget",
     }
     # EXACT, not a subset. `expected <= names` passed while a tool nobody
     # meant to publish sat in the list, and the surface of an MCP server is


### PR DESCRIPTION
A session was a dictionary that died with the server, so "reopen the one I was working in" meant nothing and an identity built up over an hour went with the process.

What is saved now is the declaration: which browsers a session has, who each one is, and which one commands were going to. Not eight live browsers - eight of those were measured at 61 processes and about 6.5 GB, the eighth taking 13.6 s to start, so a reopen that launched them all would spend a minute and most of the machine on something nobody asked for yet. The engines come back one at a time, when a command is aimed at one, as the right person.

Two tools go with it. `session_list` finds the session you were in; `session_forget` deletes one, closing its browsers, which is not the same as closing browsers and keeping the session.

Three things this got wrong first, all of them silent:

- The write was hooked to `browser_open`, `browser_close` and `browser_focus`, which is three of the five places a browser gets an identity. `session_start` was missed, and so was the lazy auto-start that every client written before browsers had names uses, so the one session almost everybody has was the only one never saved. The registry now says when a key gains or loses an identity, because the thing that knows a browser became somebody is the registry and not its callers.
- The saved fields were named from the tool's vocabulary - `seed`, `proxy`, `profile` - and the launch kwarg is `profile_dir`, so the filter matched nothing and the profile was the single field never written. Every browser came back with the right seed and the right exit, logged out, which is the one thing a person reopens a session for. The list is now checked against what the planner actually produces, in both directions.
- Reading the session back happened only in `browsers_in`, so a server that had just restarted gave the right browsers to a client that asked what the session held, and a brand new stranger to one that simply navigated.

Sixteen new tests, each carrying the known-bad input that turns it red, and all fifteen mutations were run and killed before this was trusted. `tests/conftest.py` points `AIHAWK_HOME` at a temporary directory for every test, because the first run of these wrote three real files into the developer's own `%APPDATA%` and the next test read them back.