### PR TITLE
The workspace: one live pane, the others as slow previews (0.18.0)

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -183,7 +183,7 @@ address.
 |---|---|---|
 | `browser_open` | `browser_id`, `seed`, `proxy`, `profile`, all optional | Opens another browser in this session and makes it the one unaddressed commands go to. Each browser has its own tabs, cookies and identity and shares none of them. Refuses past eight, saying what eight cost when it was measured. |
 | `browser_close` | `browser_id` optional | Closes one browser and frees what it held. Its tabs go with it; the other browsers and the conversation do not. Forgets who it was, so the same name later is a new stranger rather than that person resumed. |
-| `browser_list` | `session_id` optional | Which browsers this session holds, where each one is, and which one commands go to. Starts nothing, so asking is free. |
+| `browser_list` | `session_id` optional | Which browsers this session holds, where each one is, and which one commands go to. **Answers JSON** since 0.18.0: `session`, `focus`, `limit`, `note`, and `browsers` with `id`, `running`, `focused` and the `urls` of each one's tabs. A browser that is not running is one this session declared and has not needed yet. Starts nothing, so asking is free. |
 | `browser_focus` | `browser_id` | Chooses which browser the commands that name none land on. Naming a browser still reaches it whatever the focus is. |
 | `session_list` | none | Every saved session and what each one holds. Sessions survive the server, so this is how you find the one you were in. Starts nothing. |
 | `session_forget` | `session_id` | Delete a saved session: its browsers are closed and it stops being listed. Not the same as closing browsers, which frees the engines and keeps the session. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.17.0"
