### PR TITLE
A declared browser wakes where it was, tabs and all (0.19.0)

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -211,8 +211,11 @@ Sessions are written down as soon as one holds a browser, and what is written is
 the DECLARATION - which browsers a session has, who each one is, and where its
 tabs were pointing - not eight running engines. Reopening one gives the
 identities back immediately; each engine starts when a command is aimed at it,
-as the right person. Cookies and logins come back only where a browser had a
-`profile`, which is the mechanism that already exists for that.
+as the right person, **and reopens the tabs it had** - the urls are saved with
+the identity, and the first command aimed at a declared browser is what pays
+them back. That happens once: after it, the tabs are the browser's own business.
+Cookies and logins come back only where a browser had a `profile`, which is the
+mechanism that already exists for that.
 
 - **`seed`** is the identity. Same seed, same fingerprint, every time. Leave it
   out and one is drawn; the answer says which, so a session worth repeating can

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.18.0"
+version = "0.19.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/mcp/server.py
+++ b/src/aihawk/mcp/server.py
@@ -269,9 +269,16 @@ def remember(session_id: str | None = None) -> None:
         if not key.startswith(prefix):
             continue
         config = registry.config(key) or {}
-        browsers[key[len(prefix):]] = {
-            k: v for k, v in config.items() if k in WHO_A_BROWSER_IS
-        }
+        wrote = {k: v for k, v in config.items() if k in WHO_A_BROWSER_IS}
+        # Where it was, so reopening gives back the work and not only the
+        # person. A browser that has never been looked at contributes nothing
+        # rather than an empty list: an empty list would mean "it had no tabs",
+        # which is a different thing from "nobody has asked yet" and would wipe
+        # the pages of a browser that is up and busy.
+        been = _seen_tabs.get(key)
+        if been:
+            wrote["urls"] = been
+        browsers[key[len(prefix):]] = wrote
     try:
         if not browsers:
             store.erase(at_session)
@@ -296,7 +303,17 @@ def restore(session_id: str | None = None) -> bool:
     if not saved:
         return False
     for name, config in (saved.get("browsers") or {}).items():
-        registry.declare("%s/%s" % (at_session, name), config)
+        key = "%s/%s" % (at_session, name)
+        # The identity is DECLARED - the browser does not start - and the tabs
+        # are OWED, to be reopened by the wake that starts it. Kept apart from
+        # the identity on purpose: `declare` writes the launch settings, and a
+        # list of urls is not one of them. Handing them to the registry would
+        # make it carry a fact about pages, which is the one thing it has
+        # deliberately never known.
+        owed = config.pop("urls", None)
+        registry.declare(key, config)
+        if owed:
+            _tabs_owed[key] = list(owed)
     if saved.get("focus"):
         _focus[at_session] = saved["focus"]
     return True
@@ -321,6 +338,79 @@ def addressed(session_id: str | None = None, browser_id: str | None = None) -> s
     return "%s/%s" % (at_session, browser_id or focused(at_session))
 
 
