### PR TITLE
A column of sessions, and each one drives its own browsers (0.17.0)

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -143,7 +143,7 @@ between what the browser says it is and where it appears to be.
 | `STEALTHFOX_MCP_TRANSPORT` | `http` to serve over streamable HTTP instead of stdio. Default is stdio, which is what MCP clients expect. |
 | `STEALTHFOX_MCP_HOST` | Bind address for the HTTP transport. Default `127.0.0.1`. |
 | `STEALTHFOX_MCP_PORT` | Port for the HTTP transport. Default `8765`, which is also the AIHawk interface's default: change one of the two if you run both. |
-| `AIHAWK_HOME` | Where saved sessions are kept. Defaults to `%APPDATA%ihawk` on Windows, `~/Library/Application Support/aihawk` on macOS and `$XDG_DATA_HOME/aihawk` on Linux. Set it to put them on another disk. |
+| `AIHAWK_HOME` | Where saved sessions are kept. Defaults to `%APPDATA%/aihawk` on Windows, `~/Library/Application Support/aihawk` on macOS and `$XDG_DATA_HOME/aihawk` on Linux. Set it to put them on another disk. |
 
 Anything a tool call says wins over these. `session_start` can pick another
 seed, another exit or another profile for one session; the variables are what a
@@ -200,6 +200,12 @@ default. A session holds up to eight browsers, so two accounts CAN be live at
 the same time: open a second browser with `browser_open` and address commands to
 whichever one you mean. `session_start` still replaces the browser you are in
 rather than adding one, which is the difference between the two.
