### PR TITLE
session_forget deleted the session and then said it had never existed (0.16.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.16.0"
+version = "0.16.1"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/mcp/server.py
+++ b/src/aihawk/mcp/server.py
@@ -380,10 +380,19 @@ async def session_forget(session_id: str) -> str:
     comes back.
     """
     restore(session_id)
+    # ⛔ ASKED BEFORE ANYTHING IS CLOSED, and the order is the whole bug. Closing
+    # the last browser makes the registry report the change, which writes the
+    # session down, which - having no browsers left - ERASES the file. So by the
+    # time the erase below runs there is nothing left to erase, and reading the
+    # answer of that erase told the caller that a session it had just deleted
+    # had never existed. The deletion was always right; the sentence was not,
+    # and a model that reads "there is no saved session called X" concludes the
+    # name it used was wrong and goes looking for another one.
+    existed = store.load(session_id) is not None or bool(browsers_in(session_id))
     for name in browsers_in(session_id):
         await registry.forget(addressed(session_id, name))
     _focus.pop(session_id, None)
-    existed = store.erase(session_id)
+    store.erase(session_id)
     return ("session %s is gone." % session_id if existed
             else "there is no saved session called %s." % session_id)
 

--- a/tests/mcp_server/test_a_session_survives_the_process.py
+++ b/tests/mcp_server/test_a_session_survives_the_process.py
@@ -361,6 +361,14 @@ async def test_forgetting_a_session_closes_its_browsers_and_unlists_it(registry)
     browsers. They stay running, holding their memory and their profiles, with
     nothing left that names them - the leak being unreachable engines rather
     than a wrong answer.
+
+    ⛔ AND THE ASSERTION ON WHAT IT SAYS IS THE POINT OF THE THIRD LINE, because
+    the first version of it was `"work" in said` and that is satisfied by BOTH
+    sentences this tool can answer - including "there is no saved session called
+    work", which is what it really said for one release. The deletion was right
+    the whole time; the report was not, and only a check in a clean environment
+    caught it. An assertion that cannot tell a tool's two answers apart is not
+    checking the answer, it is checking that the id got echoed.
     """
     await server.browser_open(browser_id="docs", session_id="work")
     running = registry.peek("work/docs")
@@ -369,7 +377,9 @@ async def test_forgetting_a_session_closes_its_browsers_and_unlists_it(registry)
 
     assert running.closed, "the session was forgotten with its browser still up"
     assert store.load("work") is None
-    assert "work" in said
+    assert said == "session work is gone.", (
+        "a session that WAS deleted was reported as never having existed, so a "
+        "model reading this goes looking for a different name: %r" % said)
     assert server.browsers_in("work") == []
 
 


### PR DESCRIPTION
Found by trying 0.16.0 in a clean environment, from the index, doing what a person does: forget a saved session, and the tool answers `there is no saved session called lavoro` about the session it has just deleted.

The deletion was correct throughout. Only the sentence was wrong, and it is the sentence a model reads: told the name does not exist, it goes looking for another one.

The cause is an order. Closing the last browser makes the registry report that the key lost its identity, which writes the session down, which - having no browsers left - erases the file. So the erase at the end had nothing left to erase, and its answer was being read as "did this session exist". It is now asked before anything is closed.

The test that should have caught it is fixed in the same commit, because it is the more useful half. It asserted `"work" in said`, which is true of BOTH sentences the tool can answer, so it passed on the wrong one for a whole release.