+#: Where each browser's tabs were, by composed key. Written whenever a browser
+#: is handed out or listed, read by `remember` when the session is written down.
+#:
+#: ⛔ A CACHE AND NOT A SECOND TRUTH, and the difference is which way it flows.
+#: The tabs live in the running browser; this only remembers what they were the
+#: last time anybody looked, because `remember` is called from a synchronous
+#: hook and asking a browser for its tabs is asynchronous. So it is at most one
+#: command stale, and a session that ends between two looks comes back one
+#: command behind rather than empty.
+_seen_tabs: dict = {}
+
+#: Tabs a saved session declared and that have not been reopened yet, by key.
+#: Emptied by the wake that uses them, so a browser is restored ONCE: after that
+#: its tabs are its own business and reopening them would fight the caller.
+_tabs_owed: dict = {}
+
+
+def _note_tabs(key: str, urls) -> None:
+    """Remember where this browser's tabs are, and write it down if it moved.
+
+    ⛔ ON THE CHANGE AND NOT ON EVERY COMMAND, and the difference is a disk
+    write thirteen times a second. Every tool call passes through `ready`, and
+    the live view's frames are tool calls: saving from there unconditionally
+    would put the session file in the path of the frame pump. Pages move rarely
+    compared to how often a browser is touched, so comparing first turns "every
+    command" into "every navigation", which is what the file is actually about.
+    """
+    if urls is None:
+        return
+    fresh = [u for u in urls if u]
+    if _seen_tabs.get(key) == fresh:
+        return
+    _seen_tabs[key] = fresh
+    remember(key.split("/")[0])
+
+
+async def ready(session_id=None, browser_id=None):
+    """This browser, started, and back where it was.
+
+    ⛔ ONE FUNNEL, AND THAT IS THE WHOLE POINT OF IT EXISTING. Every tool used to
+    write `registry.ensure(addressed(...))` for itself - fourteen of them, plus
+    the retry - so "what it takes to hand somebody a usable browser" was a fact
+    known in fifteen places. The moment it stopped being just `ensure` - a
+    declared browser now has tabs owed to it - fifteen places would have had to
+    learn the same new step, and the one that did not would hand back a browser
+    that came home empty. The rule this follows is the project's: after the fix,
+    the places that know a thing are one.
+
+    Reopening happens ONCE per browser and only for tabs a SAVED session
+    declared. A browser that has been woken owns its own tabs, and a wake that
+    kept reopening them would fight whoever is using it.
+    """
+    at = addressed(session_id, browser_id)
+    owed = _tabs_owed.pop(at, None)
+    session = await registry.ensure(at)
+    if owed:
+        try:
+            for url in owed:
+                await session.new_page()
+                await actions.navigate(session, url)
+        except Exception:
+            # A url that will not load must not cost the browser. It is up, it
+            # is the right person, and the tab it could not reopen is one tab -
+            # refusing to hand it back would turn a stale bookmark into a
+            # session somebody cannot use.
+            pass
+    try:
+        _note_tabs(at, [p["url"] for p in await session.describe_pages()])
+    except Exception:
+        pass
+    return session
+
+
 async def _retrying(fn, *args, session_id=None, browser_id=None, **kwargs):
     """Run an action on one browser, and on failure rebuild it once and retry.
 
@@ -335,12 +425,22 @@ async def _retrying(fn, *args, session_id=None, browser_id=None, **kwargs):
     thing.
     """
     at = addressed(session_id, browser_id)
-    session = await registry.ensure(at)
+    session = await ready(session_id, browser_id)
     try:
         return await fn(session, *args, **kwargs)
     except Exception:
+        # ⛔ THE TABS ARE OWED AGAIN, or the recovery gives back half a browser.
+        # `drop` keeps the identity on purpose - the replacement is the same
+        # person - and until this line the pages were not part of "the same":
+        # a browser that died mid-command came back correct and empty, and the
+        # only way to notice was to go looking for your own work. What it had
+        # is what was last seen, which is what would have been saved had the
+        # process ended instead.
+        been = _seen_tabs.get(at)
+        if been:
+            _tabs_owed[at] = list(been)
         await registry.drop(at)
-        session = await registry.ensure(at)
+        session = await ready(session_id, browser_id)
         return await fn(session, *args, **kwargs)
 
 
@@ -504,6 +604,7 @@ async def browser_list(session_id: str | None = None) -> str:
         if running:
             try:
                 urls = [p["url"] or "" for p in await session.describe_pages()]
+                _note_tabs(addressed(at_session, name), urls)
             except Exception:
                 # Readable as a state rather than as an absence: a browser whose
                 # tabs cannot be read is not a browser with no tabs, and a pane
@@ -691,7 +792,7 @@ async def session_list_pages(session_id: str | None = None,
     default browser's tabs, as before; name them when a session holds more than
     one, since each browser numbers its own tabs."""
     return await actions.list_pages(
-        await registry.ensure(addressed(session_id, browser_id)))
+        await ready(session_id, browser_id))
 
 
 @mcp.tool()
@@ -705,7 +806,7 @@ async def session_select_page(page_id: str, session_id: str | None = None,
     default browser's tab, as before; name them when a session holds more than
     one, and use the browser the page id came from."""
     return actions.select_page(
-        await registry.ensure(addressed(session_id, browser_id)), page_id)
+        await ready(session_id, browser_id), page_id)
 
 
 @mcp.tool()