+
+**The interface's session column lists these same sessions.** A conversation
+in `aihawk ui` and a session here are one thing with one id: the chat named
+`lavoro` drives the browsers of session `lavoro` and no others, and deleting it
+there closes them. A client that names no session and a page that names none
+both land on `default`, which is why they share a browser.
 
 Sessions are written down as soon as one holds a browser, and what is written is
 the DECLARATION - which browsers a session has, who each one is, and where its

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.16.1"
+version = "0.17.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/brain.py
+++ b/src/aihawk/brain.py
@@ -63,6 +63,25 @@ class OpenRouterBrain(Brain):
         """
         self._convo = Conversation(self._convo.client, self._convo.model)
 
+    def remember(self, messages: list, usage: dict | None = None) -> None:
+        """Take up a transcript that was written down, and continue it.
+
+        The twin of `forget`, and the reason it exists is the same one stated
+        there from the other side: what the follow-up box means is the
+        transcript. A session reopened with the page showing the conversation
+        and the model holding nothing would answer "and now sort them by price"
+        with a question about what "them" is - worse than an empty chat, because
+        it looks like it remembers.
+
+        Written into the conversation this brain already has rather than by
+        building a new one: the client and the model are this process's, and the
+        file has no business deciding either.
+        """
+        if messages:
+            self._convo.messages = list(messages)
+        if usage:
+            self._convo.usage.update(usage)
+
     @property
     def usage(self) -> dict:
         return self._convo.usage

--- a/src/aihawk/cli.py
+++ b/src/aihawk/cli.py
@@ -136,7 +136,7 @@ def ui(openrouter_key, model, host, port, proxy, seed, headed, binary, profile_d
     from .brain import OpenRouterBrain
     from .link import Link
     from .llm import make_client
-    from .web import ChatService, build_app
+    from .web import Sessions, build_app
 
     key = openrouter_key or os.environ.get("OPENROUTER_API_KEY")
     if not key:
@@ -146,7 +146,11 @@ def ui(openrouter_key, model, host, port, proxy, seed, headed, binary, profile_d
             "the invisible_playwright library directly: same engine, "
             "Playwright's whole API.")
     mdl = resolve_model(model, os.environ)
-    brain = OpenRouterBrain(make_client(key), mdl)
+    # ONE client, a brain PER CONVERSATION. The client is a connection and the
+    # brain is a transcript: sharing the first is what it is for, and sharing
+    # the second would give every session in the column the same memory, so
+    # asking one thing in a session would answer with another session's work.
+    client = make_client(key)
     label = mdl
     click.echo("model    %s via %s" % (mdl, BASE_URL))
 
@@ -159,8 +163,9 @@ def ui(openrouter_key, model, host, port, proxy, seed, headed, binary, profile_d
         link = await Link(opts, key=key).open()
         click.echo("server   connected, %d tools" % len(link.tools))
         click.echo("open     http://%s:%d" % (host, port))
-        service = ChatService(link, brain, model_label=label)
-        app = build_app(link, service)
+        sessions = Sessions(link, lambda: OpenRouterBrain(client, mdl),
+                            model_label=label)
+        app = build_app(link, sessions)
         server = uvicorn.Server(uvicorn.Config(app, host=host, port=port,
                                                log_level="warning"))
         try:

--- a/src/aihawk/link.py
+++ b/src/aihawk/link.py
@@ -134,3 +134,71 @@ def image_of(result) -> "tuple[bytes, str] | None":
         except Exception:
             continue
     return None
+
+
+class SessionLink:
+    """One session's view of the shared connection: every call carries its id.
+
+    ⛔ WITHOUT THIS THE SESSION COLUMN IS DECORATION. The interface holds several
+    conversations now, and the server has addressed browsers per session since
+    0.15.0 - but a tool call that names no session lands on the default one, so
+    two conversations would drive the SAME browser while each drew its own
+    transcript. Nothing would fail: the second session would find the first
+    one's tabs, its cookies and its identity, and read them as its own.
+
+    The id is IMPOSED, not defaulted. A model that passes `session_id` itself -
+    because it read one in a tool result, or guessed - has it overwritten rather
+    than honoured. Letting it through would mean the thing that decides which
+    person's browser a command reaches is the model, and a model that names
+    another session's id gets that session's logins. Which session a
+    conversation belongs to is not a modelling decision.
+
+    Which tools take an address is read from the SCHEMA the server publishes,
+    never from a list written here: a list drifts, and the failure it produces
+    is a tool called with an argument it does not accept, which is an error the
+    person sees instead of the browser they meant.
+    """
+
+    def __init__(self, link: "Link", session_id: str) -> None:
+        self._link = link
+        self._session_id = session_id
+        #: Whether THIS session has ever issued an instruction. Per session and
+        #: not per connection, and the difference is a browser nobody asked for:
+        #: the live pane is allowed to ask for a picture only once a browser
+        #: could exist, and over MCP there is no way to ask "is one running"
+        #: without starting one. Delegating to the shared link would make every
+        #: NEW conversation inherit the answer from an old one, so opening a
+        #: second chat would launch an engine to draw a pane for a session that
+        #: has done nothing.
+        self._touched = False
+        self._addressable = {
+            t.name for t in link.tools
+            if "session_id" in (getattr(t, "inputSchema", None) or {}).get(
+                "properties", {})
+        }
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def tools(self):
+        return self._link.tools
+
+    @property
+    def touched(self) -> bool:
+        return self._touched
+
+    def addresses(self, name: str) -> bool:
+        """Whether a call to this tool will carry the session id."""
+        return name in self._addressable
+
+    async def call(self, name: str, arguments: dict | None = None):
+        args = dict(arguments or {})
+        if name in self._addressable:
+            args["session_id"] = self._session_id
+        self._touched = True
+        return await self._link.call(name, args)
+
+    async def call_text(self, name: str, arguments: dict | None = None) -> str:
+        return text_of(await self.call(name, arguments))

--- a/src/aihawk/mcp/store.py
+++ b/src/aihawk/mcp/store.py
@@ -139,3 +139,95 @@ def erase(session_id: str) -> bool:
         return False
     except Exception:
         return False
+
+
+# --- the other half of a session: its conversation ---------------------------
+#
+# ⛔ A SEPARATE FILE, WRITTEN BY A SEPARATE PROCESS, AND THAT IS THE REASON.
+# The browsers above are written by the MCP SERVER; a conversation is written by
+# the INTERFACE, which reaches the server over stdio and is therefore another
+# program. One file with two writers is a race that costs somebody their
+# transcript on the day two writes land together, and neither process can see
+# the other to take a lock. So the session id is the join key and each writer
+# owns its own file, which is also why the conversation does not live under
+# `sessions/`: `known()` globs that directory, and a chat file landing in it
+# would be listed as a session with no browsers.
+#
+# What is saved is the transcript as the PAGE draws it plus the transcript as
+# the MODEL holds it. Saving only the first would give somebody back a
+# conversation they can read and cannot continue - the follow-up box would still
+# be there, meaning nothing.
+
+
+def _chats_dir() -> Path:
+    return home() / "chats"
+
+
+def chat_path(session_id: str) -> Path:
+    return _chats_dir() / ("%s.json" % _safe(session_id))
+
+
+def save_chat(session_id: str, name: str, history: List[dict],
+              messages: List[dict], usage: Optional[dict] = None) -> Path:
+    """Write one conversation down. Returns where it went."""
+    where = chat_path(session_id)
+    where.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "id": session_id,
+        "name": name,
+        "saved": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "history": history,
+        "messages": messages,
+        "usage": usage or {},
+    }
+    blob = json.dumps(payload, indent=2).encode("utf-8")
+    beside = where.with_suffix(".json.writing")
+    beside.write_bytes(blob)
+    os.replace(beside, where)
+    return where
+
+
+def load_chat(session_id: str) -> Optional[dict]:
+    """One conversation as it was written, or None if there is nothing to read."""
+    try:
+        return json.loads(chat_path(session_id).read_bytes().decode("utf-8"))
+    except Exception:
+        return None
+
+
+def known_chats() -> List[dict]:
+    """Every saved conversation, newest first, WITHOUT its transcript.
+
+    The list is drawn every time somebody opens the page, and a session that has
+    been worked in all afternoon holds a transcript of thousands of lines.
+    Reading them all to show a column of names would make the cheapest thing the
+    interface does the most expensive.
+    """
+    out = []
+    try:
+        files = sorted(_chats_dir().glob("*.json"))
+    except Exception:
+        return out
+    for f in files:
+        try:
+            d = json.loads(f.read_bytes().decode("utf-8"))
+        except Exception:
+            continue
+        out.append({"id": d.get("id") or f.stem,
+                    "name": d.get("name") or d.get("id") or f.stem,
+                    "saved": d.get("saved") or "",
+                    "turns": sum(1 for e in (d.get("history") or [])
+                                 if e.get("kind") == "you")})
+    out.sort(key=lambda s: s.get("saved") or "", reverse=True)
+    return out
+
+
+def erase_chat(session_id: str) -> bool:
+    """Forget a saved conversation. Answers whether there was one."""
+    try:
+        chat_path(session_id).unlink()
+        return True
+    except FileNotFoundError:
+        return False
+    except Exception:
+        return False

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -46,7 +46,8 @@ from starlette.responses import HTMLResponse, JSONResponse, Response, StreamingR
 from starlette.routing import Route
 
 from .brain import Brain
-from .link import Link, image_of, text_of
+from .link import Link, SessionLink, image_of, text_of
+from .mcp import store
 
 # A RAW string. The script below contains \n, \w and \s inside JavaScript
 # literals and regular expressions; in an ordinary triple-quoted string Python
@@ -124,6 +125,45 @@ code,pre,.g,.meta,.badge,#url,#tok{
 [hidden]{ display:none !important }
 
 /* ---------------- panes ---------------- */
+/* The session column is FIXED width and the two panes beside it share what is
+   left, because the column holds names and a name does not get more readable
+   with more room, while the transcript and the picture both do. It collapses
+   below 900px rather than squeezing the two things that matter. */
+#rail { width:212px; flex:none; display:flex; flex-direction:column;
+        background:var(--well); border-right:1px solid var(--line-1) }
+#rail h2{ margin:0; padding:var(--s3) var(--s3) var(--s2);
+          font-size:var(--t-label); font-weight:600; letter-spacing:.07em;
+          text-transform:uppercase; color:var(--fg-4) }
+#newchat{ margin:0 var(--s3) var(--s2); padding:7px 10px; border-radius:8px;
+          border:1px solid var(--line-2); background:var(--raised); color:var(--fg);
+          font:inherit; font-size:var(--t-small); text-align:left; cursor:pointer }
+#newchat:hover{ border-color:var(--line-3) }
+#chats{ flex:1; min-height:0; overflow-y:auto; padding:0 var(--s2) var(--s3);
+        /* A long list is cheap to skip past: the rows below the fold are not
+           laid out until they are scrolled to, and Ctrl+F still finds them. */
+        content-visibility:auto; contain-intrinsic-size:auto 600px }
+.chat{ display:flex; align-items:center; gap:6px; width:100%;
+       padding:7px 8px; border:0; border-radius:8px; background:none;
+       color:var(--fg-2); font:inherit; font-size:var(--t-small);
+       text-align:left; cursor:pointer }
+.chat:hover{ background:var(--raised); color:var(--fg) }
+.chat[aria-current="true"]{ background:var(--raised); color:var(--fg); font-weight:600 }
+/* The name is a button so it can be reached by keyboard, and the whole of the
+   user agent's button chrome has to come off or it draws as a raised box with
+   its text centred - which is what shipped in the first screenshot of this
+   column. A row in a list looks like a row. */
+.chat .nm{ flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis;
+           white-space:nowrap; border:0; background:none; color:inherit;
+           font:inherit; text-align:left; padding:0; cursor:pointer }
+.chat .cnt{ flex:none; font-family:var(--mono); font-size:var(--t-label);
+            color:var(--fg-4) }
+.chat .x{ flex:none; width:18px; height:18px; border:0; border-radius:4px;
+          background:none; color:var(--fg-4); cursor:pointer; line-height:1;
+          visibility:hidden }
+.chat:hover .x, .chat:focus-within .x{ visibility:visible }
+.chat .x:hover{ background:var(--line-2); color:var(--fg) }
+@media (max-width:900px){ #rail{ display:none } }
+
 #left { width:44%; min-width:380px; display:flex; flex-direction:column;
         position:relative; border-right:1px solid var(--line-1) }
 #right{ flex:1; min-width:0; display:flex; flex-direction:column; background:var(--well) }
@@ -363,9 +403,15 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
 }
 </style>
 
+<nav id="rail" aria-label="Conversations">
+  <h2>Sessions</h2>
+  <button id="newchat" type="button">+ New session</button>
+  <div id="chats" role="list"></div>
+</nav>
+
 <div id="left">
   <div id="head"><b>AIHawk</b><span class="badge" id="model">no model</span>
-    <button id="fresh" type="button" title="New conversation">New</button></div>
+    <button id="fresh" type="button" title="Clear this conversation">Clear</button></div>
   <div id="log">
     <div id="thread">
       <div id="hint">
@@ -601,8 +647,27 @@ function settleOnce(){
   settle = setTimeout(() => { pinned = true; anchor.scrollIntoView({block:'end'}); }, 150);
 }
 
-const es = new EventSource('/chat/events');
-es.onmessage = (e) => {
+/* ---------------- which conversation this page is in ----------------
+   ⛔ ONE PLACE, AND EVERY REQUEST GOES THROUGH IT. The server routes all read
+   `?s=`, so a fetch that forgets it acts on the DEFAULT conversation while the
+   page shows another - and the way that shows up is the picture on the right
+   belonging to somebody else's browser, with nothing red anywhere. `at()` is
+   the only thing that writes the parameter, so there is one place to be wrong
+   and it is covered by a test that reads this file.
+
+   The id is kept in the URL rather than in a variable, so a reload, a bookmark
+   and a second tab all land in the same conversation instead of silently
+   dropping to the default one. */
+let here = new URLSearchParams(location.search).get('s') || 'default';
+const at = (path) => path + (path.includes('?') ? '&' : '?') + 's=' + encodeURIComponent(here);
+
+let es = null;
+function listen(){
+  if(es) es.close();
+  es = new EventSource(at('/chat/events'));
+  es.onmessage = onEvent;
+}
+const onEvent = (e) => {
   const m = JSON.parse(e.data), r = m.replay;
   switch(m.kind){
     case 'model': $('model').textContent = m.text; break;
@@ -615,6 +680,12 @@ es.onmessage = (e) => {
       /* Not on a replay: those events describe a wait that is over. */
       if(busyNow && !r) waiting(); else waited();
       if(!busyNow){ flush(true, r); live = null; clearInterval(timer);
+                    /* The name of a conversation is decided by its FIRST
+                       instruction, on the server, so the column is stale from
+                       the moment a new session is used until it is redrawn.
+                       Redrawn on the end of a turn and not on its start: the
+                       turn count beside the name is only right once. */
+                    if(!r) drawChats();
                     if(queued){ const t = queued; queued = null; send(t); } }
       paint(); break;
     case 'you':   flush(false, r); live = null; newTurn();
@@ -676,7 +747,7 @@ i.addEventListener('keydown', e => {
 document.addEventListener('keydown', e => {
   if(e.key !== 'Escape' || !busyNow) return;
   if(document.activeElement === i && i.value.trim()) return;
-  fetch('/chat/stop', {method:'POST'});
+  fetch(at('/chat/stop'), {method:'POST'});
 });
 /* A pencil and not a cross: a cross would read as "cancel the queued message".
    This returns it to the composer to be edited. */
@@ -684,7 +755,7 @@ chip.onclick = () => { i.value = queued; queued = null; i.focus();
                        i.dispatchEvent(new Event('input')); };
 
 function send(text){
-  fetch('/chat/send', {method:'POST', headers:{'Content-Type':'application/json'},
+  fetch(at('/chat/send'), {method:'POST', headers:{'Content-Type':'application/json'},
                        body: JSON.stringify({text})});
 }
 /* Clearing the page is NOT what this does, and the difference is the point:
@@ -704,9 +775,9 @@ function wipe(){
   busyNow = false;
   queued = null; paint();
 }
-fresh.onclick = () => fetch('/chat/fresh', {method:'POST'});
+fresh.onclick = () => fetch(at('/chat/fresh'), {method:'POST'});
 
-halt.onclick = () => fetch('/chat/stop', {method:'POST'});
+halt.onclick = () => fetch(at('/chat/stop'), {method:'POST'});
 f.onsubmit = (e) => {
   e.preventDefault();
   const t = i.value.trim();
@@ -747,7 +818,7 @@ $('mode').onclick = (e) => {
 
 async function tick(){
   if(!frozen) try {
-    const r = await fetch('/live/frame?t=' + Date.now(), {cache:'no-store'});
+    const r = await fetch(at('/live/frame?t=' + Date.now()), {cache:'no-store'});
     if(r.status === 204){ img.hidden = true; empty.hidden = false; say('idle'); }
     else if(r.ok){
       const blob = await r.blob(), old = img.src;
@@ -825,30 +896,106 @@ function paintTabs(rows){
    through the same tool an agent would call. */
 $('tabs').onclick = (e) => {
   const b = e.target.closest('button'); if(!b) return;
-  fetch('/live/select', {method:'POST', headers:{'Content-Type':'application/json'},
+  fetch(at('/live/select'), {method:'POST', headers:{'Content-Type':'application/json'},
                          body: JSON.stringify({id: b.dataset.id})});
 };
 
 async function where(){
-  try { const r = await fetch('/live/tabs', {cache:'no-store'});
+  try { const r = await fetch(at('/live/tabs'), {cache:'no-store'});
         if(r.ok){ const j = await r.json(); paintUrl(j.url || ''); paintTabs(j.tabs); } }
   catch(err){}
   setTimeout(where, 2000);
 }
-paint(); tick(); where();
+/* ---------------- the session column ----------------
+   Drawn from the server every time it changes rather than kept in step by hand:
+   a name is set by the FIRST INSTRUCTION of a conversation, which happens on
+   the server, so a column the page maintained locally would be right until
+   somebody actually used a session. */
+async function drawChats(){
+  let rows = [];
+  try { const r = await fetch('/sessions', {cache:'no-store'});
+        if(r.ok) rows = (await r.json()).sessions || []; }
+  catch(err){ return; }
+  const box = $('chats');
+  box.textContent = '';
+  for(const s of rows){
+    const row = el('div','chat');
+    row.setAttribute('role','listitem');
+    if(s.id === here) row.setAttribute('aria-current','true');
+    const open = el('button', 'nm', s.name || s.id);
+    open.type = 'button';
+    open.title = s.name || s.id;
+    /* Switching is a NAVIGATION, not a repaint: the transcript, the picture and
+       the stream all belong to the conversation, and the server hands back the
+       whole of it for an id. Rebuilding that by hand would be a second
+       implementation of what a page load already does correctly. */
+    open.onclick = () => { if(s.id !== here) location.search = '?s=' + encodeURIComponent(s.id); };
+    open.ondblclick = () => renameChat(s.id, s.name || s.id);
+    row.appendChild(open);
+    if(s.turns) row.appendChild(el('span','cnt', String(s.turns)));
+    const kill = el('button','x','x');
+    kill.type = 'button';
+    kill.title = 'Delete this session and close its browsers';
+    kill.setAttribute('aria-label', 'Delete ' + (s.name || s.id));
+    kill.onclick = (e) => { e.stopPropagation(); forgetChat(s.id, s.name || s.id); };
+    row.appendChild(kill);
+    box.appendChild(row);
+  }
+}
+
+async function renameChat(id, was){
+  const name = prompt('Name this session', was);
+  if(name === null) return;
+  await fetch('/sessions/rename', {method:'POST', headers:{'Content-Type':'application/json'},
+                                   body: JSON.stringify({id, name})});
+  drawChats();
+}
+
+async function forgetChat(id, name){
+  /* The browsers go with it, and that is worth saying before it happens rather
+     than after: a session can be holding eight logged-in engines. */
+  if(!confirm('Delete "' + name + '"? Its conversation and its browsers go with it.')) return;
+  await fetch('/sessions/forget', {method:'POST', headers:{'Content-Type':'application/json'},
+                                   body: JSON.stringify({id})});
+  if(id === here){ location.search = ''; return; }
+  drawChats();
+}
+
+$('newchat').onclick = async () => {
+  const r = await fetch('/sessions/new', {method:'POST'});
+  if(!r.ok) return;
+  const j = await r.json();
+  location.search = '?s=' + encodeURIComponent(j.id);
+};
+
+paint(); listen(); tick(); where(); drawChats();
 </script>
 """