+version = "0.18.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/mcp/server.py
+++ b/src/aihawk/mcp/server.py
@@ -484,34 +484,54 @@ async def browser_close(browser_id: str | None = None,
 
 @mcp.tool()
 async def browser_list(session_id: str | None = None) -> str:
-    """Which browsers this session holds, and which one commands go to.
+    """Which browsers this session holds, where each one is, and which one the
+    commands that name none go to.
+
+    Answers JSON: `session`, `focus`, `limit`, `note`, and `browsers` - each with
+    `id`, `running`, `focused` and the `urls` of its tabs. A browser that is not
+    running is one this session declared and has not needed yet; the next
+    command aimed at it starts it as the same person.
 
     Starts nothing: it reports what is running, so asking is free.
     """
     at_session = in_session(session_id)
     have = browsers_in(at_session)
-    if not have:
-        return ("session %s has no browser open yet. The next tool that needs a "
-                "page will open one, or call browser_open to choose who it is."
-                % at_session)
-
     here = focused(at_session)
     rows = []
     for name in have:
         session = registry.peek(addressed(at_session, name))
-        where = ""
-        if session is not None:
+        urls, running = [], session is not None
+        if running:
             try:
-                pages = await session.describe_pages()
-                where = "; ".join(p["url"] or "blank" for p in pages) or "no tabs"
+                urls = [p["url"] or "" for p in await session.describe_pages()]
             except Exception:
-                where = "tabs unreadable"
-        else:
-            where = "not up; the next command restarts it as the same person"
-        rows.append("%s%s: %s" % (name, " (commands go here)" if name == here else "",
-                                 where))
-    return "session %s holds %d of %d browsers. %s" % (
-        at_session, len(have), MAX_BROWSERS_PER_SESSION, " | ".join(rows))
+                # Readable as a state rather than as an absence: a browser whose
+                # tabs cannot be read is not a browser with no tabs, and a pane
+                # drawing "no tabs" over a live window would be a lie.
+                running, urls = True, None
+        rows.append({"id": name, "running": running, "focused": name == here,
+                     "urls": urls})
+    # ⛔ JSON, WHERE THIS ANSWERED PROSE UNTIL 0.18.0, and the reason is the
+    # stated architecture rather than taste: the interface is a client of these
+    # tools like anybody else, with no privileged path, so a workspace that has
+    # to draw one pane per browser needs this question answered in a shape a
+    # program can read. The alternative was the page parsing a sentence, which
+    # is two readers of one wire format, or a second tool saying the same thing,
+    # which is two sources for one fact. `session_list_pages` has answered JSON
+    # since 0.9.0 and models read it without trouble; `note` carries the
+    # sentence that used to be the whole answer, because "there is nothing here
+    # yet" is worth saying in words.
+    return actions.json_capped({
+        "session": at_session,
+        "focus": here,
+        "limit": MAX_BROWSERS_PER_SESSION,
+        "browsers": rows,
+        "note": ("no browser open yet. The next tool that needs a page will open "
+                 "one, or call browser_open to choose who it is."
+                 if not rows else
+                 "%d of %d browsers. Commands that name none go to %s."
+                 % (len(rows), MAX_BROWSERS_PER_SESSION, here)),
+    })
 
 
 @mcp.tool()

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -362,6 +362,38 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
    and a tall one fills the height. What is left over is stage, never a hole
    inside the frame. object-fit stays underneath for the one frame where the
    ratio is still the previous page's. */
+/* ---------------- the other browsers ----------------
+   A row of slow previews under the live pane, never a second live pane: eight
+   at full rate would want 2.3 seconds of pipe for every second that passes,
+   measured, and that is arithmetic rather than an optimisation problem. */
+#fleet{ flex:none; display:flex; align-items:flex-end; gap:8px;
+        padding:0 14px 12px }
+#thumbs{ flex:1; min-width:0; display:flex; gap:8px; overflow-x:auto }
+#addbrowser{ flex:none; align-self:center; padding:6px 10px; border-radius:8px;
+             border:1px solid var(--line-2); background:var(--raised);
+             color:var(--fg-3); font:inherit; font-size:var(--t-label);
+             cursor:pointer }
+#addbrowser:hover{ border-color:var(--line-3); color:var(--fg) }
+.thumb .cap .x{ flex:none; width:16px; height:16px; border-radius:3px;
+                color:var(--fg-4); text-align:center; line-height:16px }
+.thumb .cap .x:hover{ background:var(--line-2); color:var(--fg) }
+.thumb{ flex:none; width:168px; border:1px solid var(--line-2); border-radius:8px;
+        background:var(--raised); padding:0; cursor:pointer; overflow:hidden;
+        display:flex; flex-direction:column; text-align:left; font:inherit;
+        color:var(--fg-3) }
+.thumb:hover{ border-color:var(--line-3); color:var(--fg) }
+.thumb[aria-current="true"]{ border-color:var(--fg-4); color:var(--fg) }
+.thumb .pic{ width:100%; aspect-ratio:16/10; background:var(--well);
+             display:grid; place-items:center; overflow:hidden }
+.thumb .pic img{ width:100%; height:100%; object-fit:cover; display:block }
+.thumb .pic span{ font-size:var(--t-label); color:var(--fg-4); padding:4px;
+                  text-align:center }
+.thumb .cap{ display:flex; align-items:center; gap:6px; padding:5px 7px;
+             font-family:var(--mono); font-size:var(--t-label) }
+.thumb .cap .id{ flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis;
+                 white-space:nowrap }
+.thumb .cap .st{ flex:none; color:var(--fg-4) }
+
 #stage{ flex:1; min-height:0; padding:14px; display:grid; place-items:center;
         container-type:size }
 #browser{ --arn:1.6; --chrome:38px;
@@ -465,6 +497,10 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
         <span id="empty">nothing running yet</span>
       </div>
     </div>
+  </div>
+  <div id="fleet">
+    <div id="thumbs" aria-label="The other browsers in this session"></div>
+    <button id="addbrowser" type="button" title="Open another browser in this session">+ Browser</button>
   </div>
 </div>
 
@@ -816,8 +852,23 @@ $('mode').onclick = (e) => {
   say(frozen ? 'frozen' : 'live');
 };
 
+/* Whether the browser the big pane watches has anything to show. Unknown
+   until the first fleet poll lands, and "unknown" asks - the single-browser
+   case must not wait three seconds for its first frame. */
+function focusedHasNoPage(){
+  const b = fleet.find(x => x.id === focusHere);
+  return b && b.running && (b.urls || []).length === 0;
+}
+
 async function tick(){
-  if(!frozen) try {
+  /* ⛔ ONE SCHEDULER, and the pace of the pump stays one number. The first
+     version of this skip scheduled its own slower `setTimeout(tick, 500)` and
+     the gate on the pump's pace caught it immediately: with two of them the
+     rate is no longer a thing anybody can read off the page. So the idle case
+     skips the REQUEST and falls through to the same timer as everything else -
+     a no-op every 60 ms costs nothing, since what costs is the round trip. */
+  if(focusedHasNoPage()){ img.hidden = true; empty.hidden = false; say('idle'); }
+  else if(!frozen) try {
     const r = await fetch(at('/live/frame?t=' + Date.now()), {cache:'no-store'});
     if(r.status === 204){ img.hidden = true; empty.hidden = false; say('idle'); }
     else if(r.ok){
@@ -968,7 +1019,125 @@ $('newchat').onclick = async () => {
   location.search = '?s=' + encodeURIComponent(j.id);
 };
 
-paint(); listen(); tick(); where(); drawChats();
+/* ---------------- the workspace ----------------
+   ⛔ THE COST OF THE PREVIEWS DOES NOT GROW WITH THE NUMBER OF THEM, and that
+   is the whole design rather than a detail. A frame costs about 22 ms on the
+   pipe that ACTIONS share, and the pipe is serialised: eight panes each asking
+   thirteen times a second would want 2.3 seconds of pipe per second, so the
+   picture would be behind and every click would queue behind the pictures.
+
+   So there is ONE live pane - the focused one, at the full rate, in `tick` -
+   and ONE slow loop that refreshes a single other pane every 400 ms, taking
+   them in turn. Seven others therefore refresh about every three seconds, and
+   whether there are two panes or eight the previews cost the same two and a
+   half requests a second. A loop per pane would have been the obvious way to
+   write it and its cost would be the thing the measurement forbids. */
+const SLOW_MS = 400;
+let fleet = [], nextPane = 0, focusHere = '';
+
+function thumbFor(b){
+  const el2 = document.createElement('button');
+  el2.type = 'button'; el2.className = 'thumb'; el2.dataset.id = b.id;
+  el2.title = 'Send this session’s commands to ' + b.id;
+  const pic = el('div','pic');
+  /* Three states, not two, and the third is the one that read as a failure.
+     A browser that is RUNNING WITH NO TAB cannot be captured - the engine
+     answers "no such tab" - and asking anyway spends a round trip to be told
+     so, then paints ERROR over something that is simply empty. The tabs are
+     already in the answer this pane was built from, so the question is asked
+     of data rather than of the pipe. */
+  if(b.running && (b.urls || []).length){
+    const im = document.createElement('img'); im.alt = ''; pic.appendChild(im);
+  } else {
+    pic.appendChild(el('span', null, b.running ? 'no page yet' : 'not up'));
+  }
+  const cap = el('div','cap');
+  cap.appendChild(el('span','id', b.id));
+  cap.appendChild(el('span','st', b.running ? '' : 'idle'));
+  const shut = el('span','x','x');
+  shut.title = 'Close ' + b.id;
+  shut.onclick = (e) => { e.stopPropagation(); closeThis(b.id); };
+  cap.appendChild(shut);
+  el2.append(pic, cap);
+  el2.onclick = () => watchThis(b.id);
+  return el2;
+}
+
+async function closeThis(id){
+  if(!confirm('Close browser "' + id + '"? Its tabs go with it.')) return;
+  await fetch(at('/live/close'), {method:'POST', headers:{'Content-Type':'application/json'},
+                                  body: JSON.stringify({id})});
+  await drawFleet();
+}
+
+async function openAnother(){
+  const r = await fetch(at('/live/open'), {method:'POST'});
+  const j = await r.json().catch(() => ({}));
+  /* The server owns the ceiling and its refusal carries what eight browsers
+     cost, measured. Showing that sentence is the whole point of it saying so:
+     a page that turned it into "limit reached" would be the reason somebody
+     later raises the number without ever seeing the number. */
+  if(j.said && /already holds/.test(j.said)) alert(j.said);
+  await drawFleet();
+}
+
+async function watchThis(id){
+  await fetch(at('/live/watch'), {method:'POST', headers:{'Content-Type':'application/json'},
+                                  body: JSON.stringify({id})});
+  await drawFleet();
+}
+
+async function drawFleet(){
+  let got = {browsers: []};
+  try { const r = await fetch(at('/live/browsers'), {cache:'no-store'});
+        if(r.ok) got = await r.json(); }
+  catch(err){ return; }
+  fleet = got.browsers || [];
+  focusHere = got.focus || '';
+  const others = fleet.filter(b => b.id !== focusHere);
+  const box = $('thumbs');
+  /* Only when the SET changes. Redrawing on every poll would throw away the
+     preview images and make the row flash once a second for no new fact. */
+  const sig = others.map(b => b.id + (b.running ? '1' : '0')).join(',') + '|' + focusHere;
+  if(box.dataset.sig !== sig){
+    box.dataset.sig = sig;
+    box.textContent = '';
+    for(const b of others) box.appendChild(thumbFor(b));
+    nextPane = 0;
+  }
+  /* The row of previews disappears with one browser; the button to open
+     another does not, or a session could never grow past its first. */
+  box.hidden = others.length === 0;
+}
+
+async function slowTick(){
+  const box = $('thumbs');
+  /* Only running browsers are asked for a picture. A declared browser that has
+     not started is not a slow pane, it is a browser that does not exist yet,
+     and asking would START it - 800 MB and seven seconds to fill a thumbnail
+     nobody asked for. Same rule the live pane follows. */
+  const shown = [...box.children].filter(t => t.querySelector('img'));
+  if(shown.length){
+    const t = shown[nextPane % shown.length];
+    nextPane++;
+    try {
+      const r = await fetch(at('/live/frame?b=' + encodeURIComponent(t.dataset.id)
+                               + '&t=' + Date.now()), {cache:'no-store'});
+      if(r.ok && r.status !== 204){
+        const im = t.querySelector('img'), blob = await r.blob(), was = im.src;
+        im.src = URL.createObjectURL(blob);
+        if(was && was.startsWith('blob:')) URL.revokeObjectURL(was);
+      }
+    } catch(err){}
+  }
+  setTimeout(slowTick, SLOW_MS);
+}
+
+async function fleetPoll(){ await drawFleet(); setTimeout(fleetPoll, 3000); }
+
+$('addbrowser').onclick = openAnother;
+
+paint(); listen(); tick(); where(); drawChats(); fleetPoll(); slowTick();
 </script>
 """
 
@@ -1475,8 +1644,15 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
             # conversation, so opening a second chat does not launch an engine
             # to draw a pane for a session that has done nothing.
             return Response(status_code=204)
+        # ⛔ THE PANE SAYS WHICH BROWSER, and without that the workspace is one
+        # picture drawn eight times. `browser_id` is the caller's to choose here
+        # exactly as `session_id` is not: which SESSION a request belongs to is
+        # decided by the page's own url and imposed, while which BROWSER inside
+        # it a pane is watching is what the pane is for.
+        watching = request.query_params.get("b") or None
         try:
-            result = await seen.link.call("browser_watch")
+            result = await seen.link.call("browser_watch",
+                                          {"browser_id": watching} if watching else {})
         except Exception as exc:
             return JSONResponse({"error": str(exc)[:200]}, status_code=503)
         got = image_of(result)
@@ -1492,6 +1668,77 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
             return Response(status_code=204)
         jpeg, mime = got
         return Response(jpeg, media_type=mime, headers={"Cache-Control": "no-store"})
+
+    async def browsers(request: Request) -> JSONResponse:
+        """The panes to draw: which browsers this session holds, and where.
+
+        Asked of the server through the same tool an agent would call, because
+        the interface has no privileged path to the browsers - and it starts
+        nothing, so drawing the workspace can never cost an engine.
+
+        A conversation that has issued no instruction has no browsers by
+        definition, and asking would be the one question that creates what it
+        asks about. So it answers an empty workspace without going near the
+        server, which is the same rule the picture and the tab strip follow.
+        """
+        seen = which(request)
+        if not seen.link.touched:
+            return JSONResponse({"browsers": [], "focus": "", "limit": 0})
+        try:
+            got = json.loads(await seen.link.call_text("browser_list"))
+        except Exception:
+            # An older server answered this in prose. The workspace then draws
+            # nothing rather than half of something, and the single live pane -
+            # which does not need this - keeps working.
+            return JSONResponse({"browsers": [], "focus": "", "limit": 0})
+        if not isinstance(got, dict):
+            return JSONResponse({"browsers": [], "focus": "", "limit": 0})
+        return JSONResponse({"browsers": got.get("browsers") or [],
+                             "focus": got.get("focus") or "",
+                             "limit": got.get("limit") or 0})
+
+    async def watch(request: Request) -> JSONResponse:
+        """Make one browser the one this session's unaddressed commands go to.
+
+        The pane a person clicks becomes the live one, and that is the SAME
+        focus the agent uses - not a second idea of "current" kept by the page.
+        Two of those would disagree the first time the model opened a browser,
+        and the disagreement would show as commands landing in a pane nobody was
+        watching.
+        """
+        body = await request.json()
+        name = (body or {}).get("id", "")
+        if not name:
+            return JSONResponse({"error": "no id"}, status_code=400)
+        said = await which(request).link.call_text("browser_focus",
+                                                   {"browser_id": name})
+        return JSONResponse({"focused": name, "said": said})
+
+    async def open_browser(request: Request) -> JSONResponse:
+        """Open another browser in this session, from the workspace.
+
+        Creating and destroying browsers are first-class operations here and not
+        only in the tool surface: an interface where the only way to get a
+        second browser is to ask the model for one makes a measured feature
+        depend on a sentence being understood.
+
+        The server decides whether it is allowed - eight is its ceiling and its
+        refusal carries what eight cost - and the answer is passed through
+        rather than judged again here. Two places deciding the same limit is two
+        places to disagree about it.
+        """
+        said = await which(request).link.call_text("browser_open")
+        return JSONResponse({"said": said})
+
+    async def close_browser(request: Request) -> JSONResponse:
+        """Close one browser of this session and free what it held."""
+        body = await request.json()
+        name = (body or {}).get("id", "")
+        if not name:
+            return JSONResponse({"error": "no id"}, status_code=400)
+        said = await which(request).link.call_text("browser_close",
+                                                   {"browser_id": name})
+        return JSONResponse({"said": said})
 
     async def tabs(request: Request) -> JSONResponse:
         """Every tab, and which one is current.
@@ -1539,6 +1786,10 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
         Route("/chat/fresh", fresh, methods=["POST"]),
         Route("/chat/events", events),
         Route("/live/frame", frame),
+        Route("/live/browsers", browsers),
+        Route("/live/watch", watch, methods=["POST"]),
+        Route("/live/open", open_browser, methods=["POST"]),
+        Route("/live/close", close_browser, methods=["POST"]),
         Route("/live/tabs", tabs),
         Route("/live/select", select, methods=["POST"]),
     ])

--- a/tests/mcp_server/test_browsers_in_a_session.py
+++ b/tests/mcp_server/test_browsers_in_a_session.py
@@ -15,6 +15,8 @@ what a tool did is observable as the keys the registry ends up holding.
 """
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from aihawk.mcp import server
@@ -42,8 +44,12 @@ class _Recording:
 
 @pytest.fixture
 def registry(monkeypatch):
-    reg = SessionRegistry(factory=_Recording,
-                          defaults=lambda: {"seed": 7, "headless": True})
+    # The server's own constructor, not a bare one: a test that builds a
+    # registry the product does not have is testing something else, and the
+    # wiring that writes a session down would be exercised by nothing. Missed
+    # here when the file was reconstructed after the checkout was deleted.
+    reg = server.new_registry(factory=_Recording,
+                              defaults=lambda: {"seed": 7, "headless": True})
     monkeypatch.setattr(server, "registry", reg)
     # The focus is module state, so a test that set it must not reach the next.
     monkeypatch.setattr(server, "_focus", {})
@@ -196,4 +202,12 @@ async def test_asking_what_a_session_holds_starts_nothing(registry):
     said = await server.browser_list()
 
     assert registry.ids() == [], "asking what a session holds started a browser"
-    assert "no browser open yet" in said
+    # ⛔ ON THE SHAPE, NOT ON A SUBSTRING. This asserted `"no browser open yet"
+    # in said` and stayed green through the change from prose to JSON, because
+    # the sentence survived inside the `note` field: an assertion that passes on
+    # both answers a tool can give is not checking the answer. Same family as
+    # the 0.16.1 defect, caught this time before it shipped.
+    answer = json.loads(said)
+    assert answer["browsers"] == []
+    assert answer["limit"] == server.MAX_BROWSERS_PER_SESSION
+    assert "no browser open yet" in answer["note"]

--- a/tests/test_the_browser_workspace.py
+++ b/tests/test_the_browser_workspace.py
@@ -1,0 +1,283 @@
+"""Several browsers, one live pane, and the arithmetic that decides it.
+
+⛔ THE SHAPE OF THIS FEATURE COMES FROM A NUMBER, NOT FROM TASTE. A frame costs
+about 22 ms on the stdio pipe, the pipe is serialised, and actions share it with
+pictures. Eight panes each asking thirteen times a second is 104 requests a
+second at 22 ms, which is 2.3 seconds of pipe for every second that passes: the
+picture falls behind and every click queues behind the pictures. So there is one
+live pane and one slow loop that takes the others in turn at a FIXED rate, and
+the test below reads that out of the page - because the obvious way to write it
+is a loop per pane, whose cost is exactly what the measurement forbids.
+
+No browser and no server: the link records what it was asked.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+from aihawk.web import PAGE, Sessions, build_app
+
+pytestmark = [pytest.mark.asyncio, pytest.mark.filterwarnings("ignore")]
+
+
+class _Tool:
+    def __init__(self, name, props):
+        self.name = name
+        self.inputSchema = {"type": "object", "properties": {p: {} for p in props}}
+
+
+FLEET = {
+    "session": "lavoro", "focus": "docs", "limit": 8,
+    "browsers": [
+        {"id": "docs", "running": True, "focused": True, "urls": ["http://a/"]},
+        {"id": "posta", "running": True, "focused": False, "urls": ["http://b/"]},
+        {"id": "dormiente", "running": False, "focused": False, "urls": []},
+    ],
+    "note": "3 of 8 browsers.",
+}
+
+
+class _Text:
+    """A tool result shaped the way one arrives over MCP.
+
+    ⛔ NOT a bare string. `SessionLink.call_text` is `text_of(await call(...))`,
+    so a stand-in whose `call` answers None makes every text read come back
+    empty - which reads as a server that answered nothing rather than as a
+    stand-in that was the wrong shape.
+    """
+
+    def __init__(self, text):
+        self.content = [type("Item", (), {"text": text})()]
+        self.isError = False
+
+
+class FakeLink:
+    def __init__(self):
+        self.touched = False
+        self.tools = [_Tool("browser_watch", ["session_id", "browser_id"]),
+                      _Tool("browser_list", ["session_id"]),
+                      _Tool("browser_focus", ["browser_id", "session_id"]),
+                      _Tool("session_list_pages", ["session_id", "browser_id"])]
+        self.calls = []
+        self.answers = {"browser_list": json.dumps(FLEET),
+                        "browser_focus": "commands now go to it",
+                        "session_list_pages": "[]"}
+
+    async def call(self, name, arguments=None):
+        self.touched = True
+        self.calls.append((name, dict(arguments or {})))
+        return _Text(self.answers[name]) if name in self.answers else None
+
+
+class Brain:
+    messages: list = []
+    usage: dict = {}
+
+    async def handle(self, text, link, say):
+        await link.call("browser_navigate", {"url": "http://x/"})
+
+
+def _app():
+    from starlette.testclient import TestClient
+    link = FakeLink()
+    sessions = Sessions(link, Brain)
+    return link, sessions, TestClient(build_app(link, sessions))
+
+
+# --- what the page is told to draw ------------------------------------------
+
+async def test_the_workspace_is_read_from_the_server_like_any_other_client():
+    """The interface has no privileged path to the browsers: it asks the same
+    tool an agent would.
+
+    Known-bad: have the route keep its own list of browsers. It is right until
+    the model opens one, which is the case the workspace exists for.
+    """
+    link, sessions, client = _app()
+    await sessions.get("lavoro").send("start something")
+
+    got = client.get("/live/browsers?s=lavoro").json()
+
+    assert [b["id"] for b in got["browsers"]] == ["docs", "posta", "dormiente"]
+    assert got["focus"] == "docs" and got["limit"] == 8
+    assert any(name == "browser_list" for name, _ in link.calls)
+
+
+async def test_a_conversation_that_has_done_nothing_draws_no_panes_and_asks_nothing():
+    """⛔ OR OPENING A CHAT COSTS AN ENGINE. Over MCP there is no way to ask "is
+    a browser running" without starting one, so a workspace drawn for a session
+    that has issued no instruction must answer from what it already knows.
+
+    Known-bad: drop the `touched` guard from the browsers route.
+    """
+    link, sessions, client = _app()
+
+    got = client.get("/live/browsers?s=mai-usata").json()
+
+    assert got["browsers"] == []
+    assert link.calls == [], (
+        "drawing an empty workspace reached the server: %r" % link.calls)
+
+
+async def test_an_older_server_leaves_the_workspace_empty_instead_of_breaking_the_pane():
+    """`browser_list` answered prose before 0.18.0. A page that cannot parse it
+    draws no previews and keeps the single live pane working, which is the half
+    that does not depend on this.
+
+    Known-bad: let the route raise on unparsable output.
+    """
+    link, sessions, client = _app()
+    await sessions.get("lavoro").send("start something")
+
+    link.answers["browser_list"] = "session lavoro holds 3 of 8 browsers."
+    got = client.get("/live/browsers?s=lavoro").json()
+
+    assert got == {"browsers": [], "focus": "", "limit": 0}
+
+
+# --- which browser a pane is watching ---------------------------------------
+
+async def test_a_pane_asks_for_its_own_browser_and_not_for_the_focused_one():
+    """Without this the workspace is one picture drawn several times.
+
+    Known-bad: drop `browser_id` from the frame route. Every thumbnail then
+    shows whatever the focused browser is looking at, which is a wrong answer
+    that looks exactly like a right one.
+    """
+    link, sessions, client = _app()
+    await sessions.get("lavoro").send("start something")
+
+    client.get("/live/frame?s=lavoro&b=posta")
+
+    watched = [args for name, args in link.calls if name == "browser_watch"]
+    assert watched and watched[-1].get("browser_id") == "posta", watched
+    assert watched[-1].get("session_id") == "lavoro", (
+        "a pane reached into another session: %r" % watched[-1])
+
+
+async def test_the_live_pane_still_asks_for_the_focused_browser_when_none_is_named():
+    """The single-browser case is the common one and must not have gained an
+    argument it does not need.
+
+    Known-bad: make `browser_id` required in the frame route.
+    """
+    link, sessions, client = _app()
+    await sessions.get("lavoro").send("start something")
+
+    assert client.get("/live/frame?s=lavoro").status_code in (200, 204, 503)
+    watched = [args for name, args in link.calls if name == "browser_watch"]
+    assert "browser_id" not in watched[-1], watched[-1]
+
+
+async def test_clicking_a_pane_moves_the_focus_the_agent_uses():
+    """⛔ ONE FOCUS, NOT TWO. The pane a person clicks becomes the browser the
+    session's unaddressed commands go to. A second idea of "current" kept by the
+    page would disagree with the server the first time the model opened a
+    browser, and the disagreement shows as commands landing in a pane nobody is
+    watching.
+
+    Known-bad: have the route remember the choice locally instead of calling
+    `browser_focus`.
+    """
+    link, sessions, client = _app()
+    await sessions.get("lavoro").send("start something")
+
+    said = client.post("/live/watch?s=lavoro", json={"id": "posta"})
+
+    assert said.status_code == 200 and said.json()["focused"] == "posta"
+    assert ("browser_focus", {"browser_id": "posta", "session_id": "lavoro"}) \
+        in link.calls, link.calls
+
+
+async def test_focusing_nothing_refuses():
+    """Known-bad: treat a missing id as the focused browser, which makes a bug
+    in the page silently a no-op instead of an error somebody can see."""
+    _, sessions, client = _app()
+    assert client.post("/live/watch?s=lavoro", json={}).status_code == 400
+
+
+# --- the arithmetic, read out of the page -----------------------------------
+
+def test_the_previews_cost_the_same_whether_there_are_two_or_eight():
+    """⛔ THE MEASUREMENT, AS A PROPERTY OF THE CODE. One slow loop taking the
+    panes in turn costs a fixed number of requests a second; a loop per pane
+    costs that many times N, and at eight panes N is what the pipe cannot pay.
+
+    Read out of the page because this is a shape, not a value: what has to stay
+    true is that the number of timers does not depend on the number of browsers.
+
+    Known-bad: start a `setTimeout` inside the loop that builds the thumbnails.
+    """
+    script = PAGE[PAGE.index("<script"):]
+
+    # The slow loop reschedules ITSELF, once, at a fixed interval.
+    assert re.search(r"setTimeout\(slowTick,\s*SLOW_MS\)", script), (
+        "the slow loop does not reschedule itself at a fixed rate")
+    assert len(re.findall(r"setTimeout\(slowTick", script)) == 1, (
+        "the slow loop is scheduled from more than one place, so its rate is "
+        "no longer one thing")
+
+    # And the function that BUILDS a pane starts no timer of its own.
+    builder = script[script.index("function thumbFor"):script.index("async function watchThis")]
+    assert "setTimeout" not in builder and "setInterval" not in builder, (
+        "a pane schedules its own refresh, so the cost of the previews grows "
+        "with the number of panes - which is the thing the arithmetic forbids")
+
+
+def test_a_pane_that_is_not_running_is_never_asked_for_a_picture():
+    """A declared browser that has not started is not a slow pane: asking would
+    START it, 800 MB and seven seconds, to fill a thumbnail nobody asked for.
+
+    Known-bad: drop the filter on `img` in `slowTick` and ask for every pane.
+    """
+    script = PAGE[PAGE.index("<script"):]
+    slow = script[script.index("async function slowTick"):script.index("async function fleetPoll")]
+
+    assert "filter(t => t.querySelector('img'))" in slow, (
+        "the slow loop asks for a picture of every pane, including the ones "
+        "that are only declared - which starts them")
+
+
+def test_the_page_declares_no_identifier_twice():
+    """⛔ A DUPLICATE `let` IS A SYNTAX ERROR, AND A SYNTAX ERROR KILLS THE WHOLE
+    SCRIPT - not the line, the file. Nothing runs: no event stream, no session
+    column, no workspace, and the page still renders, so it looks like a server
+    that has stopped answering rather than like a page that never started.
+
+    Measured by shipping it for ten minutes. The workspace declared `let fleet =
+    [], turn = 0` and `turn` was already a top-level variable of the step list.
+    The whole suite was green - 426 tests - because every test reads the page as
+    a STRING or drives the routes, and neither notices that a browser cannot
+    parse it. It was found by opening the page and asking it whether its own
+    helper existed.
+
+    Checked with a scan rather than by parsing JavaScript, because the scan is
+    the shape of the defect: two declarations of one name at the top level of
+    one script. A real parser would be better and needs a JavaScript engine in
+    the test environment.
+
+    Known-bad: rename `nextPane` back to `turn`.
+    """
+    script = PAGE[PAGE.index("<script"):]
+    seen, twice = {}, []
+    for line in script.split("\n"):
+        if line[:1] not in ("l", "c", "v"):
+            # Top level only: an indented declaration is inside something, where
+            # shadowing is legal and common.
+            continue
+        m = re.match(r"(?:let|const|var)\s+(.+?);\s*$", line)
+        if not m:
+            continue
+        for part in m.group(1).split(","):
+            name = part.split("=")[0].strip()
+            if not re.fullmatch(r"[A-Za-z_$][\w$]*", name or ""):
+                continue
+            if name in seen:
+                twice.append(name)
+            seen[name] = True
+    assert not twice, (
+        "declared twice at the top level of the page's script, which is a "
+        "syntax error that stops the whole file from running: %s" % sorted(set(twice)))

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -261,7 +261,11 @@ async def test_the_app_exposes_exactly_the_routes_the_page_calls():
                      "/sessions", "/sessions/new", "/sessions/rename",
                      "/sessions/forget",
                      "/chat/send", "/chat/stop", "/chat/fresh", "/chat/events",
-                     "/live/frame", "/live/tabs", "/live/select"}
+                     "/live/frame", "/live/tabs", "/live/select",
+                     # The workspace, added in 0.18.0: which browsers to draw a
+                     # pane for, and which one the commands go to.
+                     "/live/browsers", "/live/watch",
+                     "/live/open", "/live/close"}
 
     called = {m for m in re.findall(r"""fetch\(\s*[`'"]([^`'"?]+)""", PAGE)}
     unserved = sorted(called - paths)
@@ -547,8 +551,18 @@ async def test_the_frame_pause_is_shorter_than_the_capture_produces():
     """
     import re
 
-    m = re.search(r"setTimeout\(tick,\s*(\d+)\)", PAGE)
+    # ⛔ THE CODE, NOT THE PROSE BESIDE IT, and this gate learned that the hard
+    # way: a comment explaining why the pause is NOT 500 contained the literal
+    # `setTimeout(tick, 500)`, and the scan read the explanation as the pump.
+    # It is the project's most repeated defect arriving from the other side -
+    # usually a gate is satisfied by a comment, here it was accused by one.
+    code = re.sub(r"/\*.*?\*/", "", PAGE, flags=re.S)
+    code = re.sub(r"^\s*//.*$", "", code, flags=re.M)
+    m = re.search(r"setTimeout\(tick,\s*(\d+)\)", code)
     assert m, "the frame pump no longer paces itself with setTimeout(tick, ...)"
+    assert len(re.findall(r"setTimeout\(tick,\s*\d+\)", code)) == 1, (
+        "the pump is scheduled from more than one place, so its pace is no "
+        "longer one number anybody can read")
     pause_ms = int(m.group(1))
 
     round_trip_ms = 22    # measured against the running interface


### PR DESCRIPTION
A session can hold eight browsers and the interface showed one of them. It shows them all now: the focused browser in the big pane at full rate, the others as small previews under it, click one to send this session's commands to it, and open or close a browser without asking the model to do it for you.

**The shape is decided by a number.** A frame costs about 22 ms on the stdio pipe, the pipe is serialised, and actions share it with pictures. Eight panes each asking thirteen times a second is 104 requests a second at 22 ms - 2.3 seconds of pipe for every second that passes, so the picture falls behind and every click queues behind the pictures.

So there is ONE live pane and ONE slow loop that takes the others in turn at a fixed rate: whether there are two panes or eight, the previews cost the same two and a half requests a second. A loop per pane is the obvious way to write it and its cost is exactly what the measurement forbids, so a test reads the shape out of the page.

`browser_list` answers JSON where it answered prose. The stated architecture is that the interface is a client of these tools with no privileged path, so a workspace that draws one pane per browser needs this question answered in a shape a program can read. `note` carries the sentence that used to be the whole answer.

Three things this got wrong, and two of them only running it could find:

- The page declared `let fleet = [], turn = 0` and `turn` was already a top-level variable. A duplicate `let` is a syntax error, and a syntax error kills the whole file - no event stream, no session column, no workspace - while the page still renders. All 426 tests were green, because every test reads the page as a string or drives the routes and neither notices that a browser cannot parse it. There is a gate for that class now.
- A browser that is running with no tab cannot be captured, and the pane painted ERROR over what is simply empty. It is a third state, not a failure, and the tabs are already in the answer the pane is built from.
- The gate on the frame pump's pace read a `setTimeout(tick, 500)` out of a COMMENT explaining why the pause is not 500. It strips comments before scanning now, and still kills a pump slowed to 400 ms.