@@ -717,7 +818,7 @@ async def session_close_page(page_id: str = "", session_id: str | None = None,
     of the default browser, as before; name them when a session holds more than
     one."""
     return await actions.close_page(
-        await registry.ensure(addressed(session_id, browser_id)), page_id)
+        await ready(session_id, browser_id), page_id)
 
 
 # --- reading ---------------------------------------------------------------
@@ -761,7 +862,7 @@ async def browser_read_text(selector: str = "body", max_chars: int = 6000,
     session_id and browser_id are optional. Leave them out and this reads the
     default browser, as before; name them when a session holds more than one."""
     return await actions.read_text(
-        await registry.ensure(addressed(session_id, browser_id)),
+        await ready(session_id, browser_id),
         selector, max_chars)
 
 
@@ -788,7 +889,7 @@ async def browser_snapshot(max_chars: int = 0, session_id: str | None = None,
     default browser, as before. Name them to reach one of several.
     """
     return await actions.snapshot(
-        await registry.ensure(addressed(session_id, browser_id)), max_chars)
+        await ready(session_id, browser_id), max_chars)
 
 
 @mcp.tool()
@@ -813,7 +914,7 @@ async def browser_read_html(mode: str = "form", session_id: str | None = None,
     browser, as before. Name them to reach one of several.
     """
     return await actions.read_html(
-        await registry.ensure(addressed(session_id, browser_id)), mode)
+        await ready(session_id, browser_id), mode)
 
 
 @mcp.tool()
@@ -824,7 +925,7 @@ async def browser_take_screenshot(session_id: str | None = None,
     session_id and browser_id are optional. Leave them out and this pictures the
     default browser, as before; name them when a session holds more than one."""
     png = await actions.screenshot_png(
-        await registry.ensure(addressed(session_id, browser_id)))
+        await ready(session_id, browser_id))
     return Image(data=png, format="png")
 
 
@@ -840,7 +941,7 @@ async def browser_watch(session_id: str | None = None,
     session_id and browser_id are optional. Leave them out and this watches the
     default browser, as before; name them to watch one of several."""
     jpeg = await actions.watch_jpeg(
-        await registry.ensure(addressed(session_id, browser_id)))
+        await ready(session_id, browser_id))
     return Image(data=jpeg, format="jpeg")
 
 
@@ -859,7 +960,7 @@ async def browser_click(selector: str, session_id: str | None = None,
     the default browser, as before; name them when a session holds more than
     one, and use the browser the selector came from."""
     return await actions.click(
-        await registry.ensure(addressed(session_id, browser_id)), selector)
+        await ready(session_id, browser_id), selector)
 
 
 @mcp.tool()
@@ -889,7 +990,7 @@ async def browser_click_at(x: float, y: float, hold_seconds: float = 0.0,
     the default browser, as before; name them when a session holds more than
     one, and use the browser the coordinates came from."""
     png = await actions.click_at(
-        await registry.ensure(addressed(session_id, browser_id)),
+        await ready(session_id, browser_id),
         x, y, hold_seconds)
     return Image(data=png, format="png")
 
@@ -907,7 +1008,7 @@ async def browser_type(selector: str, text: str, session_id: str | None = None,
     the default browser, as before; name them when a session holds more than
     one."""
     return await actions.type_text(
-        await registry.ensure(addressed(session_id, browser_id)), selector, text)
+        await ready(session_id, browser_id), selector, text)
 
 
 @mcp.tool()
@@ -926,7 +1027,7 @@ async def browser_select_option(selector: str, value: str,
     the default browser, as before; name them when a session holds more than
     one."""
     return await actions.select_option(
-        await registry.ensure(addressed(session_id, browser_id)), selector, value)
+        await ready(session_id, browser_id), selector, value)
 
 
 @mcp.tool()
@@ -939,7 +1040,7 @@ async def browser_press_key(key: str, session_id: str | None = None,
     the default browser, as before; name them when a session holds more than
     one."""
     return await actions.press_key(
-        await registry.ensure(addressed(session_id, browser_id)), key)
+        await ready(session_id, browser_id), key)
 
 
 @mcp.tool()
@@ -965,7 +1066,7 @@ async def browser_evaluate(expression: str, session_id: str | None = None,
     session_id and browser_id are optional. Leave them out and this reads the
     default browser, as before; name them when a session holds more than one."""
     return await actions.evaluate(
-        await registry.ensure(addressed(session_id, browser_id)), expression)
+        await ready(session_id, browser_id), expression)
 
 
 def main() -> None:

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -1059,8 +1059,34 @@ function thumbFor(b){
   shut.onclick = (e) => { e.stopPropagation(); closeThis(b.id); };
   cap.appendChild(shut);
   el2.append(pic, cap);
-  el2.onclick = () => watchThis(b.id);
+  /* A pane that is only declared has to be STARTED before it can be watched,
+     and the two are one gesture: clicking it means "work here". */
+  el2.onclick = () => b.running ? watchThis(b.id) : wakeThis(b.id, el2);
   return el2;
+}
+
+/* ⛔ THE WAIT IS SHOWN, because it is seven to fourteen seconds - measured, and
+   the eighth browser takes twice the first. An interface that goes quiet for
+   fourteen seconds is the defect this project fixed elsewhere with the Thinking
+   clock, and a pane that simply does not change is indistinguishable from a
+   click that did nothing. */
+async function wakeThis(id, pane){
+  const st = pane.querySelector('.st'), pic = pane.querySelector('.pic span');
+  const t0 = performance.now();
+  const beat = setInterval(() => {
+    st.textContent = ((performance.now() - t0) / 1000).toFixed(0) + 's';
+  }, 250);
+  if(pic) pic.textContent = 'starting';
+  pane.disabled = true;
+  try {
+    await fetch(at('/live/wake'), {method:'POST', headers:{'Content-Type':'application/json'},
+                                   body: JSON.stringify({id})});
+    await watchThis(id);
+  } finally {
+    clearInterval(beat);
+    pane.disabled = false;
+    await drawFleet();
+  }
 }
 
 async function closeThis(id){
@@ -1676,14 +1702,17 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
         the interface has no privileged path to the browsers - and it starts
         nothing, so drawing the workspace can never cost an engine.
 
-        A conversation that has issued no instruction has no browsers by
-        definition, and asking would be the one question that creates what it
-        asks about. So it answers an empty workspace without going near the
-        server, which is the same rule the picture and the tab strip follow.
+        ⛔ AND IT ASKS EVEN WHEN THIS CONVERSATION HAS DONE NOTHING, which is
+        the opposite of what the picture and the tab strip do. Those may not ask
+        before an instruction because asking STARTS a browser; `browser_list` is
+        the one question that starts nothing, by construction and by its own
+        test. Copying the guard here looked prudent and was a bug: a session
+        reopened after a restart has browsers it declared and no instruction
+        yet, so the workspace would have been empty in exactly the case the
+        declarations exist for - and the panes offering to wake them would
+        never have been drawn.
         """
         seen = which(request)
-        if not seen.link.touched:
-            return JSONResponse({"browsers": [], "focus": "", "limit": 0})
         try:
             got = json.loads(await seen.link.call_text("browser_list"))
         except Exception:
@@ -1713,6 +1742,39 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
         said = await which(request).link.call_text("browser_focus",
                                                    {"browser_id": name})
         return JSONResponse({"focused": name, "said": said})
+
+    async def wake(request: Request) -> JSONResponse:
+        """Start a browser this session declared but has not needed yet.
+
+        ⛔ NO NEW TOOL, BECAUSE THE CONTRACT ALREADY SAYS WHAT A WAKE IS: the
+        next command aimed at a declared browser starts it, as the same person,
+        and reopens the tabs it had. So the wake IS that command - asking it for
+        its tabs - and the interface stays a client of the tools as they are
+        rather than growing a verb that only it can use.
+
+        It takes seven to fourteen seconds, measured, so it answers when the
+        browser is up rather than immediately: the page shows a stopwatch on the
+        pane meanwhile, and a route that returned early would leave that
+        stopwatch to guess.
+
+        ⛔ A TOOL THAT FAILS REACHES A CLIENT AS AN ERROR RESULT, NOT AS AN
+        EXCEPTION, so catching exceptions alone reported a browser awake that
+        had never started - measured, on the first real wake: the route answered
+        `awake` in five seconds while the pane still said "not up", and nothing
+        anywhere said why. The reason is read off the result and handed back.
+        """
+        body = await request.json()
+        name = (body or {}).get("id", "")
+        if not name:
+            return JSONResponse({"error": "no id"}, status_code=400)
+        try:
+            got = await which(request).link.call("session_list_pages",
+                                                 {"browser_id": name})
+        except Exception as exc:
+            return JSONResponse({"error": str(exc)[:200]}, status_code=503)
+        if getattr(got, "isError", False):
+            return JSONResponse({"error": text_of(got)[:300]}, status_code=503)
+        return JSONResponse({"awake": name, "said": text_of(got)})
 
     async def open_browser(request: Request) -> JSONResponse:
         """Open another browser in this session, from the workspace.
@@ -1788,6 +1850,7 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
         Route("/live/frame", frame),
         Route("/live/browsers", browsers),
         Route("/live/watch", watch, methods=["POST"]),
+        Route("/live/wake", wake, methods=["POST"]),
         Route("/live/open", open_browser, methods=["POST"]),
         Route("/live/close", close_browser, methods=["POST"]),
         Route("/live/tabs", tabs),

--- a/tests/mcp_server/test_a_browser_comes_back_where_it_was.py
+++ b/tests/mcp_server/test_a_browser_comes_back_where_it_was.py
@@ -1,0 +1,188 @@
+"""Waking a declared browser gives back the person AND the pages.
+
+Slice 3 made a saved session give back WHO its browsers were. That is half of
+what somebody reopens a session for: a browser that comes home as the right
+person with nothing open is right about its identity and wrong about its work.
+This file is the other half - where it was.
+
+⛔ AND IT HAPPENS ONCE. A browser that kept reopening the tabs a file remembers
+would fight whoever is using it, closing nothing and adding the same pages back
+every time it was handed out. The tabs are OWED, and the wake that pays them
+clears the debt.
+
+No browser starts here: the registry is given a factory that launches nothing,
+and its sessions record the pages they were asked to open.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aihawk.mcp import actions, server, store
+
+
+class _Recording:
+    """A session that launches nothing and records the pages it was given."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self._browser = None
+        self._context = object()
+        self.closed = False
+        self.pages = []
+
+    async def start(self):
+        pass
+
+    async def close(self):
+        self.closed = True
+
+    async def new_page(self):
+        self.pages.append("")
+        return "tab-%d" % len(self.pages)
+
+    async def describe_pages(self):
+        return [{"id": "tab-%d" % (i + 1), "url": u, "title": "", "active": False}
+                for i, u in enumerate(self.pages)]
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    reg = server.new_registry(factory=_Recording,
+                              defaults=lambda: {"seed": 7, "headless": True})
+    monkeypatch.setattr(server, "registry", reg)
+    monkeypatch.setattr(server, "_focus", {})
+    monkeypatch.setattr(server, "_loaded", set())
+    monkeypatch.setattr(server, "_seen_tabs", {})
+    monkeypatch.setattr(server, "_tabs_owed", {})
+
+    async def _went(session, url, wait_until="domcontentloaded"):
+        session.pages[-1] = url
+        return "navigated to %s" % url
+
+    monkeypatch.setattr(actions, "navigate", _went)
+    return reg
+
+
+async def test_where_a_browser_was_is_written_down_with_who_it_was(registry):
+    """Known-bad: drop the `urls` line from `remember`. The session comes back
+    with the right person and an empty window, which is the half of the promise
+    nobody notices is missing until they look for their work.
+    """
+    await server.browser_open(browser_id="docs", seed=4242)
+    session = await server.ready(browser_id="docs")
+    await session.new_page()
+    await actions.navigate(session, "http://example.test/one")
+    # Any command aimed at it notes where it is; this is the one the interface
+    # uses to draw its panes.
+    await server.browser_list()
+
+    saved = store.load("default")
+    assert saved["browsers"]["docs"]["urls"] == ["http://example.test/one"]
+    assert saved["browsers"]["docs"]["seed"] == 4242
+
+
+async def test_a_browser_nobody_has_looked_at_does_not_report_an_empty_window(registry):
+    """⛔ "NOBODY ASKED" IS NOT "IT HAD NO TABS", and writing the second would
+    wipe the pages of a browser that is up and busy the moment anything saved
+    the session for another reason.
+
+    Known-bad: write `wrote["urls"] = been or []` instead of only when there is
+    something.
+    """
+    await server.browser_open(browser_id="docs")
+
+    saved = store.load("default")
+    assert "urls" not in saved["browsers"]["docs"], saved["browsers"]["docs"]
+
+
+async def test_waking_a_declared_browser_reopens_the_tabs_it_had(registry, monkeypatch):
+    """The point of the whole slice.
+
+    Known-bad, two: drop the reopen loop from `ready`, and have `restore` hand
+    the urls to `registry.declare` as part of the identity - the registry would
+    then pass `urls` to the session factory, which is a launch setting no
+    browser has.
+    """
+    store.save("default", {"docs": {"seed": 4242, "headless": True,
+                                    "urls": ["http://a.test/", "http://b.test/"]}},
+               focus="docs")
+
+    assert server.browsers_in() == ["docs"]
+    assert registry.ids() == [], "reading a session back started a browser"
+
+    session = await server.ready(browser_id="docs")
+
+    assert session.kwargs.get("seed") == 4242, "it came back as somebody else"
+    assert "urls" not in session.kwargs, (
+        "the urls were handed to the browser as a launch setting: %r"
+        % session.kwargs)
+    assert session.pages == ["http://a.test/", "http://b.test/"]
+
+
+async def test_the_tabs_are_reopened_once_and_not_on_every_command(registry):
+    """⛔ OTHERWISE THE WAKE FIGHTS THE PERSON USING IT. A browser handed out
+    twice would get the same two pages added twice, and a session used for an
+    hour would end with a hundred copies of where it started.
+
+    Known-bad: read `_tabs_owed` without removing the entry.
+    """
+    store.save("default", {"docs": {"seed": 1, "headless": True,
+                                    "urls": ["http://a.test/"]}})
+
+    first = await server.ready(browser_id="docs")
+    await server.ready(browser_id="docs")
+    await server.ready(browser_id="docs")
+
+    assert first.pages == ["http://a.test/"], first.pages
+
+
+async def test_a_url_that_will_not_load_does_not_cost_the_browser(registry, monkeypatch):
+    """It is up and it is the right person. Refusing to hand it back over one
+    stale bookmark turns a dead link into a session nobody can use.
+
+    Known-bad: remove the try/except around the reopen loop.
+    """
+    async def _refuses(session, url, wait_until="domcontentloaded"):
+        raise RuntimeError("NS_ERROR_UNKNOWN_HOST")
+
+    monkeypatch.setattr(actions, "navigate", _refuses)
+    store.save("default", {"docs": {"seed": 1, "headless": True,
+                                    "urls": ["http://gone.test/"]}})
+
+    session = await server.ready(browser_id="docs")
+
+    assert session is not None
+    assert session.kwargs.get("seed") == 1
+
+
+async def test_a_browser_that_was_never_saved_is_woken_empty(registry):
+    """Known-bad: default the owed tabs to something. A brand new browser then
+    opens a page nobody asked for.
+    """
+    session = await server.ready(browser_id="fresh")
+    assert session.pages == []
+
+
+async def test_the_retry_path_wakes_the_same_way(registry):
+    """`_retrying` rebuilds a browser that died mid-command, and that rebuild is
+    a wake like any other: the same person, back where it was.
+
+    Known-bad: have `_retrying` call `registry.ensure` directly again. The
+    browser comes back correct and empty, and only a caller looking for its tabs
+    would ever notice.
+    """
+    store.save("default", {"main": {"seed": 9, "headless": True,
+                                    "urls": ["http://a.test/"]}})
+    seen = {}
+
+    async def _once(session, *a, **k):
+        if "first" not in seen:
+            seen["first"] = True
+            raise RuntimeError("the browser died")
+        return json.dumps([p["url"] for p in await session.describe_pages()])
+
+    got = await server._retrying(_once)
+
+    assert json.loads(got) == ["http://a.test/"], got

--- a/tests/mcp_server/test_addressing.py
+++ b/tests/mcp_server/test_addressing.py
@@ -323,12 +323,62 @@ def test_no_registry_call_in_the_server_is_left_without_an_address():
     assert not unaddressed, (
         "these reach the registry with no browser named, so they act on the "
         "default one whatever the caller asked for: %s" % unaddressed)
-    # 20 today. A floor rather than the number, because the point is that the
-    # scan found the calls at all: a scan that matches nothing passes the
-    # assertion above without reading a line of the module.
-    assert len(checked) >= 18, (
+    # ⛔ THE FLOOR WENT FROM 18 TO 10 ON PURPOSE, AND THE SCAN GOT STRONGER
+    # RATHER THAN WEAKER. In 0.19.0 the fourteen tools that each wrote
+    # `registry.ensure(addressed(...))` for themselves were moved onto one
+    # funnel, `ready`, because "what it takes to hand somebody a usable browser"
+    # had stopped being just `ensure` - a declared browser now has tabs owed to
+    # it - and fifteen places would have had to learn the same new step. So
+    # there are fewer registry calls to guard because there are fewer places
+    # able to get it wrong. Lowering a floor is normally how a gate is quietly
+    # switched off, which is why the reason is written here and why the
+    # companion test below asserts that the funnel is what the tools use.
+    assert len(checked) >= 10, (
         "only %d registry calls were found in %s; has the module moved?"
         % (len(checked), SERVER_PY.name))
+
+
+def test_no_tool_reaches_for_a_browser_on_its_own():
+    """⛔ THE GUARANTEE THAT REPLACED THE ONE ABOVE, and it is stronger than
+    what it replaced. The floor on registry calls fell from 18 to 10 when the
+    tools were moved onto `ready`; a lower floor on its own is how a gate gets
+    switched off, so this says the thing the floor used to imply and says it
+    directly: no TOOL touches the registry itself.
+
+    It matters because `ready` is no longer a synonym for `ensure`. A browser
+    restored from a saved session has tabs owed to it, and a tool that called
+    `ensure` for itself would hand back that person's browser with none of that
+    person's pages - a browser that is right about who it is and wrong about
+    where it was.
+
+    Known-bad: put `await registry.ensure(addressed(session_id, browser_id))`
+    back into any one tool. The scan above still passes, because that call IS
+    addressed; only this one sees it.
+    """
+    tree = ast.parse(SERVER_PY.read_text(encoding="utf-8"))
+    #: The three that legitimately act on the registry rather than ask it for a
+    #: browser to drive: opening one, closing one, and choosing an identity.
+    NOT_DRIVING_A_PAGE = {"browser_open", "browser_close", "session_start",
+                          "session_forget", "session_status", "browser_list"}
+    rogue = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        decorated = any(
+            isinstance(d, ast.Call) and isinstance(d.func, ast.Attribute)
+            and d.func.attr == "tool" for d in node.decorator_list)
+        if not decorated or node.name in NOT_DRIVING_A_PAGE:
+            continue
+        for inner in ast.walk(node):
+            if (isinstance(inner, ast.Call)
+                    and isinstance(inner.func, ast.Attribute)
+                    and isinstance(inner.func.value, ast.Name)
+                    and inner.func.value.id == "registry"):
+                rogue.append("%s: registry.%s" % (node.name, inner.func.attr))
+    assert not rogue, (
+        "these reach the registry themselves instead of asking `ready` for a "
+        "browser, so a session restored from disk comes back without its "
+        "tabs: %s" % rogue)
 
 
 def _tools_that_reach_a_browser():
@@ -352,7 +402,8 @@ def _tools_that_reach_a_browser():
                     and inner.func.value.id == "registry"
                     and inner.func.attr in ADDRESSABLE):
                 found.add(node.name)
-            if isinstance(inner.func, ast.Name) and inner.func.id == "_retrying":
+            if (isinstance(inner.func, ast.Name)
+                    and inner.func.id in ("_retrying", "ready")):
                 found.add(node.name)
     return found
 

--- a/tests/test_the_browser_workspace.py
+++ b/tests/test_the_browser_workspace.py
@@ -106,20 +106,31 @@ async def test_the_workspace_is_read_from_the_server_like_any_other_client():
     assert any(name == "browser_list" for name, _ in link.calls)
 
 
-async def test_a_conversation_that_has_done_nothing_draws_no_panes_and_asks_nothing():
-    """⛔ OR OPENING A CHAT COSTS AN ENGINE. Over MCP there is no way to ask "is
-    a browser running" without starting one, so a workspace drawn for a session
-    that has issued no instruction must answer from what it already knows.
+async def test_the_workspace_asks_the_one_question_that_starts_nothing():
+    """⛔ THE GUARD THAT BELONGS ON THE PICTURE DOES NOT BELONG HERE, and putting
+    it here cost the feature its whole point. The frame and the tab strip may not
+    ask before an instruction because asking STARTS a browser. `browser_list`
+    starts nothing - that is its promise and there is a test for it in the
+    server - so the workspace asks always.
 
-    Known-bad: drop the `touched` guard from the browsers route.
+    Copying the guard looked prudent and was a bug: a session reopened after a
+    restart has browsers it DECLARED and no instruction yet, so the workspace
+    would have been empty in exactly the case the declarations exist for, and
+    the panes offering to wake them would never have been drawn.
+
+    Known-bad: put `if not seen.link.touched: return empty` back at the top of
+    the browsers route.
     """
     link, sessions, client = _app()
 
     got = client.get("/live/browsers?s=mai-usata").json()
 
-    assert got["browsers"] == []
-    assert link.calls == [], (
-        "drawing an empty workspace reached the server: %r" % link.calls)
+    assert [b["id"] for b in got["browsers"]] == ["docs", "posta", "dormiente"], (
+        "a session that has issued no instruction was shown no panes, so a "
+        "reopened session cannot offer to wake the browsers it declared")
+    assert [name for name, _ in link.calls] == ["browser_list"], (
+        "drawing the workspace called something other than the question that "
+        "starts nothing: %r" % link.calls)
 
 
 async def test_an_older_server_leaves_the_workspace_empty_instead_of_breaking_the_pane():
@@ -221,10 +232,35 @@ def test_the_previews_cost_the_same_whether_there_are_two_or_eight():
         "no longer one thing")
 
     # And the function that BUILDS a pane starts no timer of its own.
-    builder = script[script.index("function thumbFor"):script.index("async function watchThis")]
+    #
+    # ⛔ BOUNDED BY BRACES, not by "up to the next function". The first version
+    # cut from `function thumbFor` to the name of whatever came next, so a
+    # function written between them was read as part of the builder: the wake's
+    # stopwatch tripped it, and a stopwatch that ticks during one click is not
+    # a pane refreshing itself. A slice that moves when unrelated code moves is
+    # a gate that goes red for the wrong reason, which teaches people to widen
+    # it - and the widened version would have stopped seeing the real thing.
+    start = script.index("function thumbFor")
+    depth, end = 0, start
+    for i in range(script.index("{", start), len(script)):
+        if script[i] == "{":
+            depth += 1
+        elif script[i] == "}":
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    builder = script[start:end]
     assert "setTimeout" not in builder and "setInterval" not in builder, (
         "a pane schedules its own refresh, so the cost of the previews grows "
         "with the number of panes - which is the thing the arithmetic forbids")
+
+    # The wake's stopwatch is allowed and is not a refresh, but an interval that
+    # is never cleared is a leak that outlives the click that made it.
+    wake = script[script.index("async function wakeThis"):]
+    wake = wake[:wake.index(chr(10) + "}")]
+    assert "setInterval" not in wake or "clearInterval" in wake, (
+        "the wake starts a stopwatch it never stops")
 
 
 def test_a_pane_that_is_not_running_is_never_asked_for_a_picture():
@@ -281,3 +317,37 @@ def test_the_page_declares_no_identifier_twice():
     assert not twice, (
         "declared twice at the top level of the page's script, which is a "
         "syntax error that stops the whole file from running: %s" % sorted(set(twice)))
+
+
+async def test_waking_nothing_refuses():
+    """A wake takes seven to fourteen seconds and starts an engine. Treating a
+    missing id as "the current one" would make a bug in the page spend that on a
+    browser nobody asked about.
+
+    Known-bad: default the id instead of refusing.
+    """
+    _, sessions, client = _app()
+    assert client.post("/live/wake?s=lavoro", json={}).status_code == 400
+
+
+async def test_the_wake_is_the_first_command_aimed_at_the_browser():
+    """⛔ NO NEW TOOL FOR IT. The contract already says a declared browser starts
+    on the next command aimed at it, as the same person, with the tabs it had.
+    So the wake IS that command, and the interface stays a client of the tools
+    as they are rather than growing a verb only it can use.
+
+    Known-bad: have the route call `browser_open`. That opens a NEW browser
+    instead of starting the declared one, so the person waiting for their tabs
+    gets a stranger with none.
+    """
+    link, sessions, client = _app()
+    await sessions.get("lavoro").send("start something")
+    before = len(link.calls)
+
+    client.post("/live/wake?s=lavoro", json={"id": "dormiente"})
+
+    made = [c for c in link.calls[before:]]
+    assert ("session_list_pages",
+            {"browser_id": "dormiente", "session_id": "lavoro"}) in made, made
+    assert not any(name == "browser_open" for name, _ in made), (
+        "waking a declared browser opened a new one instead: %r" % made)

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -265,7 +265,9 @@ async def test_the_app_exposes_exactly_the_routes_the_page_calls():
                      # The workspace, added in 0.18.0: which browsers to draw a
                      # pane for, and which one the commands go to.
                      "/live/browsers", "/live/watch",
-                     "/live/open", "/live/close"}
+                     "/live/open", "/live/close",
+                     # Waking a declared browser, added in 0.19.0.
+                     "/live/wake"}
 
     called = {m for m in re.findall(r"""fetch\(\s*[`'"]([^`'"?]+)""", PAGE)}
     unserved = sorted(called - paths)


### PR DESCRIPTION
A saved session gave back WHO its browsers were. That is half of what somebody reopens a session for: a browser that comes home as the right person with nothing open is right about its identity and wrong about its work.

The urls are saved with the identity now, and the first command aimed at a declared browser reopens them. Click a pane that says "not up" and it starts, with a stopwatch on it, because seven to fourteen seconds of silence is the defect this project fixed elsewhere with the Thinking clock. The reopen happens once - a wake that kept reopening would fight whoever is using the browser.

**Fourteen tools wrote `registry.ensure(addressed(...))` for themselves**, so "what it takes to hand somebody a usable browser" was a fact known in fifteen places. The moment it stopped being just `ensure`, fifteen places would have had to learn the same new step, and the one that did not would hand back a browser that came home empty. They go through one funnel, `ready`, and a test says no tool reaches the registry on its own. The floor on the address scan fell from 18 to 10 because there are fewer places able to get it wrong; that is normally how a gate gets switched off, so the reason sits where the number is and a stronger guarantee replaced it.

Three things this got wrong:

- The recovery path brought back half a browser. `drop` keeps the identity on purpose, and the pages were not part of "the same person" - a browser that died mid-command came back correct and empty, and the only way to notice was to go looking for your own work.
- The session file was never rewritten when tabs moved, so the urls were fresh in memory and stale on disk. Saving from `ready` unconditionally would have put a disk write in the path of the frame pump, thirteen times a second, so it writes when the tabs actually changed.
- The workspace copied the `touched` guard from the picture route, where it belongs because asking for a picture STARTS a browser. `browser_list` starts nothing, so the copy emptied the workspace in exactly the case declarations exist for.

Verified with a real engine: a session file declaring a browser with a url, a restart, and the wake brought it back on that page - then a second browser made the first one a preview showing a real frame.