### PR TITLE
The measure, in characters this time, and a divider that moves (0.23.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.22.0"
+version = "0.23.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -95,7 +95,16 @@ PAGE = r"""<!doctype html>
   --sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --mono: ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas,
           "Liberation Mono", "DejaVu Sans Mono", monospace;
-  --t-label:11px; --t-mono:13px; --t-ui:13px; --t-body:14px;
+  /* ⛔ rem AND NOT px, WHICH IS THE DIFFERENCE BETWEEN HONOURING AND IGNORING
+     A SETTING SOMEBODY CHANGED FOR THEIR EYES. A default font size set in the
+     browser or the system does nothing to a page whose sizes are absolute -
+     page zoom still works, but that is a different control and it scales the
+     browser view on the right along with the text. web.dev's typography
+     accessibility guidance marks `font-size: 16px` "Don't" and `1rem` "Do" for
+     exactly this. Same pixels at the default 16px root, so nothing moves for
+     anybody who never changed it. */
+  --t-label:.6875rem; --t-mono:.8125rem; --t-ui:.8125rem; --t-body:.875rem;
+  --t-h1:1.0625rem; --t-h2:.9375rem; --t-h3:.8125rem;  /* the answer's headings */
 
   --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s5:20px; --s6:32px;
   --r-sm:4px; --r:8px; --r-lg:12px; --r-pill:999px;
@@ -188,9 +197,25 @@ code,pre,.g,.meta,.badge,#url,#tok{
    thread: 460px of nothing, taken from the pane that could have used it. The
    clamp holds the column at what the thread plus its gutters actually need and
    hands the rest to the right. Only desktops run this, so the floor is the
-   narrow end of a laptop and there is no phone case to carry. */
-#left { width:clamp(420px, 44%, 760px); display:flex; flex-direction:column;
-        position:relative; border-right:1px solid var(--line-1) }
+   narrow end of a laptop and there is no phone case to carry.
+
+   The ceiling is derived, not chosen: the thread caps at 66ch, which is 498px
+   in this font, plus the 32px of log padding it sits in. Anything wider would
+   be slack inside this pane rather than measure, and it is worth more to the
+   picture on the right. */
+#left { width:clamp(420px, 44%, 530px); display:flex; flex-direction:column;
+        position:relative }
+/* The separator carries the line that used to be `#left`'s right border, so
+   the thing you drag and the thing you see are the same thing. Wider than the
+   line it draws: a 1px target is a 1px target, and this one is grabbed by
+   hand. */
+#split{ flex:0 0 9px; cursor:col-resize; position:relative; background:none;
+        border:0; padding:0; touch-action:none }
+#split::after{ content:""; position:absolute; top:0; bottom:0; left:4px; width:1px;
+               background:var(--line-1); transition:background-color 120ms ease-out }
+#split:hover::after{ background:var(--line-3) }
+#split:focus-visible{ outline:none }
+#split:focus-visible::after, #split[data-drag]::after{ background:var(--accent); width:2px }
 #right{ flex:1; min-width:0; display:flex; flex-direction:column; background:var(--well) }
 #head { display:flex; align-items:center; gap:10px; padding:var(--s3) var(--s4);
         border-bottom:1px solid var(--line-1) }
@@ -212,17 +237,31 @@ code,pre,.g,.meta,.badge,#url,#tok{
    well past the 50 to 75 the readability research settles on. `ch` follows the
    font instead of guessing at it.
 
