### PR TITLE
A queued message survives the page going away (0.20.2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.20.1"
+version = "0.20.2"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -575,6 +575,42 @@ const LONG = 120;
 const thread = $('thread'), anchor = $('anchor'), log = $('log');
 let turn = null, live = null, hold = null, n = 0, t0 = 0, timer = 0;
 let busyNow = false, queued = null, pinned = false, settle = 0;
+
+/* ---------------- the queued message ----------------
+   ⛔ IT WAS A VARIABLE, AND A RELOAD ATE IT. Somebody types a follow-up while
+   the agent is working, the page reloads - a refresh, a crash, a laptop lid -
+   and the sentence they wrote is gone with nothing said. That is the one thing
+   this interface must not do to typed text: the transcript is saved, the
+   answer is saved, and the instruction that was waiting to run was the only
+   thing held in a variable.
+
+   Kept per conversation, because it belongs to one: switching sessions must
+   not carry somebody's pending sentence into another chat. Written through ONE
+   function rather than beside each of the five places that assign it - that is
+   how it went unsaved in the first place, and a sixth assignment somewhere
+   would go unsaved the same way.
+
+   Storage can refuse (a private window, site data blocked) and the page has to
+   work when it does: the queue simply goes back to being a variable. */
+/* ⛔ A FUNCTION AND NOT A CONSTANT, because a constant here read `here`
+   before `here` was declared - and a top-level binding used in its own dead
+   zone throws at parse time, which kills the WHOLE script: no event stream, no
+   session column, no workspace, and the page still renders. 440 tests green
+   with the page dead, for the second time in two days and by a different
+   mechanism than the first. Computed when called, the order of the lines stops
+   being something anybody has to keep right. */
+const qkey = () => 'aihawk.queued.' + here;
+function setQueued(text){
+  queued = text || null;
+  try {
+    if(queued) localStorage.setItem(qkey(), queued);
+    else localStorage.removeItem(qkey());
+  } catch(err){}
+  paint();
+}
+function queuedFromBefore(){
+  try { return localStorage.getItem(qkey()); } catch(err){ return null; }
+}
 let pend = null, pendTimer = 0;
 
 const dur = ms => ms < 1000 ? Math.round(ms) + 'ms' : (ms/1000).toFixed(1) + 's';
@@ -722,7 +758,7 @@ const onEvent = (e) => {
                        Redrawn on the end of a turn and not on its start: the
                        turn count beside the name is only right once. */
                     if(!r) drawChats();
-                    if(queued){ const t = queued; queued = null; send(t); } }
+                    if(queued){ const t = queued; setQueued(null); send(t); } }
       paint(); break;
     case 'you':   flush(false, r); live = null; newTurn();
                   put(el('div','you', m.text), r); break;
@@ -787,7 +823,7 @@ document.addEventListener('keydown', e => {
 });
 /* A pencil and not a cross: a cross would read as "cancel the queued message".
    This returns it to the composer to be edited. */
