### PR TITLE
The review says which versions it read, not what PyPI serves today

### DIFF
--- a/docs/aihawk-review.md
+++ b/docs/aihawk-review.md
@@ -25,9 +25,12 @@ AIHawk is an open-source AI web agent: you describe a task in plain
 language and it drives a real browser until the task is done. The
 repository sits at about 30,300 stars and 4,600 forks, has existed since
 August 2024, and is MIT licensed. The Python package `aihawk` is on PyPI
-at version 0.3.0, published 3 September 2026, requiring Python 3.11 or
-newer; the repository's main branch already carries 0.4.0, and the
-statements below that name a version say which one they describe.
+and needs Python 3.11 or newer. This review was written against what the
+index and the repository carried on 3 September 2026: 0.3.0 published,
+0.4.0 on the main branch. The package has shipped many times since, so
+[the PyPI page](https://pypi.org/project/aihawk/) is the current answer
+and this paragraph is not; the statements below that name a version say
+which one they describe.
 
 One factual line on where it came from, because the repository description
 still says it: the project was born as an AI web agent that applied to


### PR DESCRIPTION
The paragraph introducing the review said the package "is on PyPI at version 0.3.0". True when it was written on 3 September; the index now serves 0.19.0.

A reader today sees a number sixteen releases behind and reasonably concludes the project has stalled, which is the opposite of what the repository shows - the wiki page argues that every claim on it is checkable, so a stale number costs it more than it would cost an ordinary page.

The sources list at the bottom already had the right shape: it dates its reading rather than asserting a present tense, so it cannot go stale. The paragraph now matches it and points at the PyPI page for the current answer.

The versions stay in the text on purpose. A review of something that ships several times a week has to say which build it looked at, or none of its claims can be checked.

## Test plan

- [x] `scripts/check_content.py` clean, and its own selftest green (13 mutations caught, 6 clean cases pass)
- [x] `scripts/check_english_only.py` clean
- [x] One paragraph changed, no other page touched