-   ⛔ BUT THE CAP WAS CENTRED, AND THE MEASURE IT CAPS IS NOT THE ONE IT SETS.
-   Centring splits the slack in two and puts half of it on the LEFT, where a
-   reader sees it as the column having been pushed away from the edge for no
-   reason - said in exactly those words on 2026-09-08, and visible in a
-   screenshot as 185px of nothing before the first character. And the number
-   itself was measuring the wrong thing: an answer carries `--indent` of its
-   own, about 4.7ch, so a 72ch container was giving 67 characters of prose,
-   under the range the comment above cites rather than over it. 84 minus the
-   indent lands at 79, inside the 80. Left aligned, so what is left over sits
-   on one side, next to the browser pane, instead of framing the text. */
-#thread{ max-width:84ch; margin:0 }
+   ⛔ AND `ch` IS NOT A CHARACTER. It is the advance width of the digit zero,
+   which in a proportional font is much wider than an average letter, so a
+   number written in `ch` reads like a character count and is not one.
+   MEASURED on this font with a canvas, on real prose in both languages this
+   interface serves: `0` is 7.55px at 14px system-ui, while the average
+   character of a sentence is 6.11px. One `ch` is 1.24 characters.
+
+   What that turned into, twice. The cap started at 72ch believing it was 72
+   characters: minus the indent an answer carries, it was really 83. Then it
+   was widened to 84ch on the reasoning that the indent made the column too
+   NARROW - the arithmetic was done in `ch` again, and the result was 98
+   characters per line, past every source that has a number: 65-72 in the chat
+   design guidance, 75 as Baymard's upper bound, 80 as the WCAG 2.1 AAA cap.
+
+   66ch is 498px here; minus the 37px indent that is 461px of text, and at
+   6.11px a character that is 75 characters. The unit stays `ch` because it
+   tracks the font's own metrics if the font ever changes; the number comes
+   from the measurement, and the conversion is written down here so the next
+   person does not redo it in the wrong unit for the third time.
+
+   Left aligned rather than centred: centring splits the slack in two and puts
+   half on the LEFT, which reads as the column having been pushed away from the
+   edge for no reason - 185px of nothing before the first character, in a
+   screenshot. */
+#thread{ max-width:66ch; margin:0 }
 
 /* Bottom-pinning with no scroll handler and no epsilon: the sentinel is the only
    anchor the browser may keep, so content inserted before it pushes the view
@@ -236,7 +275,7 @@ code,pre,.g,.meta,.badge,#url,#tok{
 #hint .eg{ font:var(--t-mono)/1.9 var(--mono); color:var(--fg-2);
            background:var(--raised); border:1px solid var(--line-1);
            border-radius:var(--r); padding:var(--s3) var(--s4); text-align:left }
-#hint .sm{ font-size:12px; color:var(--fg-4) }
+#hint .sm{ font-size:.75rem; color:var(--fg-4) }
 
 #jump{ position:absolute; bottom:110px; left:50%; transform:translateX(-50%); z-index:2;
        background:var(--top); border:1px solid var(--line-2); color:var(--fg);
@@ -277,6 +316,11 @@ code,pre,.g,.meta,.badge,#url,#tok{
    heading - a heading needs more space ABOVE it than below, because the space
    is what says the section starts, and a heading floating equidistant between
    two paragraphs belongs to neither. */