-chip.onclick = () => { i.value = queued; queued = null; i.focus();
+chip.onclick = () => { i.value = queued; setQueued(null); i.focus();
                        i.dispatchEvent(new Event('input')); };
 
 function send(text){
@@ -809,7 +845,7 @@ function wipe(){
      process stops believing in a run that died with the old one - which
      otherwise left the composer saying "queue for next turn" forever. */
   busyNow = false;
-  queued = null; paint();
+  setQueued(null);
 }
 fresh.onclick = () => fetch(at('/chat/fresh'), {method:'POST'});
 
@@ -819,7 +855,7 @@ f.onsubmit = (e) => {
   const t = i.value.trim();
   if(!t){ return; }
   i.value = ''; i.style.height = 'auto';
-  if(busyNow){ queued = t; paint(); return; }
+  if(busyNow){ setQueued(t); return; }
   send(t); paint();
 };
 
@@ -1170,6 +1206,14 @@ async function slowTick(){
 async function fleetPoll(){ await drawFleet(); setTimeout(fleetPoll, 3000); }
 
 $('addbrowser').onclick = openAnother;
+
+/* Whatever was waiting when the page went away comes back into the composer
+   rather than into the queue: the run it was queued behind is over, so the
+   honest place for it is where somebody can read it and press send. */
+const waiting_text = queuedFromBefore();
+if(waiting_text){ i.value = waiting_text; setQueued(null);
+                  i.style.height = 'auto';
+                  i.style.height = Math.min(i.scrollHeight, 200) + 'px'; }
 
 paint(); listen(); tick(); where(); drawChats(); fleetPoll(); slowTick();
 </script>

--- a/tests/test_the_browser_workspace.py
+++ b/tests/test_the_browser_workspace.py
@@ -319,6 +319,62 @@ def test_the_page_declares_no_identifier_twice():
         "syntax error that stops the whole file from running: %s" % sorted(set(twice)))
 
 
+def test_no_top_level_declaration_uses_a_name_declared_later():
+    """⛔ THE SAME DAMAGE BY A DIFFERENT MECHANISM, and the duplicate-name gate
+    above did not see it. `const QKEY = 'aihawk.queued.' + here;` was written
+    forty lines above `let here`, and a top-level binding read inside its own
+    dead zone throws when the script is evaluated - which kills the whole file:
+    no event stream, no session column, no workspace, and the page still
+    renders. All 440 tests were green with the page dead, the second time in
+    two days that a suite could not see a page a browser cannot run.
+
+    Both gates check the same thing from two sides: nothing at the top level of
+    this script may depend on the ORDER of the lines being right. The real fix
+    for a value that needs another is a function, which is evaluated when it is
+    called.
+
+    Only initialisers are read, not function bodies: a function may use anything
+    declared anywhere, because it runs after the script has finished.
+    """
+    script = PAGE[PAGE.index("<script"):]
+    lines = script.split(chr(10))
+
+    declared, order = {}, []
+    for n, line in enumerate(lines):
+        if line[:1] not in ("l", "c", "v"):
+            continue
+        m = re.match(r"(?:let|const|var)\s+(.+?)\s*=", line)
+        if not m:
+            continue
+        for part in m.group(1).split(","):
+            name = part.split("=")[0].strip()
+            if re.fullmatch(r"[A-Za-z_$][\w$]*", name or "") and name not in declared:
+                declared[name] = n
+                order.append((n, name, line))
+
+    early = []
+    for n, name, line in order:
+        init = line.split("=", 1)[1]
+        # ⛔ NOT INSIDE STRINGS AND REGEXES. The first version read the `i` of
+        # `/^(I will |...)/i` as the variable `i` and accused a line that is
+        # correct: a scan that cannot tell code from text is a gate that goes
+        # red for the wrong reason, which is how gates get widened until they
+        # see nothing.
+        init = re.sub(r"'[^']*'|\"[^\"]*\"|`[^`]*`", "''", init)
+        init = re.sub(r"/(?:[^/\
+]|\.)+/[gimsuy]*", "RE", init)
+        if "=>" in init or init.strip().startswith("function"):
+            # A function value: its body runs later, so it may name anything.
+            continue
+        for other, where in declared.items():
+            if where > n and re.search(r"(?<![.\w])%s(?![\w])" % re.escape(other), init):
+                early.append("%s uses %s, declared %d lines later" % (name, other, where - n))
+    assert not early, (
+        "these read a top-level name before it is declared, which throws when "
+        "the script is evaluated and stops the whole page from running: %s"
+        % early)
+
+
 async def test_waking_nothing_refuses():
     """A wake takes seven to fourteen seconds and starts an engine. Treating a
     missing id as "the current one" would make a bug in the page spend that on a

--- a/tests/test_the_session_column.py
+++ b/tests/test_the_session_column.py
@@ -374,3 +374,55 @@ async def test_every_request_the_page_makes_carries_the_conversation():
     assert "new EventSource(at('/chat/events'))" in script, (
         "the event stream is not addressed, so every page listens to the "
         "default conversation")
+
+
+@pytest.mark.filterwarnings("ignore")
+async def test_a_queued_message_is_not_lost_when_the_page_goes_away():
+    """⛔ TYPED TEXT MUST NOT VANISH SILENTLY, and this was the one thing in the
+    interface that did. The transcript is saved, the answer is saved, and the
+    instruction somebody wrote while the agent was working was held in a
+    JavaScript variable: a refresh, a crash or a closed laptop and the sentence
+    was gone with nothing said about it.
+
+    It is kept per conversation - switching sessions must not carry a pending
+    sentence into another chat - and it comes back into the COMPOSER rather than
+    into the queue, because the run it was waiting behind is over by then.
+
+    Read out of the page, and on the SHAPE rather than on the wording: what has
+    to stay true is that one function writes it and nothing else does, which is
+    exactly what went wrong when it was assigned in five places and saved in
+    none.
+
+    Known-bad: assign `queued = ...` anywhere outside `setQueued`.
+    """
+    import re
+
+    from aihawk.web import PAGE
+
+    script = PAGE[PAGE.index("<script"):]
+    code = re.sub(r"/\*.*?\*/", "", script, flags=re.S)
+
+    assert "function setQueued(" in code, "the queue has no single writer"
+    # ⛔ THE WHOLE LINE, NOT THE CALL. Asserting that `localStorage.setItem`
+    # appears passed a mutation that turned its condition into `if(false)`: the
+    # call was still there and wrote nothing. A source scan that cannot tell a
+    # reachable write from an unreachable one is not checking the write. Exact
+    # enough to break on reformatting, which is the trade being made knowingly:
+    # a page cannot be executed here, so the text is the only evidence.
+    assert "if(queued) localStorage.setItem(qkey(), queued);" in code, (
+        "the queued message is not written down where it can be read back, so "
+        "a reload loses it")
+    assert "localStorage.getItem(qkey())" in code, (
+        "nothing reads the queued message back, so saving it changes nothing")
+    assert "'aihawk.queued.' + here" in code, (
+        "the queue is not kept per conversation, so switching sessions carries "
+        "somebody's pending sentence into another chat")
+
+    # One writer. The declaration is the only other place the name may be
+    # assigned, and it is on the `let` line.
+    writes = [line.strip() for line in code.split(chr(10))
+              if re.search(r"(?<![.\w])queued\s*=(?!=)", line)]
+    stray = [w for w in writes if not w.startswith("let ") and "queued = text" not in w]
+    assert not stray, (
+        "these assign the queue outside its single writer, so they do not save "
+        "it: %s" % stray)


### PR DESCRIPTION
Somebody types a follow-up while the agent is working, the page reloads - a refresh, a crash, a closed laptop - and the sentence they wrote was gone with nothing said. It was the one thing in this interface that lost typed text: the transcript is saved, the answer is saved, and the instruction waiting to run was held in a JavaScript variable.

Kept per conversation, because it belongs to one, and it comes back into the **composer** rather than into the queue: the run it was waiting behind is over by then. Written through one function instead of beside each of the five places that assigned it, which is how it went unsaved to begin with.

**And the first version of this killed the whole page, with the suite green.** `const QKEY = 'aihawk.queued.' + here;` sat forty lines above `let here`, and a top-level binding read inside its own dead zone throws when the script is evaluated - so nothing ran: no event stream, no session column, no workspace, and the page still rendered. 440 tests green, the second time in two days that this suite could not see a page a browser cannot run, and by a different mechanism than the first: that one was a duplicate name, this one an order.

Two fixes, and the second matters more. The value is computed by a function now, so line order stops being something anybody has to keep right. And there is a gate for the class: no top-level declaration may read a name declared later. It reads initialisers only - a function body may name anything - and it ignores strings and regexes, because the first version of it accused `/^(I will |...)/i` of using the variable `i`.