+
+
+#: The conversation a page that names none is in. The SAME string the server
+#: uses for the session a tool call that names none reaches, and that is the
+#: point rather than a coincidence: every client written before this existed
+#: keeps landing on one conversation driving one browser, exactly as before.
+DEFAULT_CHAT_ID = "default"
+
+#: What a conversation is called before it has been asked anything.
+UNNAMED = "New chat"
 
 
 class ChatService:
     """One conversation, its listeners, and the link it drives."""
 
     def __init__(self, link: Link, brain: Brain,
-                 model_label: str = "no model") -> None:
+                 model_label: str = "no model", *,
+                 session_id: str = DEFAULT_CHAT_ID,
+                 name: str | None = None) -> None:
         self._link = link
         self._brain = brain
         self._listeners: List[asyncio.Queue] = []
         self.history: List[Dict[str, str]] = []
+        self.session_id = session_id
+        self.name = name or UNNAMED
         self.model_label = model_label
         self._busy = asyncio.Lock()
         self._task: Optional[asyncio.Task] = None
@@ -859,6 +1006,62 @@ class ChatService:
         #: Counted from the clock so a restart cannot collide with the run
         #: before it.
         self._epoch = str(int(time.time() * 1000))
+
+    @property
+    def link(self):
+        """The connection this conversation drives, addressed to it.
+
+        Exposed because the LIVE routes need it: the picture and the tab strip
+        belong to this session's browser, and reaching for the shared connection
+        instead would draw whatever the default session happens to be looking
+        at. That is a wrong answer that looks exactly like a right one.
+        """
+        return self._link
+
+    def save(self) -> None:
+        """Write this conversation down as it stands.
+
+        Called when the conversation CHANGES - a turn ended, it was renamed, it
+        was reset - and not on a timer, for the reason the browsers are saved
+        the same way: a file written on a tick is a version of the session that
+        existed only between two ticks.
+
+        ⛔ BOTH TRANSCRIPTS, and saving only one would be a promise the other
+        half cannot keep. The page draws `history`; the model holds `messages`.
+        Reopening with only the first gives somebody a conversation they can
+        read and cannot continue, under a follow-up box that still says "and now
+        sort them by price" will work.
+
+        A write that fails costs the saved conversation and nothing else: the
+        turn is already finished and answered, and losing it to a full disk
+        would be a strange way to report a full disk.
+        """
+        try:
+            store.save_chat(self.session_id, self.name, self.history,
+                            list(getattr(self._brain, "messages", []) or []),
+                            self.usage)
+        except Exception:
+            pass
+
+    def restore(self) -> bool:
+        """Read this conversation back, if one was saved. Answers whether it was.
+
+        The epoch is NOT restored, and that is deliberate: it says which
+        transcript a page's positions belong to, and a page reconnecting from
+        before the restart holds positions into a transcript this process never
+        had. A new epoch makes it replay from the beginning instead of resuming
+        into the middle of something else.
+        """
+        saved = store.load_chat(self.session_id)
+        if not saved:
+            return False
+        self.history = list(saved.get("history") or [])
+        self.name = saved.get("name") or self.name
+        messages = saved.get("messages") or []
+        remember = getattr(self._brain, "remember", None)
+        if callable(remember) and messages:
+            remember(messages, saved.get("usage") or {})
+        return True
 
     def subscribe(self) -> asyncio.Queue:
         q: asyncio.Queue = asyncio.Queue()
