### PR TITLE
The live pane asks for twenty-five frames a second, and gets them (0.20.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.19.0"
+version = "0.20.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -41,7 +41,7 @@ dependencies = [
     # url, and both are read off what page.goto() answers. Until 0.13.2 that
     # was hardcoded to None on every navigation, so on an older wheel the tool
     # would tell a model "no HTTP response" for every page it ever visited.
-    "invisible-playwright>=0.13.2",
+    "invisible-playwright>=0.14.0",
     # HTML parsing for browser_read_html. Chosen over lxml by measurement: on
     # six real pages both found byte-identical sets of interactive elements,
     # so correctness did not separate them, and selectolax then parsed 3-5x

--- a/src/aihawk/mcp/session.py
+++ b/src/aihawk/mcp/session.py
@@ -167,6 +167,20 @@ class StealthSession:
     #: whoever is watching, not a viewport size; the engine never scales up.
     WATCH_SIZE = {"width": 1280, "height": 800}
 
+    #: Frames a second to ask the engine for.
+    #:
+    #: ⛔ THE WRAPPER'S DEFAULT IS TEN AND THIS IS SOMEBODY WATCHING, which is
+    #: the case the parameter exists for. The default is ten because a batch
+    #: job that never looks at a frame should not pay for a live view: measured
+    #: 2026-09-08, ten costs 257 KB/s and twenty-five costs 629. Here there IS
+    #: somebody looking, so the bandwidth buys something.
+    #:
+    #: It is the last link of a chain that was slow in three places and is now
+    #: fast in all three: the engine makes what it is asked for, the wrapper
+    #: passes the request on (0.14.0, which the floor below requires), and the
+    #: page asks often enough to collect them.
+    WATCH_FPS = 25
+
     async def watch_frame(self, page_id: Optional[str] = None,
                           timeout: float = 3.0) -> bytes:
         """The latest JPEG frame of the WINDOW the active tab lives in.
@@ -179,8 +193,8 @@ class StealthSession:
         system, in the parent process, with nothing injected into the page.
 
         The capture is started on first use and kept running for the life of
-        the tab, so the frame answered here is at most a tenth of a second
-        old. Stopped with the tab in `close_page`.
+        the tab, so the frame answered here is at most a twenty-fifth of a
+        second old. Stopped with the tab in `close_page`.
         """
         page = self.page(page_id)
         pid = next(k for k, v in self._pages.items() if v is page)
@@ -194,7 +208,8 @@ class StealthSession:
 
             try:
                 await page.screencast.start(on_frame=on_frame,
-                                            size=dict(self.WATCH_SIZE))
+                                            size=dict(self.WATCH_SIZE),
+                                            fps=self.WATCH_FPS)
             except Exception as refused:
                 # The installed engine or wrapper predates the screencast.
                 # Say which feature is missing rather than surfacing a

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -905,13 +905,21 @@ async function tick(){
      4.6 fps to the pane, 60 ms delivers 10.0, which is everything the capture
      produces (9.6 fps measured at its own callback).
 
-     60 and not 0: a frame costs one round trip of about 22 ms on the pipe that
-     ACTIONS also use, so the cycle is roughly 82 ms and asks about 13 times a
-     second for 10 frames - a little waste to keep the picture whole, against
-     the 46 a second an unpaced loop would ask, which would spend the pipe on
-     duplicates and make every click queue behind them. An action still waits
-     at most one frame. */
-  setTimeout(tick, 60);
+     18 and not 0, and 18 rather than 60 since the server started asking the
+     engine for 25 frames a second instead of taking its default of 10. A frame
+     costs one round trip of about 22 ms on the pipe that ACTIONS also use, so
+     the cycle is about 40 ms: 25 requests a second for 25 frames, which is
+     roughly 55% of the pipe. That is a lot and it is bought deliberately - it
+     is the difference between a pane that moves and one that stutters - and
+     what it leaves is still far more than an agent needs, since an action
+     costs about 20 ms and an agent takes one or two a second. The slow
+     previews of the other browsers add about 5% more, by design: their cost
+     does not grow with how many there are.
+
+     Unpaced it would ask about 46 times a second, spend the pipe on duplicate
+     frames and make every click queue behind them. An action still waits at
+     most one frame. */
+  setTimeout(tick, 18);
 }
 
 /* Built from elements with textContent and never innerHTML: this string comes

--- a/tests/mcp_server/test_watch.py
+++ b/tests/mcp_server/test_watch.py
@@ -32,8 +32,14 @@ class _FakeScreencast:
         self.stops = 0
         self.on_frame = None
 
-    async def start(self, on_frame=None, size=None, quality=None, path=None):
-        self.starts.append({"size": size, "quality": quality, "path": path})
+    async def start(self, on_frame=None, size=None, quality=None, path=None,
+                    fps=None):
+        # `fps` arrived in invisible-playwright 0.14.0 and the floor requires
+        # it. A stand-in that did not take it made every test here fail with a
+        # TypeError dressed up as "this engine has no screencast", which is the
+        # stand-in being the wrong shape rather than the code being wrong.
+        self.starts.append({"size": size, "quality": quality, "path": path,
+                            "fps": fps})
         self.on_frame = on_frame
 
     async def stop(self):
@@ -82,7 +88,8 @@ async def test_the_capture_starts_once_and_answers_the_latest_frame():
     first = await s.watch_frame()
     assert first.startswith(b"\xff\xd8\xff"), first
     assert page.screencast.starts == [{"size": {"width": 1280, "height": 800},
-                                       "quality": None, "path": None}]
+                                       "quality": None, "path": None,
+                                       "fps": StealthSession.WATCH_FPS}]
     page.screencast.deliver(b"\xff\xd8\xff frame-2")
     second = await s.watch_frame()
     assert second.endswith(b"frame-2"), "the LATEST frame, not the first"
@@ -171,3 +178,37 @@ def _jpeg_height(data: bytes) -> int:
         length = int.from_bytes(data[i + 2:i + 4], "big")
         i += 2 + length
     raise AssertionError("no SOF marker in the JPEG")
+
+
+@pytest.mark.asyncio
+async def test_the_capture_is_asked_for_the_rate_somebody_watching_needs():
+    """⛔ THE LAST LINK OF A CHAIN THAT WAS SLOW IN THREE PLACES. The engine
+    makes what it is asked for, the wrapper passes the request on since 0.14.0,
+    and this is where the number is chosen. Ten is the wrapper's default because
+    a batch job that never looks at a frame should not pay for a live view -
+    measured, ten costs 257 KB/s and twenty-five costs 629 - and here there IS
+    somebody looking.
+
+    Known-bad: drop `fps=self.WATCH_FPS` from the start call. Nothing fails, no
+    test turns red without this one, and the pane silently goes back to ten
+    frames a second while the page asks for twenty-five and gets duplicates.
+    """
+    s = StealthSession()
+    s._context = _FakeContext()
+    pid = await s.new_page()
+    page = s.page(pid)
+    # The frame can only be delivered once the capture has started, and the
+    # capture starts inside `watch_frame` - so it is fed from a task, the way
+    # the first test in this file does it.
+    async def feed():
+        await asyncio.sleep(0.02)
+        page.screencast.deliver(bytes([0xFF, 0xD8, 0xFF]) + b" frame")
+
+    asyncio.ensure_future(feed())
+    await s.watch_frame()
+
+    asked = page.screencast.starts[-1]
+    assert asked["fps"] == StealthSession.WATCH_FPS, asked
+    assert StealthSession.WATCH_FPS > 10, (
+        "the live view is asking for the wrapper's default, which is the rate "
+        "chosen for consumers that are not watching")

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -568,13 +568,22 @@ async def test_the_frame_pause_is_shorter_than_the_capture_produces():
     pause_ms = int(m.group(1))
 
     round_trip_ms = 22    # measured against the running interface
-    source_period_ms = 100  # 10 fps out of the capture
+
+    # ⛔ THE RATE IS READ FROM THE CODE THAT ASKS FOR IT, not written here. It
+    # was `source_period_ms = 100  # 10 fps` and the day the server started
+    # asking the engine for 25 that comment became a false number in a gate:
+    # the assertion would have stayed green while the pane collected twelve of
+    # the twenty-five frames it was being sent, which is the failure this test
+    # exists to catch, hidden inside the test itself.
+    from aihawk.mcp.session import StealthSession
+
+    source_period_ms = 1000 / StealthSession.WATCH_FPS
 
     assert pause_ms + round_trip_ms <= source_period_ms, (
-        "a %d ms pause makes a %d ms cycle against a source that produces one "
-        "frame every %d ms, so the pane would show about %.1f of the 10 fps it "
-        "is being sent" % (pause_ms, pause_ms + round_trip_ms, source_period_ms,
-                           1000 / (pause_ms + round_trip_ms)))
+        "a %d ms pause makes a %d ms cycle against a source asked for %d fps - "
+        "one frame every %.0f ms - so the pane would show about %.1f of them"
+        % (pause_ms, pause_ms + round_trip_ms, StealthSession.WATCH_FPS,
+           source_period_ms, 1000 / (pause_ms + round_trip_ms)))
 
 
 async def test_the_answer_is_built_from_nodes_and_never_from_html():


### PR DESCRIPTION
The last link of a chain that was slow in three places. The engine makes what it is asked for; the wrapper ignored the request until invisible-playwright 0.14.0 and passed its own default of ten; and the page paused 60 ms between frames, which collects about twelve. Each link was fixed where it lived, in the order the project's rule imposes: publish the wrapper, move the floor, then use the parameter.

Ten is the right default for the **wrapper**, because a batch job that never looks at a frame should not pay for a live view - measured, ten costs 257 KB/s and twenty-five costs 629. Here there is somebody looking, so the bandwidth buys something, and the pause comes down to 18 ms: a cycle of about 40 ms, 25 requests a second for 25 frames, roughly 55% of a pipe that actions share. That is a lot and it is bought deliberately, and what is left is far more than an agent needs at one or two actions a second costing 20 ms each.

**And the gate on the pause had the old rate written into it**: `source_period_ms = 100  # 10 fps out of the capture`. The moment the server asked for 25 that comment became a false number inside a gate - the assertion would have stayed green while the pane collected twelve of the twenty-five frames it was being sent, which is the exact failure the test exists to catch, hidden in the test. It reads the rate from the code that asks for it now.

Shown rather than argued: with the rate raised to 50 and the pause left at 18, the deriving gate goes red and the hand-written one stays green.