### PR TITLE
The live view was fetching a page title twenty-five times a second (0.20.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.20.0"
+version = "0.20.1"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/mcp/server.py
+++ b/src/aihawk/mcp/server.py
@@ -405,7 +405,10 @@ async def ready(session_id=None, browser_id=None):
             # session somebody cannot use.
             pass
     try:
-        _note_tabs(at, [p["url"] for p in await session.describe_pages()])
+        # The urls only. `describe_pages` also fetches each tab's TITLE, which
+        # is a round trip per tab, and this runs on every command - including
+        # every frame of the live view, twenty-five times a second.
+        _note_tabs(at, session.where_pages_are())
     except Exception:
         pass
     return session

--- a/src/aihawk/mcp/session.py
+++ b/src/aihawk/mcp/session.py
@@ -90,6 +90,37 @@ class StealthSession:
                         self._active = pid
         return list(self._pages)
 
+    def where_pages_are(self) -> list[str]:
+        """The url of each tab, and nothing else.
+
+        ⛔ THE CHEAP HALF OF `describe_pages`, SPLIT OUT BECAUSE THE COST WAS
+        BEING PAID ON EVERY COMMAND. That method's own docstring says it: title
+        costs a round trip per tab and url does not. The server notes where a
+        browser is on every tool call so a session can be saved where it was,
+        and it was doing that by asking for the whole description - so every
+        action, and every frame of the live view, paid a round trip per tab for
+        a title nobody read.
+
+        ⛔ MEASURED, AND THE FIRST NUMBER I WROTE HERE WAS DEDUCED RATHER THAN
+        MEASURED. I read a low frame rate on a bench, inferred that each request
+        took 195 ms, and wrote that down. Splitting the time three ways said the
+        request was 13 ms and the low rate was the BENCH: a CSS animation in a
+        headless window repaints a few times a second, so most answers were the
+        same picture twice.
+
+        The real cost of the title, A-B-A on the same bench: 8.3 ms with urls
+        only, 29.5 ms with the title, 6.8 ms with urls again. Three and a half
+        times, on the request the live view makes twenty-five times a second.
+        """
+        out = []
+        for pid in self.list_pages():
+            page = self._pages.get(pid)
+            try:
+                out.append(page.url if page is not None else "")
+            except Exception:
+                out.append("")
+        return out
+
     async def describe_pages(self) -> list[dict]:
         """Each tab as id, title, url and whether it is the active one.
 

--- a/tests/mcp_server/test_a_browser_comes_back_where_it_was.py
+++ b/tests/mcp_server/test_a_browser_comes_back_where_it_was.py
@@ -42,6 +42,13 @@ class _Recording:
         self.pages.append("")
         return "tab-%d" % len(self.pages)
 
+    def where_pages_are(self):
+        # The cheap half, added in 0.20.1 when it turned out the server was
+        # asking for page TITLES on every command. A stand-in without it makes
+        # `ready` raise into a `try/except` and the tabs quietly go unnoted,
+        # which reads as a browser that could not be read.
+        return list(self.pages)
+
     async def describe_pages(self):
         return [{"id": "tab-%d" % (i + 1), "url": u, "title": "", "active": False}
                 for i, u in enumerate(self.pages)]
@@ -186,3 +193,25 @@ async def test_the_retry_path_wakes_the_same_way(registry):
     got = await server._retrying(_once)
 
     assert json.loads(got) == ["http://a.test/"], got
+
+
+def test_the_server_only_asks_the_session_for_things_it_has():
+    """⛔ THE `try/except` AROUND NOTING THE TABS HIDES A MISSING METHOD, and it
+    has to: a tab mid-navigation legitimately refuses to be read, and one that
+    does must not cost the caller their browser. But that same handler swallows
+    an AttributeError, so a server calling a method the session does not have
+    looks exactly like a browser that could not be read - measured here, on a
+    stand-in that lacked `where_pages_are` and simply stopped noting anything.
+
+    So the contract is asserted directly instead of being left to a runtime
+    path that is designed not to complain.
+
+    Known-bad: rename `where_pages_are` on `StealthSession`.
+    """
+    from aihawk.mcp.session import StealthSession
+
+    for name in ("where_pages_are", "describe_pages", "new_page", "close"):
+        assert callable(getattr(StealthSession, name, None)), (
+            "the server calls session.%s() and the session has no such method; "
+            "at runtime that is swallowed and reads as a browser that could "
+            "not be read" % name)


### PR DESCRIPTION
Every command notes where a browser is, so a session can be saved where it was. It did that by asking for the whole description of each tab - and that method's own docstring says the part that matters: title costs a round trip per tab and url does not. So every action, and every frame of the live view, paid for a title nobody read.

A-B-A on the same bench, median of twenty frame requests each: **8.3 ms** with urls only, **29.5 ms** with the title, **6.8 ms** with urls again. Three and a half times, on the request the pane makes twenty-five times a second.

**And the first version of this had a number I had deduced rather than measured.** A bench showed a low frame rate, I divided elapsed time by frames and concluded each request took 195 ms. Splitting the time three ways - a route that never touches the pipe, one small round trip, one with a JPEG in it - said the request was 13 ms and the low rate was the bench: a CSS animation in a headless window repaints a few times a second, so most answers were the same picture twice and the loop was counting distinct ones.

The chain itself is fine and was measured properly afterwards: same bench, 25 asked delivers 3.9 distinct frames a second against 1.8 for 10 asked, a ratio of 2.2 that follows the rates.

Also a contract test, because the `try/except` that lets a tab mid-navigation go unread also swallows a method that does not exist: a stand-in without `where_pages_are` looked exactly like a browser that could not be read.