+/* 1.6 rather than the 1.55 the rest of the app uses: this is the only place
+   somebody reads paragraphs rather than scans rows, and the guidance for
+   long-form chat answers puts the comfortable leading at about 1.6. WCAG 2.2
+   asks 1.5 as a floor, so both pass; this one is the reading surface. */
+.md-p, .md-i{ line-height:1.6 }
 .md-p{ margin:0 0 var(--s4); white-space:pre-wrap; overflow-wrap:anywhere }
 h3.md-h, h4.md-h, h5.md-h, h6.md-h{
       margin:calc(var(--s4) + var(--s2)) 0 var(--s2); font-family:var(--sans);
@@ -284,9 +328,9 @@ h3.md-h, h4.md-h, h5.md-h, h6.md-h{
 /* `##` is what a model writes most, so h4 is the one that has to read as a
    heading and not as a bold line: at 14px it was the size of the body text
    under it, which is a hierarchy only the weight was carrying. */
-h3.md-h{ font-size:17px }
-h4.md-h{ font-size:15px }
-h5.md-h, h6.md-h{ font-size:13px; color:var(--fg-2) }
+h3.md-h{ font-size:var(--t-h1) }
+h4.md-h{ font-size:var(--t-h2) }
+h5.md-h, h6.md-h{ font-size:var(--t-h3); color:var(--fg-2) }
 /* A fenced block inside an answer is already inside the answer's indent, and
    `.out` carries its own for the tool output it was written for: the two
    stacked, so code sat a step to the right of the prose describing it. */
@@ -314,7 +358,7 @@ h5.md-h, h6.md-h{ font-size:13px; color:var(--fg-2) }
    whatever page the agent last read, and the browser it drives is right there.
    The address is printed next to them so an injected one is legible. */
 .lk  { color:var(--fg) }
-.href{ color:var(--fg-4); font:12px/1.5 var(--mono); overflow-wrap:anywhere }
+.href{ color:var(--fg-4); font:.75rem/1.5 var(--mono); overflow-wrap:anywhere }
 .href::before{ content:" " }
 .orph  { display:flex; gap:8px; font-size:var(--t-mono); color:var(--err);
          background:rgba(232,131,107,.08); border-radius:var(--r-sm);
@@ -368,7 +412,7 @@ h5.md-h, h6.md-h{ font-size:13px; color:var(--fg-2) }
 .out{ margin:2px 0 var(--s2) var(--indent);
       max-height:290px; max-height:15lh; overflow:auto; overscroll-behavior:contain;
       white-space:pre-wrap; overflow-wrap:anywhere;
-      font:12px/1.5 var(--mono); color:var(--fg-3);
+      font:.75rem/1.5 var(--mono); color:var(--fg-3);
       background:var(--raised); border-left:2px solid var(--line-2);
       border-radius:0 var(--r-sm) var(--r-sm) 0; padding:8px 10px }
 
@@ -438,7 +482,7 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
 [data-state="offline"] #dot, [data-state="error"] #dot{ background:var(--err) }
 #url{ flex:1; min-width:0; height:24px; line-height:24px; padding:0 10px;
       border-radius:var(--r-pill); background:var(--well); border:1px solid var(--line-1);
-      font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis }
+      font-size:.75rem; white-space:nowrap; overflow:hidden; text-overflow:ellipsis }
 #url .dim{ color:var(--fg-4) }
 #url .host{ color:var(--fg) }
 #mode{ display:inline-flex; gap:2px; flex:none; background:var(--base);
@@ -581,6 +625,15 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
     </div>
   </form>
 </div>
+
+<!-- The split is a control, so it says so: a real separator with a value a
+     screen reader can read and the arrow keys can move. Which pane deserves
+     the room is a property of the TASK - reading a long answer wants one
+     ratio, watching a form being filled wants another - so it is not a number
+     this file gets to decide once. -->
+<div id="split" role="separator" aria-orientation="vertical" tabindex="0"
+     aria-label="Width of the conversation" aria-valuemin="420"
+     aria-valuenow="530"></div>
 
 <div id="right" data-state="idle">
   <div id="tabs" hidden></div>
@@ -1408,7 +1461,82 @@ if(waiting_text){ i.value = waiting_text; setQueued(null);
                   i.style.height = 'auto';
                   i.style.height = Math.min(i.scrollHeight, 200) + 'px'; }
 
-paint(); listen(); tick(); where(); fleetPoll(); slowTick();
+/* ---- the split between the two panes ----
+   ⛔ THE RATIO IS A PROPERTY OF THE TASK, NOT OF THIS FILE. Reading a long
+   answer wants one, watching a form get filled wants another, and the ratio
+   this page picks is right for neither for very long. The measured default is
+   still a default - the conversation stops at its reading measure and the rest
+   goes to the picture - and from there it is dragged, with the arrow keys, or
+   double-clicked back to the default. Remembered per browser, because somebody
+   who has set it once has said what they want.
+
+   Everything here is a FUNCTION called from the boot line below: nothing at
+   the top level of this script may depend on the order of the lines. */
+const SPLITKEY = 'aihawk.split';
+
+function splitTo(px, remember){
+  /* The floor is the narrowest the conversation stays usable at; the ceiling
+     leaves the browser pane enough to be a picture rather than a strip. Both
+     are recomputed against the window, so a value dragged wide on a big
+     monitor does not strand the right pane on a laptop. */
+  const min = 420, max = Math.max(min, window.innerWidth - 480);
+  const w = Math.round(Math.min(max, Math.max(min, px)));
+  $('left').style.width = w + 'px';
+  $('split').setAttribute('aria-valuenow', String(w));
+  $('split').setAttribute('aria-valuemax', String(max));
+  if(remember){ try { localStorage.setItem(SPLITKEY, String(w)); } catch(e) {} }
+}
+
+function splitReset(){
+  try { localStorage.removeItem(SPLITKEY); } catch(e) {}
+  $('left').style.width = '';
+  $('split').setAttribute('aria-valuenow',
+                          String(Math.round($('left').getBoundingClientRect().width)));
+}
+
+function splitter(){
+  const bar = $('split');
+  let saved = null;
+  try { saved = localStorage.getItem(SPLITKEY); } catch(e) {}
+  if(saved) splitTo(parseInt(saved, 10), false);
+  else splitReset();
+
+  bar.addEventListener('pointerdown', e => {
+    bar.setPointerCapture(e.pointerId);
+    bar.dataset.drag = '1';
+    /* ⛔ FOCUS BY HAND, BECAUSE THE LINE BELOW TAKES IT AWAY. preventDefault on
+       pointerdown stops the drag from selecting the text beside it, and it also
+       stops the browser from focusing what was pressed - so the separator could
+       be dragged and then not moved with the arrow keys, which is the half of
+       this control that exists for people who do not drag. Found by clicking
+       it: nothing in the suite clicks. */
+    bar.focus();
+    e.preventDefault();
+  });
+  bar.addEventListener('pointermove', e => {
+    if(!bar.dataset.drag) return;
+    splitTo(e.clientX - $('left').getBoundingClientRect().left, true);
+  });
+  bar.addEventListener('pointerup', e => {
+    delete bar.dataset.drag;
+    bar.releasePointerCapture(e.pointerId);
+  });
+  bar.addEventListener('dblclick', splitReset);
+  bar.addEventListener('keydown', e => {
+    const step = e.shiftKey ? 64 : 16;
+    const now = $('left').getBoundingClientRect().width;
+    if(e.key === 'ArrowLeft'){ splitTo(now - step, true); e.preventDefault(); }
+    else if(e.key === 'ArrowRight'){ splitTo(now + step, true); e.preventDefault(); }
+    else if(e.key === 'Home' || e.key === 'Escape'){ splitReset(); e.preventDefault(); }
+  });
+  /* A width saved on a wide monitor is not a width on a laptop: put it back
+     through the same clamp whenever the window changes. */
+  window.addEventListener('resize', () => {
+    if($('left').style.width) splitTo(parseFloat($('left').style.width), false);
+  });
+}
+
+paint(); listen(); tick(); where(); fleetPoll(); slowTick(); splitter();
 if(!$('rail').hidden) drawChats();
 </script>
 """

--- a/tests/test_the_browser_workspace.py
+++ b/tests/test_the_browser_workspace.py
@@ -431,3 +431,42 @@ def test_every_handler_the_page_wires_up_exists():
     assert not missing, (
         "the page wires these to an event and nothing defines them, so the "
         "handler throws the first time somebody uses it: %s" % missing)
+
+
+def test_the_answer_measure_is_inside_the_range_every_source_agrees_on():
+    """⛔ THIS NUMBER HAS BEEN WRONG TWICE, THE SAME WAY BOTH TIMES: computed in
+    `ch` and read as characters.
+
+    `ch` is the advance width of the digit zero. In a proportional font that is
+    much wider than an average letter, so a cap written in `ch` looks like a
+    character count and is not one. Measured on this font with a canvas, on real
+    prose in both languages this interface serves: `0` is 7.55px at 14px
+    system-ui, the average character of a sentence is 6.11px, so one `ch` is
+    1.24 characters.
+
+    First the cap was 72ch believing it was 72 characters, and minus the indent
+    an answer carries it was 83. Then it was widened to 84ch to make up for that
+    indent, in `ch` again, and became 98 - past 65-72 (chat design guidance), 75
+    (Baymard's upper bound) and 80 (WCAG 2.1 AAA, SC 1.4.8).
+
+    So the conversion lives here rather than in a comment, and it reads the page
+    instead of repeating it: change the cap or the gutter and this recomputes.
+
+    Known-bad, both real: 84ch gives 98 and 72ch gives 83, and both go red.
+    """
+    import re
+
+    cap = float(re.search(r"#thread\{ max-width:([\d.]+)ch", PAGE).group(1))
+    gutter = float(re.search(r"--gutter:([\d.]+)rem", PAGE).group(1))
+    gap = float(re.search(r"--gap:([\d.]+)rem", PAGE).group(1))
+
+    #: Both measured in the browser, on the font the page actually declares.
+    CH_PX, AVG_CHAR_PX, ROOT_PX = 7.55, 6.11, 16.0
+
+    indent = (gutter + gap) * ROOT_PX          # --indent, which an answer carries
+    chars = (cap * CH_PX - indent) / AVG_CHAR_PX
+    assert 65 <= chars <= 80, (
+        "the answer is %.0f characters per line. Under 65 the eye returns too "
+        "often; over 80 it loses the line, and 80 is the WCAG 2.1 AAA cap. "
+        "The cap is %.0fch, which is NOT %.0f characters: one ch is 1.24 of "
+        "them in this font" % (chars, cap, cap))

--- a/tests/test_the_split_between_the_panes.py
+++ b/tests/test_the_split_between_the_panes.py
@@ -1,0 +1,158 @@
+"""Dragging the divider, and the arithmetic that keeps both panes usable.
+
+⛔ WHICH PANE DESERVES THE ROOM IS A PROPERTY OF THE TASK. Reading a long answer
+wants one ratio, watching a form get filled wants another, and a ratio this file
+picks is right for neither for long. So the page ships a measured default and
+lets it be dragged - which is the change the project's own layout research rated
+first, on the grounds that the audience for this tool is closer to an editor
+than to a consumer chat.
+
+The part worth executing is the CLAMP. A width dragged wide on a big monitor and
+remembered would strand the right pane down to nothing on a laptop, and nothing
+about that failure is visible in a string scan: the page still parses, the
+handler still exists, and the browser view is simply gone. So the two functions
+that compute it are lifted out and run, the same way the renderer is.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+
+import pytest
+
+from aihawk.web import PAGE
+
+NODE = shutil.which("node")
+FIRST = "const SPLITKEY ="
+LAST = "function splitter()"
+
+#: Enough DOM for two functions: an element with a style and a width, one that
+#: records attributes, and a store that behaves like localStorage.
+SHIM = r"""
+const KEPT = {};
+const localStorage = {
+  getItem: k => (k in KEPT ? KEPT[k] : null),
+  setItem: (k, v) => { KEPT[k] = String(v); },
+  removeItem: k => { delete KEPT[k]; },
+};
+const LEFT = {
+  style: {width: ''},
+  getBoundingClientRect: () => ({width: parseFloat(LEFT.style.width) || 530, left: 0}),
+};
+const SPLIT = {attrs: {}, setAttribute(k, v){ this.attrs[k] = v; }};
+const $ = id => (id === 'left' ? LEFT : SPLIT);
+const window = {innerWidth: 1920};
+"""
+
+
+def clamp(asked, width=1920, remember=True):
+    """What the page would set the conversation to, asked for `asked` pixels."""
+    body = PAGE[PAGE.index(FIRST):PAGE.index(LAST)]
+    js = (SHIM + body
+          + "\nwindow.innerWidth = %d;" % width
+          + "\nsplitTo(%s, %s);" % (json.dumps(asked), "true" if remember else "false")
+          + "\nprocess.stdout.write(JSON.stringify({width: LEFT.style.width,"
+            " attrs: SPLIT.attrs, kept: KEPT}));")
+    done = subprocess.run([NODE, "-e", js], capture_output=True, text=True,
+                          encoding="utf-8", timeout=30)
+    assert done.returncode == 0, "the splitter threw:\n%s" % done.stderr
+    got = json.loads(done.stdout)
+    got["px"] = float(str(got["width"]).replace("px", "") or 0)
+    return got
+
+
+pytestmark = pytest.mark.skipif(
+    not NODE, reason="needs node to EXECUTE the page's splitter")
+
+
+def test_a_width_that_is_asked_for_is_the_width_that_is_set():
+    got = clamp(700)
+    assert got["px"] == 700
+    assert got["attrs"]["aria-valuenow"] == "700", got["attrs"]
+
+
+def test_the_conversation_cannot_be_dragged_to_nothing():
+    """Known-bad: drop the `Math.max(min, ...)`. A drag to the left edge leaves
+    a column too narrow to read a sentence in, and it is remembered."""
+    assert clamp(0)["px"] == 420
+    assert clamp(-500)["px"] == 420
+
+
+def test_the_browser_pane_cannot_be_dragged_to_nothing_either():
+    """⛔ THE HALF THAT WOULD BE INVISIBLE. A conversation dragged over the
+    whole window leaves no picture at all, and the page still parses, the
+    handler still exists, and nothing is red anywhere.
+
+    Known-bad: drop the `Math.min(max, ...)`.
+    """
+    assert clamp(5000)["px"] == 1920 - 480
+    assert clamp(1900)["px"] == 1440
+
+
+def test_a_width_saved_on_a_big_monitor_is_clamped_on_a_laptop():
+    """The reason the ceiling is computed against the window every time rather
+    than stored once: the same person opens the same page on a smaller screen.
+
+    Known-bad: compute `max` from a constant.
+    """
+    assert clamp(1440, width=1280)["px"] == 1280 - 480
+    assert clamp(1440, width=1920)["px"] == 1440
+
+
+def test_the_floor_wins_when_the_window_is_too_small_for_both():
+    """A window narrow enough that floor and ceiling cross: the conversation
+    keeps its floor rather than collapsing below it, because a browser pane
+    with nothing readable beside it is the worse of the two."""
+    assert clamp(600, width=700)["px"] == 420
+
+
+def test_a_drag_is_remembered_and_a_restore_is_not():
+    """The page reads a saved width back through the same clamp on load, and
+    that pass must not write it again: nothing the person did, nothing saved.
+
+    Known-bad: ignore the `remember` argument and always write.
+    """
+    assert clamp(700, remember=True)["kept"] == {"aihawk.split": "700"}
+    assert clamp(700, remember=False)["kept"] == {}
+
+
+def test_the_separator_says_what_it_is_and_where_it_is():
+    """A divider that only a mouse can find is a divider half the people using
+    this cannot move. The page declares the role and the bounds; the value
+    moves with every drag, which is what a screen reader reads out.
+    """
+    assert 'role="separator"' in PAGE
+    assert 'aria-orientation="vertical"' in PAGE
+    assert 'tabindex="0"' in PAGE
+    assert clamp(700)["attrs"]["aria-valuemax"] == "1440"
+    assert "ArrowLeft" in PAGE and "ArrowRight" in PAGE, (
+        "the arrow keys do not move it, so it can only be dragged")
+
+
+def test_pressing_the_separator_leaves_it_focused():
+    """⛔ preventDefault ON pointerdown TAKES THE FOCUS AWAY, and that turns the
+    keyboard half of this control off without breaking anything visible.
+
+    The handler calls preventDefault so a drag does not select the text beside
+    it. The browser's default action for pressing an element is also what
+    focuses it, so cancelling one cancels the other: the divider dragged fine
+    and then the arrow keys did nothing, because what had focus was the
+    document. Measured by clicking it in a real browser and reading
+    `document.activeElement` - no test in this suite clicks anything, and the
+    page parses, draws and drags with the defect in place.
+
+    Known-bad: remove the `bar.focus()` line.
+    """
+    import re
+
+    body = PAGE[PAGE.index("function splitter()"):]
+    body = body[:body.index("\npaint();")]
+    down = re.search(r"addEventListener\('pointerdown'.*?\n  \}\);", body, re.S)
+    assert down, "the separator has no pointerdown handler at all"
+    handler = down.group(0)
+    if "preventDefault" in handler:
+        assert ".focus()" in handler, (
+            "the pointerdown handler cancels the default action, which is what "
+            "focuses the element, and never focuses it itself: the separator "
+            "can be dragged and then not moved with the arrow keys")


### PR DESCRIPTION
`ch` is not a character. It is the advance width of the digit zero, which in a proportional font is much wider than an average letter, so a cap written in `ch` reads like a character count and is not one. Measured on this font with a canvas, on real prose in both languages this interface serves: `0` is 7.55px at 14px system-ui, the average character of a sentence is 6.11px. One ch is 1.24 characters.

That number has now been wrong twice, the same way both times. The cap started at 72ch believing it was 72 characters; minus the indent an answer carries it was 83. It was then widened to 84ch to make up for that indent, in `ch` again, and became 98 - past 65-72 (chat design guidance), 75 (Baymard's upper bound) and 80 (WCAG 2.1 AAA, SC 1.4.8). 66ch is 75 characters, read off the running page. The conversion is now a test that reads the page rather than a comment beside it.

Three more had been written down in this project's own layout and typography research and never applied:

* the text sizes were absolute, so a default font size somebody set in their browser to read more comfortably did nothing here. In rem now: identical at the default 16px root, different for anybody who changed it;
* 1.6 leading on the prose blocks, which is what the guidance for long-form answers asks and what this pane is for. The rest of the app keeps 1.55;
* the left pane's width is derived from its own reading measure instead of a raw percentage, so the surplus goes to the picture, which improves with every pixel, rather than to a column that stops improving at its cap.

And the strongest recommendation was that the ratio is not this file's to choose: reading a long answer wants one, watching a form get filled wants another. The divider is a real separator now - dragged, moved with the arrow keys, double-clicked back to the default, remembered per browser, and clamped against the window on both sides so neither pane can be dragged away.

Found by clicking it, which nothing in the suite does: preventDefault on pointerdown stops a drag from selecting the text beside it, and it also stops the browser from focusing what was pressed. The divider dragged fine and then the arrow keys did nothing.

## Gates

The splitter's clamp is EXECUTED under node against a small DOM, the way the markdown renderer is, because the failure it prevents is invisible to a string scan: a width dragged wide on a big monitor and remembered would strand the browser pane to nothing on a laptop, and the page would still parse, still draw, still drag.

Five known-bads, all killed: no floor, no ceiling, a ceiling computed from a constant instead of the window, a restore that writes itself back, and the missing focus call.

478 tests green.