### PR TITLE
Give the two pages with no in-body links out a way onward

### DIFF
--- a/docs/automating-linkedin-posts-read-this-first.md
+++ b/docs/automating-linkedin-posts-read-this-first.md
@@ -90,14 +90,21 @@ engagement SaaS products whose LinkedIn support does not run through the
 approved API, operating instead through unofficial means; and there is browser
 automation in all its forms, AI agents included, driving the site the way a
 person would. The clauses quoted above cover both, and the help pages say what
-happens next: detection, then restriction. LinkedIn's automated-activity page
+happens next: detection, then restriction. The detection half is not specific
+to this platform and is
+[its own subject](why-does-my-ai-agent-get-blocked.md); what is specific here
+is that the terms already answer the question before detection enters it. LinkedIn's automated-activity page
 describes the recovery path for a restricted account, which involves disabling
 the software before the account is re-enabled, and the restrictions page says
 plainly that the outcome can be temporary or permanent.
 
 The cost side deserves one plain sentence. A LinkedIn account is, for most
 people, a professional identity built over years, which makes it about the
-most expensive account there is to lose to a tool experiment.
+most expensive account there is to lose to a tool experiment. That calculation
+is the same one behind
+[whether to log an agent into your accounts at all](should-you-log-your-ai-agent-into-accounts.md),
+and it comes out differently for a throwaway login than for the account your
+career sits on.
 
 One line acknowledging the obvious, because pretending otherwise would insult
 you: tools and workflows that automate LinkedIn through the browser exist in
@@ -105,9 +112,14 @@ the wild, and this page does not name, link or describe them.
 
 ## Why this wiki does not publish a LinkedIn walkthrough
 
-The social posting series here has per-platform pages for Facebook, Instagram
-and X. LinkedIn is deliberately absent, and this page is the explanation
-rather than the replacement.
+The social posting series here has per-platform pages for
+[Facebook](post-to-facebook-with-an-ai-agent.md),
+[Instagram](post-to-instagram-with-an-ai-agent.md) and
+[X](ai-agent-post-to-x.md). LinkedIn is deliberately absent, and this page is
+the explanation rather than the replacement. Reading one of the three next to
+this one is the clearest way to see the difference: they open with what their
+platform's terms say and then continue, and here the opening is where the page
+ends.
 
 An honest LinkedIn automation guide would have to open by telling you that the
 platform's terms prohibit the approach it was about to teach; section 8.2

--- a/docs/post-to-instagram-with-an-ai-agent.md
+++ b/docs/post-to-instagram-with-an-ai-agent.md
@@ -64,7 +64,11 @@ inferred from a failed attempt. The agent can log in with your saved
 session, open the create dialog and write a caption, but it cannot hand a
 file to the picker. Since a feed post cannot exist without media, **AIHawk
 cannot post to Instagram end to end, and this page will not pretend
-otherwise.**
+otherwise.** What each of those tools returns, and why the ladder between them
+stops where it does, is
+[written down separately](mcp-tool-design.md), which is what makes a limit
+like this one checkable against the source instead of guessed at from a
+failure.
 
 What works instead is a division of labor that is honest about who does
 what. Run headed, so the browser is a normal window on your desktop:
@@ -84,6 +88,9 @@ that cannot say that sentence is selling something.
 
 The final click stays yours either way. AIHawk's stated rule for every
 surface applies verbatim here: do not submit anything a human has not read.
+[The forms page](ai-agent-fill-out-forms.md) states the same rule and shows
+what it costs to follow, since a form that rejects a submission puts the agent
+into a read-back loop where the temptation to stop reading is highest.
 
 ## The terms, and the account you are risking
 
@@ -106,7 +113,10 @@ trigger action against the account - challenges, feature blocks,
 restriction, or loss of the account - and Instagram has enforced against
 automation more visibly than almost any platform. A personal account driven
 by an agent, even gently, carries that risk, and the account is yours, not
-the tool's. The lowest-risk shape is the one this page describes: your
+the tool's. That is the whole of
+[the question of whether to log an agent in at all](should-you-log-your-ai-agent-into-accounts.md),
+and a personal account with years of history in it is the case where the
+answer is least obvious. The lowest-risk shape is the one this page describes: your
 session, your media click, your review, single posts at human frequency.
 
 ## Short answers to the questions that lead here


### PR DESCRIPTION
The link graph counts 61 pages in this wiki, and two of them had no contextual outgoing links at all: every internal link sitting in the See also footer, which the graph excludes because boilerplate carries no weight. Both are the pages where the honest answer is a boundary rather than a walkthrough, which is why they had the fewest natural places to send a reader onward.

Nothing operational is added and no step is taught.

The LinkedIn page names the three sibling platform pages in the sentence that already says LinkedIn is deliberately absent from that series, points the detection half at the page that owns it, and connects the cost of losing a professional account to the question of logging an agent in at all.

The Instagram page points its checkable limit at how the tool set is shaped, its read-before-submit rule at the forms page that states the same rule, and its account-risk paragraph at the same accounts page.

Two anchors were rewritten after reading the target: one credited the tool-design page with an argument about a short list of verbs, and one put words in the forms page about fields an agent did not author. Neither page says that, and an anchor that describes its target wrongly is worse than no link.

Checked before opening: aihawk goes from 2 mute pages to 0, outbound density median 3.5 per thousand words, inside the 2-5 house range. The content gate and its selftest, english-only, and the wiki build with its sidebar and Home are all clean, and the built wiki has no unresolved internal links.