@@ -954,6 +1157,13 @@ class ChatService:
             # of the transcript: somebody opening the page mid-run sees what was
             # asked, and a reload does not lose it. The page adding it locally is
             # one line shorter and leaves a conversation with no questions in it.
+            if self.name == UNNAMED:
+                # Named from what it was first asked, because a column of eight
+                # rows that all say "New chat" is a column nobody can use, and
+                # asking somebody to name a conversation before having it is
+                # asking them to describe work they have not done yet.
+                flat = " ".join(text.split())
+                self.name = flat[:48] + ("..." if len(flat) > 48 else "")
             await self.emit("you", text)
             await self.emit("busy", "1")
             try:
@@ -975,32 +1185,188 @@ class ChatService:
                 await self.emit("err", f"{type(exc).__name__}: {exc}")
             finally:
                 await self.emit("busy", "0")
+                # After the turn and not during it: a transcript written
+                # mid-run is a version of the conversation that existed for a
+                # moment, and this is the moment it is worth keeping. Stopped
+                # and failed runs are saved too - what was asked and how far it
+                # got is exactly what somebody reopens the session to see.
+                self.save()
 
 
-def build_app(link: Link, service: ChatService) -> Starlette:
+class Sessions:
+    """Every conversation this interface holds, by id, saved as it goes.
+
+    ⛔ A CONVERSATION AND ITS BROWSERS ARE ONE SESSION, and this class is where
+    that is true rather than nearly true. The id it keys on is the SAME id the
+    server keys browsers on, so the chat called `lavoro` drives the browsers of
+    session `lavoro` and nothing else - which is why `forget` below closes them
+    as well. Two ids would have been easier and would have meant that deleting a
+    conversation left up to eight engines running with nothing naming them.
+
+    The MCP connection underneath is shared on purpose: one server, one process,
+    one place the browsers live. What keeps two conversations from driving each
+    other's browser is `SessionLink`, which puts the id on every call.
+
+    Conversations are built on demand and read from disk the first time they are
+    asked for. They are not all loaded at startup: a transcript is thousands of
+    lines and somebody with twenty sessions wants a column of names, not twenty
+    transcripts in memory to draw it.
+    """
+
+    def __init__(self, link: Link, make_brain, model_label: str = "no model") -> None:
+        self._link = link
+        self._make_brain = make_brain
+        self.model_label = model_label
+        self._live: Dict[str, ChatService] = {}
+
+    @classmethod
+    def around(cls, service: "ChatService") -> "Sessions":
+        """A registry holding one conversation somebody else built.
+
+        For callers that make the conversation themselves - the tests do, and so
+        would anything embedding this - so that having one conversation does not
+        require a second code path through the routes. One path means the single
+        case is exercised by the same code the many-session case uses.
+        """
+        got = cls(service._link, lambda: service._brain, service.model_label)
+        got._live[service.session_id] = service
+        return got
+
+    def get(self, session_id: str | None = None) -> ChatService:
+        """The conversation with this id, loaded from disk the first time."""
+        at = session_id or DEFAULT_CHAT_ID
+        found = self._live.get(at)
+        if found is not None:
+            return found
+        service = ChatService(SessionLink(self._link, at), self._make_brain(),
+                              model_label=self.model_label, session_id=at)
+        service.restore()
+        self._live[at] = service
+        return service
+
+    def new(self) -> ChatService:
+        """A conversation nobody has used yet, with an id of its own.
+
+        The id is the clock, not a counter: a counter has to be stored somewhere
+        to survive a restart, and the place it would be stored is the thing that
+        breaks. It is never shown - the name is - so it only has to be unique.
+        """
+        at = "s%d" % int(time.time() * 1000)
+        while at in self._live or store.load_chat(at) is not None:
+            at += "x"
+        return self.get(at)
+
+    def listing(self) -> List[dict]:
+        """Every conversation, saved or only live, newest first.
+
+        A conversation opened a moment ago has nothing on disk yet, and leaving
+        it out would make the column disagree with the page it is drawn beside.
+        """
+        rows = {r["id"]: dict(r) for r in store.known_chats()}
+        for at, service in self._live.items():
+            row = rows.setdefault(at, {"id": at, "saved": "", "turns": 0})
+            row["name"] = service.name
+            row["turns"] = sum(1 for e in service.history if e.get("kind") == "you")
+            row["live"] = True
+        out = list(rows.values())
+        out.sort(key=lambda r: (r.get("saved") or "", r["id"]), reverse=True)
+        return out
+
+    def rename(self, session_id: str, name: str) -> bool:
+        clean = " ".join((name or "").split())[:80]
+        if not clean:
+            return False
+        service = self.get(session_id)
+        service.name = clean
+        service.save()
+        return True
+
+    async def forget(self, session_id: str) -> bool:
+        """Delete a conversation AND the browsers that belonged to it.
+
+        ⛔ Both halves, because they are one session. Erasing only the chat file
+        would leave up to eight engines running with nothing left that names
+        them - 6.5 GB, measured, unreachable and unkillable short of the task
+        manager. `session_forget` on the server is the tool that does the other
+        half, and it exists for exactly this.
+
+        Refused while that conversation is mid-run: the same reason `reset` is.
+        """
+        service = self._live.get(session_id)
+        if service is not None and service.busy:
+            return False
+        try:
+            await self._link.call("session_forget", {"session_id": session_id})
+        except Exception:
+            # The browsers could not be closed - the server is gone, or it
+            # refused. The conversation is still deleted: leaving it listed
+            # because something else failed would tell somebody the delete did
+            # not work, when the half they were looking at did.
+            pass
+        self._live.pop(session_id, None)
+        return store.erase_chat(session_id) or service is not None
+
+
+def build_app(link: Link, sessions: "Sessions") -> Starlette:
+    def which(request: Request) -> ChatService:
+        """The conversation this request is about.
+
+        ⛔ EVERY ROUTE GOES THROUGH HERE, the live ones included. A route that
+        read the session id and a route that did not would act on two different
+        conversations while the page showed one, and the way that fails is the
+        picture on the right belonging to somebody else's browser. A caller that
+        names nothing gets the default conversation, which is what every page
+        written before this existed does.
+        """
+        return sessions.get(request.query_params.get("s"))
+
     async def root(_request: Request) -> HTMLResponse:
         return HTMLResponse(PAGE)
+
+    async def listing(_request: Request) -> JSONResponse:
+        return JSONResponse({"sessions": sessions.listing(),
+                             "default": DEFAULT_CHAT_ID})
+
+    async def new_session(_request: Request) -> JSONResponse:
+        service = sessions.new()
+        return JSONResponse({"id": service.session_id, "name": service.name})
+
+    async def rename_session(request: Request) -> JSONResponse:
+        body = await request.json()
+        at = (body or {}).get("id") or DEFAULT_CHAT_ID
+        done = sessions.rename(at, (body or {}).get("name", ""))
+        return JSONResponse({"renamed": done, "name": sessions.get(at).name})
+
+    async def forget_session(request: Request) -> JSONResponse:
+        body = await request.json()
+        at = (body or {}).get("id")
+        if not at:
+            return JSONResponse({"error": "no id"}, status_code=400)
+        return JSONResponse({"forgotten": await sessions.forget(at)})
 
     async def send(request: Request) -> JSONResponse:
         body = await request.json()
         text = (body or {}).get("text", "")
         if not text:
             return JSONResponse({"error": "empty"}, status_code=400)
-        service.start(text)
+        which(request).start(text)
         return JSONResponse({"accepted": True})
 
-    async def stop(_request: Request) -> JSONResponse:
-        return JSONResponse({"stopped": service.stop()})
+    async def stop(request: Request) -> JSONResponse:
+        return JSONResponse({"stopped": which(request).stop()})
 
-    async def fresh(_request: Request) -> JSONResponse:
+    async def fresh(request: Request) -> JSONResponse:
+        service = which(request)
         done = service.reset()
         if done:
             # Told to every listener, not just the tab that asked: two tabs on
             # one session must not disagree about what the conversation is.
             await service.emit("fresh", "1")
+            service.save()
         return JSONResponse({"fresh": done})
 
     async def events(request: Request) -> StreamingResponse:
+        service = which(request)
         q = service.subscribe()
         # Freeze the replay/live boundary while subscribing. StreamingResponse
         # starts `stream` later, so taking this snapshot inside it would let an
@@ -1087,7 +1453,7 @@ def build_app(link: Link, service: ChatService) -> Starlette:
         return StreamingResponse(stream(), media_type="text/event-stream",
                                  headers={"Cache-Control": "no-store"})
 
-    async def frame(_request: Request) -> Response:
+    async def frame(request: Request) -> Response:
         """The window the active tab lives in, as `browser_watch` captures it.
 
         Not `browser_take_screenshot`: that is the page alone, and the engine
@@ -1101,13 +1467,16 @@ def build_app(link: Link, service: ChatService) -> Starlette:
         page draws above it are the same facts as elements, and those can be
         clicked and copied. Both stay.
         """
-        if not link.touched:
+        seen = which(request)
+        if not seen.link.touched:
             # 204, not an error: nothing is wrong, there is simply nothing to
             # look at. Asking the server would START a browser, which is exactly
-            # what a view is not allowed to cause.
+            # what a view is not allowed to cause - and it is asked of THIS
+            # conversation, so opening a second chat does not launch an engine
+            # to draw a pane for a session that has done nothing.
             return Response(status_code=204)
         try:
-            result = await link.call("browser_watch")
+            result = await seen.link.call("browser_watch")
         except Exception as exc:
             return JSONResponse({"error": str(exc)[:200]}, status_code=503)
         got = image_of(result)
@@ -1124,7 +1493,7 @@ def build_app(link: Link, service: ChatService) -> Starlette:
         jpeg, mime = got
         return Response(jpeg, media_type=mime, headers={"Cache-Control": "no-store"})
 
-    async def tabs(_request: Request) -> JSONResponse:
+    async def tabs(request: Request) -> JSONResponse:
         """Every tab, and which one is current.
 
         ONE call where there were two. It asks `session_list_pages`, which since
@@ -1138,10 +1507,11 @@ def build_app(link: Link, service: ChatService) -> Starlette:
         parse into those fields leaves the strip empty and the address blank,
         and the pane keeps working as a picture.
         """
-        if not link.touched:
+        seen = which(request)
+        if not seen.link.touched:
             return JSONResponse({"url": "", "tabs": []})
         try:
-            raw = await link.call_text("session_list_pages")
+            raw = await seen.link.call_text("session_list_pages")
             rows = json.loads(raw)
         except Exception:
             return JSONResponse({"url": "", "tabs": []})
@@ -1155,11 +1525,15 @@ def build_app(link: Link, service: ChatService) -> Starlette:
         page_id = (body or {}).get("id", "")
         if not page_id:
             return JSONResponse({"error": "no id"}, status_code=400)
-        await link.call("session_select_page", {"page_id": page_id})
+        await which(request).link.call("session_select_page", {"page_id": page_id})
         return JSONResponse({"ok": True})
 
     return Starlette(routes=[
         Route("/", root),
+        Route("/sessions", listing),
+        Route("/sessions/new", new_session, methods=["POST"]),
+        Route("/sessions/rename", rename_session, methods=["POST"]),
+        Route("/sessions/forget", forget_session, methods=["POST"]),
         Route("/chat/send", send, methods=["POST"]),
         Route("/chat/stop", stop, methods=["POST"]),
         Route("/chat/fresh", fresh, methods=["POST"]),

--- a/tests/test_a_session_reaches_only_its_own_browsers.py
+++ b/tests/test_a_session_reaches_only_its_own_browsers.py
@@ -1,0 +1,164 @@
+"""Every call a session makes carries its own id, and nothing can change that.
+
+⛔ THE FAILURE THIS FILE EXISTS FOR IS SILENT AND IT IS THE WORST KIND. The
+interface holds several conversations now. A tool call that names no session
+lands on the default one, so without this two conversations would drive the SAME
+browser while each drew its own transcript: the second would find the first
+one's tabs, its cookies and its identity, and report them as its own. Nothing
+raises, nothing is red, and the person sees two chats that seem to be doing
+their own work.
+
+No browser and no server here. The link is replaced by one that records what it
+was asked, so what a session did is observable as the arguments that went out.
+"""
+from __future__ import annotations
+
+import pytest
+
+from aihawk.link import SessionLink
+
+
+class _Tool:
+    def __init__(self, name, props):
+        self.name = name
+        self.inputSchema = {"type": "object", "properties": {p: {} for p in props}}
+
+
+class _Recording:
+    """A link that records every call instead of making one."""
+
+    def __init__(self, tools):
+        self.tools = tools
+        self.touched = False
+        self.calls = []
+
+    async def call(self, name, arguments=None):
+        self.calls.append((name, dict(arguments or {})))
+        return None
+
+
+#: What the server actually publishes, in the shape that matters here: some
+#: tools take an address, `session_list` does not.
+TOOLS = [
+    _Tool("browser_navigate", ["url", "session_id", "browser_id"]),
+    _Tool("browser_click", ["selector", "session_id", "browser_id"]),
+    _Tool("browser_list", ["session_id"]),
+    _Tool("session_list", []),
+]
+
+
+def _link(session_id="lavoro"):
+    rec = _Recording(TOOLS)
+    return rec, SessionLink(rec, session_id)
+
+
+async def test_every_addressable_call_carries_this_session_and_no_other():
+    """Known-bad: drop the `args["session_id"] = ...` line. Every call then goes
+    to the default session, and two conversations share one browser.
+    """
+    rec, link = _link("lavoro")
+
+    await link.call("browser_navigate", {"url": "http://127.0.0.1/"})
+    await link.call("browser_click", {"selector": "#go"})
+
+    assert [c[1].get("session_id") for c in rec.calls] == ["lavoro", "lavoro"]
+    assert rec.calls[0][1]["url"] == "http://127.0.0.1/", "the call lost its own arguments"
+
+
+async def test_a_model_cannot_send_a_command_to_another_session(caplog):
+    """⛔ IMPOSED, NOT DEFAULTED, and this is the security half rather than the
+    tidy half. A model that passes `session_id` itself - because it read one in
+    a tool result, or guessed one - must not be obeyed: the id it names decides
+    whose logins the command reaches.
+
+    Known-bad: `args.setdefault("session_id", ...)` instead of assignment. Every
+    other test in this file still passes, because nothing else ever sends one.
+    """
+    rec, link = _link("mio")
+
+    await link.call("browser_navigate", {"url": "http://x/", "session_id": "tuo"})
+
+    assert rec.calls[0][1]["session_id"] == "mio", (
+        "the model chose which session's browser to drive: %r" % rec.calls[0][1])
+
+
+async def test_a_tool_that_takes_no_session_is_not_given_one():
+    """A tool called with an argument it does not accept is an error the person
+    reads instead of the answer they asked for.
+
+    Known-bad: address every tool unconditionally. `session_list` then goes out
+    with an argument its schema does not declare.
+    """
+    rec, link = _link()
+
+    await link.call("session_list", {})
+
+    assert "session_id" not in rec.calls[0][1], rec.calls[0][1]
+
+
+async def test_which_tools_take_an_address_is_read_from_the_schema():
+    """Not from a list written in this package, which drifts from the server the
+    first time a tool is added there.
+
+    Known-bad: replace the schema scan with a hardcoded set of names. This test
+    passes a tool the set has never heard of.
+    """
+    rec = _Recording(TOOLS + [_Tool("browser_teleport", ["session_id"])])
+    link = SessionLink(rec, "lavoro")
+
+    assert link.addresses("browser_teleport"), (
+        "a tool the server published after this code was written is not "
+        "addressed, so it acts on the default session")
+    assert not link.addresses("session_list")
+
+
+async def test_two_sessions_on_one_connection_do_not_mix():
+    """The connection is shared on purpose - one server, one process - so the
+    thing that keeps them apart is this and only this.
+
+    Known-bad: make `session_id` a module-level or class-level value instead of
+    per instance. Both sessions then send whichever was built last.
+    """
+    rec = _Recording(TOOLS)
+    a, b = SessionLink(rec, "uno"), SessionLink(rec, "due")
+
+    await a.call("browser_navigate", {"url": "http://a/"})
+    await b.call("browser_navigate", {"url": "http://b/"})
+    await a.call("browser_navigate", {"url": "http://a2/"})
+
+    assert [c[1]["session_id"] for c in rec.calls] == ["uno", "due", "uno"]
+
+
+async def test_the_session_view_answers_for_the_connection_underneath():
+    """The agent loop is handed this object in place of the link, so anything it
+    reads off the link has to still be there.
+
+    Known-bad: drop the `tools` property. The agent then has no tool definitions
+    to send the model, which fails far from here and looks like a model problem.
+    """
+    rec, link = _link()
+
+    assert link.tools is rec.tools
+
+
+async def test_whether_a_browser_could_exist_is_asked_per_session():
+    """⛔ AND IT IS THE ONE THING THIS VIEW MUST NOT DELEGATE. The live pane may
+    ask for a picture only once a browser could exist, because over MCP there is
+    no way to ask "is one running" without starting one - `browser_watch` calls
+    `ensure`. If this answered for the shared CONNECTION, every new conversation
+    would inherit the answer from an old one, and opening a second chat would
+    launch an engine, 800 MB and seven seconds, to draw a pane for a session
+    that has done nothing.
+
+    Known-bad: `return self._link.touched`. `nuova` below then reports true
+    without having made a single call.
+    """
+    rec = _Recording(TOOLS)
+    vecchia, nuova = SessionLink(rec, "vecchia"), SessionLink(rec, "nuova")
+
+    await vecchia.call("browser_navigate", {"url": "http://x/"})
+
+    assert vecchia.touched is True
+    assert nuova.touched is False, (
+        "a conversation that has done nothing says a browser could exist, so "
+        "its live pane will ask for one and the server will start it")

--- a/tests/test_the_session_column.py
+++ b/tests/test_the_session_column.py
@@ -1,0 +1,376 @@
+"""Several conversations, each with its own transcript and its own browsers.
+
+⛔ WHAT MAKES THIS REAL RATHER THAN DECORATION is that a conversation drives its
+OWN browsers. The server has addressed browsers per session since 0.15.0, and a
+tool call that names no session lands on the default one - so a column that only
+swapped transcripts would have shown two chats quietly sharing one browser, with
+the second finding the first one's tabs, cookies and identity. The addressing
+itself is pinned in `test_a_session_reaches_only_its_own_browsers.py`; this file
+is about the layer above, where conversations are made, listed, saved, reopened
+and deleted.
+
+No browser, no model and no server: the link records what it was asked, the
+brain answers without thinking, and `AIHAWK_HOME` points at a temporary
+directory for every test (see `tests/conftest.py`), so what a conversation did
+is observable as the files and the calls it left behind.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aihawk.mcp import store
+from aihawk.web import DEFAULT_CHAT_ID, UNNAMED, ChatService, Sessions, build_app
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Tool:
+    def __init__(self, name, props):
+        self.name = name
+        self.inputSchema = {"type": "object", "properties": {p: {} for p in props}}
+
+
+class FakeLink:
+    """Shaped like `Link`, recording every call."""
+
+    def __init__(self):
+        self.touched = False
+        self.tools = [_Tool("browser_navigate", ["url", "session_id", "browser_id"]),
+                      _Tool("session_forget", ["session_id"]),
+                      _Tool("session_list_pages", ["session_id", "browser_id"])]
+        self.calls = []
+
+    async def call(self, name, arguments=None):
+        self.touched = True
+        self.calls.append((name, dict(arguments or {})))
+        return None
+
+    async def call_text(self, name, arguments=None):
+        await self.call(name, arguments)
+        return "[]"
+
+
+class Quiet:
+    """A brain with a transcript, so saving and restoring have something to do."""
+
+    def __init__(self):
+        self.messages = [{"role": "system", "content": "you are a browser"}]
+        self.usage = {"prompt": 0, "completion": 0, "calls": 0, "last_prompt": 0}
+
+    def remember(self, messages, usage=None):
+        self.messages = list(messages)
+        if usage:
+            self.usage.update(usage)
+
+    async def handle(self, text, link, say):
+        self.messages.append({"role": "user", "content": text})
+        # It TOUCHES the browser, because a brain that never calls a tool does
+        # not exercise the paths that depend on a browser having been reached -
+        # and one of them, the live pane's, had a mutation survive on exactly
+        # that: the shared connection stayed untouched, so reading it answered
+        # the same as reading the conversation's own.
+        await link.call("browser_navigate", {"url": "http://127.0.0.1/"})
+        await say("said", "done: " + text)
+
+
+def _sessions():
+    link = FakeLink()
+    return link, Sessions(link, Quiet, model_label="a model")
+
+
+# --- making and finding them ------------------------------------------------
+
+async def test_a_page_that_names_nothing_is_in_the_conversation_it_always_was():
+    """⛔ THE PROMISE OF THE WHOLE CHANGE, and it is the same one slice 1 made
+    about browsers. Every page and every client written before sessions existed
+    names none, and must land where it always did - one conversation, driving
+    the default session's browser.
+
+    Known-bad: give the default conversation an invented id such as `main`. The
+    chat then talks to session `main` while every tool default is `default`, so
+    the interface and any other client stop sharing a browser.
+    """
+    _, sessions = _sessions()
+
+    assert sessions.get() is sessions.get(None) is sessions.get(DEFAULT_CHAT_ID)
+    assert sessions.get().session_id == DEFAULT_CHAT_ID
+    assert DEFAULT_CHAT_ID == "default", (
+        "the interface's default conversation and the server's default session "
+        "must be the same id, or they are two sessions wearing one name")
+
+
+async def test_a_new_conversation_is_its_own_and_does_not_touch_the_others():
+    """Known-bad: return the same service from `new`. Two rows appear in the
+    column and both show one transcript.
+    """
+    _, sessions = _sessions()
+    first, second = sessions.new(), sessions.new()
+
+    assert first.session_id != second.session_id
+    assert first is not second
+    assert first.name == second.name == UNNAMED
+
+    await first.send("go to example.com")
+
+    assert second.history == [], "a new conversation was given somebody else's"
+    assert first.name.startswith("go to example.com"), (
+        "a conversation is named by what it was first asked: %r" % first.name)
+
+
+async def test_the_column_shows_conversations_that_have_not_been_saved_yet():
+    """A session opened a moment ago has nothing on disk. Leaving it out makes
+    the column disagree with the page drawn beside it.
+
+    Known-bad: build `listing` from `store.known_chats()` alone.
+    """
+    _, sessions = _sessions()
+    fresh = sessions.new()
+
+    ids = [r["id"] for r in sessions.listing()]
+    assert fresh.session_id in ids, ids
+
+
+# --- surviving the process --------------------------------------------------
+
+async def test_a_conversation_comes_back_with_both_of_its_transcripts():
+    """⛔ BOTH, AND SAVING ONLY ONE WOULD BE A LIE THE OTHER HALF CANNOT KEEP.
+    The page draws `history`; the model holds `messages`. Restoring only the
+    first gives somebody a conversation they can read and cannot continue, under
+    a follow-up box that still looks like "and now sort them by price" will work.
+
+    Known-bad, two: drop `messages` from `save_chat`, and drop the `remember`
+    call from `ChatService.restore`. The first assertion survives both.
+    """
+    _, sessions = _sessions()
+    mine = sessions.get("lavoro")
+    await mine.send("open the dashboard")
+
+    # The process ends. Nothing in memory survives; the disk does.
+    _, again = _sessions()
+    back = again.get("lavoro")
+
+    assert [e["text"] for e in back.history if e["kind"] == "you"] == \
+        ["open the dashboard"]
+    assert any(m.get("content") == "open the dashboard"
+               for m in back._brain.messages), (
+        "the page can read the conversation and the model cannot continue it")
+    assert back.name.startswith("open the dashboard")
+
+
+async def test_a_conversation_is_written_down_when_a_turn_ends_not_on_a_timer():
+    """A server that is killed never reaches a timer's next tick, and killing it
+    is how a person stops it.
+
+    Known-bad: move `save()` out of the `finally` in `send`.
+    """
+    _, sessions = _sessions()
+    mine = sessions.get("lavoro")
+    assert store.load_chat("lavoro") is None
+
+    await mine.send("do the thing")
+
+    saved = store.load_chat("lavoro")
+    assert saved is not None and saved["name"].startswith("do the thing")
+
+
+async def test_a_run_that_failed_is_saved_too():
+    """What was asked and how far it got is exactly what somebody reopens a
+    session to look at, and a turn that failed is the one they reopen soonest.
+
+    Known-bad: save only when the turn succeeded.
+    """
+    class Boom(Quiet):
+        async def handle(self, text, link, say):
+            raise RuntimeError("the model refused")
+
+    link = FakeLink()
+    sessions = Sessions(link, Boom)
+    await sessions.get("lavoro").send("do the impossible")
+
+    saved = store.load_chat("lavoro")
+    assert saved is not None
+    assert any("the model refused" in e["text"] for e in saved["history"])
+
+
+async def test_a_conversation_nobody_saved_reads_back_as_empty_and_not_as_an_error():
+    """Known-bad: let `restore` raise when there is no file. The first time
+    anybody opens a new session the interface answers 500.
+    """
+    _, sessions = _sessions()
+    assert sessions.get("mai-vista").history == []
+
+
+# --- deleting one -----------------------------------------------------------
+
+async def test_deleting_a_conversation_closes_the_browsers_that_belonged_to_it():
+    """⛔ ONE SESSION, BOTH HALVES. Erasing only the chat file would leave up to
+    eight engines running with nothing left that names them: 6.5 GB, measured,
+    unreachable except through the task manager.
+
+    Known-bad: drop the `session_forget` call. Every other assertion here still
+    passes and the leak is invisible from the page.
+    """
+    link, sessions = _sessions()
+    mine = sessions.get("lavoro")
+    await mine.send("log in somewhere")
+
+    assert await sessions.forget("lavoro") is True
+
+    assert ("session_forget", {"session_id": "lavoro"}) in link.calls, (
+        "the conversation is gone and its browsers are still running: %r"
+        % link.calls)
+    assert store.load_chat("lavoro") is None
+    assert "lavoro" not in [r["id"] for r in sessions.listing()]
+
+
+async def test_deleting_a_conversation_that_is_mid_run_is_refused():
+    """The same reason clearing one is: throwing away a transcript something is
+    still writing into is a surprise nobody can undo.
+
+    Known-bad: delete regardless of `busy`.
+    """
+    import asyncio
+
+    class Hanging(Quiet):
+        async def handle(self, text, link, say):
+            await asyncio.sleep(3600)
+
+    link = FakeLink()
+    sessions = Sessions(link, Hanging)
+    mine = sessions.get("lavoro")
+    mine.start("something slow")
+    await asyncio.sleep(0.05)
+
+    assert await sessions.forget("lavoro") is False
+    assert mine.stop()
+
+
+# --- the routes the column calls --------------------------------------------
+
+async def _client(sessions, link):
+    """The app over the SAME connection the conversations use.
+
+    ⛔ MEASURED, BY GETTING IT WRONG. This handed `build_app` a second, untouched
+    `FakeLink`, so the mutation that makes the live pane read the shared
+    connection instead of the conversation's own SURVIVED: it read a link
+    nothing had ever called, which answers exactly like a conversation that has
+    done nothing. The gate was not blind and the mutation was not wrong - the
+    test was exercising a path it did not think it was on, which is the third
+    possibility and the one that looks like the other two.
+    """
+    from starlette.testclient import TestClient
+    return TestClient(build_app(link, sessions))
+
+
+async def test_the_routes_act_on_the_conversation_the_page_names():
+    """⛔ EVERY ROUTE, THE LIVE ONES INCLUDED. A route that read the id and one
+    that did not would act on two conversations while the page showed one, and
+    the way that shows is the picture on the right belonging to another
+    session's browser.
+
+    Known-bad: leave `/chat/send` reading a fixed service.
+    """
+    link, sessions = _sessions()
+    client = await _client(sessions, link)
+
+    client.post("/chat/send?s=uno", json={"text": "primo"})
+    client.post("/chat/send?s=due", json={"text": "secondo"})
+    import asyncio
+    await asyncio.sleep(0.05)
+
+    assert [e["text"] for e in sessions.get("uno").history if e["kind"] == "you"] \
+        == ["primo"]
+    assert [e["text"] for e in sessions.get("due").history if e["kind"] == "you"] \
+        == ["secondo"]
+
+
+async def test_the_live_pane_of_a_conversation_that_has_done_nothing_asks_for_nothing():
+    """⛔ OR OPENING A CHAT LAUNCHES A BROWSER. Over MCP there is no way to ask
+    "is a browser running" without starting one, so the pane may only ask once
+    this conversation has issued an instruction. If that question were asked of
+    the shared connection, a second chat opened beside a working one would start
+    an engine - 800 MB and seven seconds - to draw a picture of nothing.
+
+    Known-bad: have the frame route read `link.touched` instead of the
+    conversation's own.
+    """
+    link, sessions = _sessions()
+    client = await _client(sessions, link)
+
+    await sessions.get("vecchia").send("do something")
+    calls_before = len(link.calls)
+
+    assert client.get("/live/frame?s=nuova").status_code == 204
+    assert len(link.calls) == calls_before, (
+        "drawing a pane for an unused conversation reached the server: %r"
+        % link.calls[calls_before:])
+
+
+async def test_the_column_can_be_listed_renamed_and_emptied_over_http():
+    """The three things the column does, through the routes it actually calls.
+
+    Known-bad: have `/sessions/rename` answer ok without writing anything. The
+    name is right until the page is reloaded.
+    """
+    link, sessions = _sessions()
+    client = await _client(sessions, link)
+
+    made = client.post("/sessions/new").json()
+    assert made["id"] and made["name"] == UNNAMED
+
+    client.post("/sessions/rename", json={"id": made["id"], "name": "  la mia  "})
+    assert sessions.get(made["id"]).name == "la mia"
+    assert store.load_chat(made["id"])["name"] == "la mia", (
+        "the new name lives only in memory, so a reload loses it")
+
+    rows = client.get("/sessions").json()
+    assert rows["default"] == DEFAULT_CHAT_ID
+    assert made["id"] in [r["id"] for r in rows["sessions"]]
+
+    client.post("/sessions/forget", json={"id": made["id"]})
+    assert made["id"] not in [r["id"] for r in client.get("/sessions").json()["sessions"]]
+
+
+async def test_forgetting_without_an_id_refuses_rather_than_deleting_the_default():
+    """Known-bad: default the id to the current conversation. A page with a bug
+    in it then deletes the session somebody is sitting in.
+    """
+    link, sessions = _sessions()
+    client = await _client(sessions, link)
+    sessions.get()  # the default exists
+
+    assert client.post("/sessions/forget", json={}).status_code == 400
+
+
+# --- the page ---------------------------------------------------------------
+
+@pytest.mark.filterwarnings("ignore")
+async def test_every_request_the_page_makes_carries_the_conversation():
+    """⛔ READ OUT OF THE PAGE, because this is the failure with no symptom: a
+    fetch that forgets the id acts on the DEFAULT conversation while the page
+    shows another, and the picture on the right is then somebody else's browser
+    with nothing red anywhere.
+
+    Known-bad: change any one `at('/live/tabs')` back to `'/live/tabs'`.
+    """
+    import re
+
+    from aihawk.web import PAGE
+
+    script = PAGE[PAGE.index("<script"):]
+    # Every fetch of a route that reads `?s=` must go through `at()`. The three
+    # session routes are deliberately NOT addressed: they are about the set of
+    # conversations, not about one, and they carry their id in the body.
+    ABOUT_THE_SET = ("/sessions", "/sessions/new", "/sessions/rename",
+                     "/sessions/forget")
+    bare = [p for p in re.findall(r"""fetch\(\s*['"]([^'"]+)""", script)
+            if p.split("?")[0] not in ABOUT_THE_SET]
+    assert not bare, (
+        "these requests do not carry the conversation, so they act on the "
+        "default one whatever the page is showing: %s" % bare)
+
+    assert "new EventSource(at('/chat/events'))" in script, (
+        "the event stream is not addressed, so every page listens to the "
+        "default conversation")

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -15,10 +15,11 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
+import re
 
 import pytest
 
-from aihawk.web import PAGE, ChatService, build_app
+from aihawk.web import PAGE, ChatService, Sessions, build_app
 
 pytestmark = pytest.mark.asyncio
 
@@ -133,7 +134,7 @@ async def test_the_replay_flag_is_on_history_and_not_on_live_events():
     svc = ChatService(FakeLink(), TalkingBrain())
     await svc.send("go")
 
-    app = build_app(FakeLink(), svc)
+    app = build_app(FakeLink(), Sessions.around(svc))
     stream = [r for r in app.routes if r.path == "/chat/events"][0]
     assert stream is not None, "the events route must exist for the page to work"
 
@@ -153,7 +154,7 @@ async def test_an_event_after_subscription_is_delivered_once_as_live():
     send it once as replay and then again as live.
     """
     svc = ChatService(FakeLink(), SilentBrain())
-    app = build_app(FakeLink(), svc)
+    app = build_app(FakeLink(), Sessions.around(svc))
     route = [r for r in app.routes if r.path == "/chat/events"][0]
 
     class Req:
@@ -243,12 +244,28 @@ async def test_a_failing_brain_reports_and_still_clears_busy():
 # --------------------------------------------------------------------------
 
 async def test_the_app_exposes_exactly_the_routes_the_page_calls():
-    """The page fetches these five paths by name. A rename here is a silent
-    404 there, and the page has no way to report it."""
+    """The page fetches these paths by name. A rename here is a silent 404
+    there, and the page has no way to report it.
+
+    ⛔ AND IT IS CHECKED BOTH WAYS, because one direction alone is half a gate.
+    A route the page never calls is dead surface nobody notices; a path the page
+    calls and the app does not serve is a button that does nothing. The set is
+    written out rather than derived from the page, so ADDING a route is a
+    deliberate edit here - which is what makes this the inventory of the surface
+    rather than a restatement of it.
+    """
     svc = ChatService(FakeLink(), SilentBrain())
-    paths = {r.path for r in build_app(FakeLink(), svc).routes}
-    assert paths == {"/", "/chat/send", "/chat/stop", "/chat/fresh",
-                     "/chat/events", "/live/frame", "/live/tabs", "/live/select"}
+    paths = {r.path for r in build_app(FakeLink(), Sessions.around(svc)).routes}
+    assert paths == {"/",
+                     # The session column, added in 0.17.0.
+                     "/sessions", "/sessions/new", "/sessions/rename",
+                     "/sessions/forget",
+                     "/chat/send", "/chat/stop", "/chat/fresh", "/chat/events",
+                     "/live/frame", "/live/tabs", "/live/select"}
+
+    called = {m for m in re.findall(r"""fetch\(\s*[`'"]([^`'"?]+)""", PAGE)}
+    unserved = sorted(called - paths)
+    assert not unserved, "the page calls paths the app does not serve: %s" % unserved
 
 
 async def test_the_stop_control_is_its_own_button_and_follows_the_run():
@@ -295,7 +312,7 @@ async def test_the_live_view_asks_for_nothing_until_an_instruction_has_been_give
     """
     link = FakeLink()
     svc = ChatService(link, SilentBrain())
-    app = build_app(link, svc)
+    app = build_app(link, Sessions.around(svc))
     frame = [r for r in app.routes if r.path == "/live/frame"][0]
 
     class Req:
@@ -353,7 +370,7 @@ class WatchingLink(FakeLink):
 
 
 async def _frame_route(link):
-    app = build_app(link, ChatService(link, SilentBrain()))
+    app = build_app(link, Sessions.around(ChatService(link, SilentBrain())))
     return [r for r in app.routes if r.path == "/live/frame"][0].endpoint
 
 
@@ -592,7 +609,7 @@ async def test_a_reconnection_resumes_instead_of_replaying_the_whole_thing():
     listener below then receives the whole history again.
     """
     svc = ChatService(FakeLink(), SilentBrain())
-    app = build_app(FakeLink(), svc)
+    app = build_app(FakeLink(), Sessions.around(svc))
     events = [r for r in app.routes if r.path == "/chat/events"][0]
 
     for text in ("first", "second", "third"):
@@ -621,7 +638,7 @@ async def test_a_reconnection_carrying_another_conversation_is_told_to_wipe():
     Known-bad: comparing only the index and ignoring the epoch.
     """
     svc = ChatService(FakeLink(), SilentBrain())
-    app = build_app(FakeLink(), svc)
+    app = build_app(FakeLink(), Sessions.around(svc))
     events = [r for r in app.routes if r.path == "/chat/events"][0]
     await svc.emit("said", "from the conversation that is gone")
 
@@ -655,7 +672,7 @@ async def test_a_page_that_joins_a_run_in_flight_is_told_the_run_is_in_flight():
     """
     brain = HangingBrain()
     svc = ChatService(FakeLink(), brain)
-    app = build_app(FakeLink(), svc)
+    app = build_app(FakeLink(), Sessions.around(svc))
     events = [r for r in app.routes if r.path == "/chat/events"][0]
 
     svc.start("something long")
@@ -682,7 +699,7 @@ async def test_a_page_that_joins_an_idle_service_is_not_told_anything_about_busy
     Known-bad: sending the state unconditionally.
     """
     svc = ChatService(FakeLink(), SilentBrain())
-    app = build_app(FakeLink(), svc)
+    app = build_app(FakeLink(), Sessions.around(svc))
     events = [r for r in app.routes if r.path == "/chat/events"][0]
 
     resp = await events.endpoint(_Req())
@@ -706,7 +723,7 @@ class TabbedLink(FakeLink):
 
 
 async def _tabs_route(link, svc=None):
-    app = build_app(link, svc or ChatService(link, SilentBrain()))
+    app = build_app(link, Sessions.around(svc or ChatService(link, SilentBrain())))
     return [r for r in app.routes if r.path == "/live/tabs"][0].endpoint
 
 


### PR DESCRIPTION
The interface held one conversation. It holds as many as you like now, listed down the left the way chats are, switched by clicking, named by whatever you first asked them, and written to disk so they are still there after the process is gone - both transcripts, the one the page draws and the one the model holds, because restoring only the first gives somebody a conversation they can read and cannot continue under a follow-up box that still looks like it works.

**What makes it real rather than decoration** is that a conversation drives its OWN browsers. The server has addressed browsers per session since 0.15.0, and a tool call that names no session lands on the default one - so a column that only swapped transcripts would have shown two chats quietly sharing one browser, the second finding the first one's tabs, cookies and identity and reporting them as its own. Nothing would have failed.

`SessionLink` puts the id on every call whose schema accepts one, read from the schema the server publishes rather than from a list written here, and it IMPOSES it: a model that passes a `session_id` of its own has it overwritten, because which person's browser a command reaches is not a modelling decision.

Deleting a conversation closes its browsers, through `session_forget`. Both halves or neither: erasing the file alone would leave up to eight engines running with nothing left that names them.

Two things came from running it rather than from a test. The routes were wired and the CLI still built a single conversation, so the column answered 500 on a real launch while the whole suite was green - the tests build their own pieces and could not see it. And the rows drew as raised boxes with centred text, because a button in a list needs the user agent's chrome taken off; that one was only visible in a screenshot.

Fourteen known-bad mutations, all killed. One survived twice first and both times the fault was the test rather than the gate: the fixture handed the app a second connection nobody had touched, and the stand-in brain never called a tool, so the path under test was not the path being run.

Also repairs a BEL byte that shipped in the 0.16.0 docs, where a backslash-a written through a heredoc became 0x07 and ate the character after it.