### PR TITLE
Answers that read like a person wrote them (0.24.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.23.0"
+version = "0.24.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/agent.py
+++ b/src/aihawk/agent.py
@@ -24,9 +24,16 @@ SYSTEM_PROMPT = (
     "them. A person may be watching the browser while you work, so prefer one "
     "clear action at a time over long chains. When the task is done, reply with "
     "the answer and do NOT call any more tools. Report only what the page "
-    "actually shows. Write the answer as prose, with markdown where it carries "
-    "structure the reader needs: a heading, a list, a table. No emoji, and no "
-    "tick or cross in front of a line - say what happened in words."
+    "actually shows. Say plainly what failed and what you could not check: the "
+    "person reading is deciding what to do next. Write the way a competent "
+    "colleague talks: the answer first, then what supports it. Do not announce "
+    "what you are about to say, do not repeat the question back, and do not end "
+    "by summarising what you just wrote - say it once. Prose by default. Use a "
+    "heading, a list or a table only when the content really is one; a bold "
+    "label in front of every paragraph is a template, not writing. Keep "
+    "decoration rare: an emoji is fine where it carries something the words do "
+    "not, and wrong as a status marker at the head of every line. Write every "
+    "dash as a plain hyphen."
 )
 
 Say = Callable[[str, str], Awaitable[None]]

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -152,14 +152,32 @@ code,pre,.g,.meta,.badge,#url,#tok{
            padding:var(--s3) var(--s3) var(--s3) var(--s4);
            border-bottom:1px solid var(--line-1) }
 #railhead .label{ flex:1 }
-#newchat, #rails{ flex:none; width:26px; height:26px; display:grid;
-                  place-items:center; padding:0; border-radius:7px;
-                  border:1px solid transparent; background:none;
-                  color:var(--fg-3); cursor:pointer;
-                  transition:background-color 120ms ease-out, color 120ms ease-out }
-#newchat:hover, #rails:hover{ background:var(--raised); color:var(--fg);
-                              border-color:var(--line-2) }
-#rails[aria-expanded="true"]{ background:var(--raised); color:var(--fg) }
+#newchat{ flex:none; width:26px; height:26px; display:grid;
+          place-items:center; padding:0; border-radius:7px;
+          border:1px solid transparent; background:none;
+          color:var(--fg-3); cursor:pointer;
+          transition:background-color 120ms ease-out, color 120ms ease-out }
+#newchat:hover{ background:var(--raised); color:var(--fg);
+                border-color:var(--line-2) }
+
+/* ⛔ THE THREE LINES WERE A GUESS AND THE WORD IS NOT. A hamburger says "there
+   is a menu here" only to somebody who has already learned that it does, and
+   what is behind this one is a list of sessions - which the rail's own header
+   says in words, in this same type. Saying it on the control too costs 70px of
+   a header that has them. Asked for in exactly those terms on 2026-09-09.
+   Same type as `.label` so the button and the column it opens read as one
+   word in one voice, rather than as a control and a title that happen to
+   agree. */
+#rails{ flex:none; width:96px; height:26px; display:grid; place-items:center;
+        padding:0; border-radius:var(--r); border:1px solid var(--line-2);
+        background:var(--raised); color:var(--fg-2); cursor:pointer;
+        font:600 var(--t-label)/1 var(--sans); letter-spacing:.07em;
+        text-transform:uppercase;
+        transition:background-color 120ms ease-out, color 120ms ease-out,
+                   border-color 120ms ease-out }
+#rails:hover{ background:var(--hover); color:var(--fg) }
+#rails[aria-expanded="true"]{ background:var(--hover); color:var(--fg);
+                              border-color:var(--line-3) }
 #chats{ flex:1; min-height:0; overflow-y:auto; padding:var(--s2) var(--s2) var(--s3);
         /* A long list is cheap to skip past: the rows below the fold are not
            laid out until they are scrolled to, and Ctrl+F still finds them. */
@@ -583,12 +601,11 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
 
 <div id="left">
   <div id="head">
+    <!-- No aria-label: the visible word IS the name now, and an aria-label
+         would replace it with a different one for a screen reader. The state
+         is carried by aria-expanded, which is what it is for. -->
     <button id="rails" type="button" aria-expanded="false" aria-controls="rail"
-            aria-label="Show sessions" title="Sessions">
-      <svg width="15" height="15" viewBox="0 0 15 15" fill="none" stroke="currentColor"
-           stroke-width="1.5" stroke-linecap="round">
-        <path d="M2 4h11M2 7.5h11M2 11h11"/></svg>
-    </button>
+            title="Sessions">Sessions</button>
     <b>AIHawk</b><span class="badge" id="model">no model</span>
     <button id="fresh" type="button" title="Clear this conversation">Clear</button></div>
   <div id="log">
@@ -1302,7 +1319,15 @@ const RAILKEY = 'aihawk.rail';
 function showRail(open){
   $('rail').hidden = !open;
   $('rails').setAttribute('aria-expanded', open ? 'true' : 'false');
-  $('rails').setAttribute('aria-label', open ? 'Hide sessions' : 'Show sessions');
+  /* ⛔ AND NO aria-label ANY MORE. It used to say "Show sessions" / "Hide
+     sessions", which was right while the control was three lines and nothing
+     else. Now the button says Sessions in words, and an aria-label REPLACES
+     that name: a screen reader would read a word that is not on the button,
+     and somebody driving by voice who says "Sessions" would find nothing to
+     click. The open state is already carried by aria-expanded, which is the
+     attribute for it. Found by reading the live DOM after the change, not the
+     source: removing the attribute from the markup left this line putting it
+     back. */
   try { localStorage.setItem(RAILKEY, open ? '1' : '0'); } catch(err){}
   if(open) drawChats();
 }

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -925,38 +925,52 @@ async def test_two_calls_to_the_same_tool_keep_distinct_ids_and_results():
     assert [m["content"] for m in results] == ["read #1", "read #2"]
 
 
-def test_the_answer_is_asked_for_in_words_and_without_emoji():
-    """⛔ THE DECORATION COMES FROM THE MODEL, SO THE FIX IS THE PROMPT.
-
-    Asked for on 2026-09-08, looking at a real conversation: ticks, crosses and
-    a stop sign in front of most lines of an answer. Nothing in the interface
-    puts them there - the model writes them, because nothing told it not to, and
-    a renderer that stripped them would be a filter over a habit instead of an
+def test_the_answer_is_asked_for_the_way_a_person_would_write_it():
+    """⛔ THE WRITING COMES FROM THE MODEL, SO THE FIX IS THE PROMPT. A renderer
+    that stripped the decoration would be a filter over a habit instead of an
     instruction against it.
 
-    The prompt also has to say that markdown is welcome: it said "plain text",
-    which was true while the pane drew the marks as characters and became a lie
-    the moment it stopped.
+    ⛔ AND THE FIRST VERSION OF THIS ASKED FOR NONE OF IT, WHICH IS NOT WHAT WAS
+    ASKED FOR. "No emoji" is a ban; what was asked for was much less decoration
+    and answers that read like a person wrote them. The ban also bought nothing:
+    MEASURED against the model this product runs, on eight finished tasks with
+    the answer asked for three ways, the arm carrying no instruction at all
+    produced ONE emoji in eight. What it produced instead was 19 bold labels, 8
+    numbered checklists, 7 em dashes, 2 openings that announce what is coming
+    and 2 closings that summarise what was just said. Those are the tells, and
+    they are what the sentences in the prompt aim at. The same eight tasks with
+    them: 3 bold, 0 checklists, 0 em dashes, 0 preambles, 0 restatements.
 
-    Known-bad, two: drop the emoji sentence, and put an emoji in the prompt
-    itself - a prompt that decorates while asking for no decoration teaches the
-    habit it forbids.
+    ⛔ AND IT ASSERTED THE WORD `markdown`, WHERE THE REQUIREMENT IS A MEANING.
+    The prompt now names the marks it allows - a heading, a list, a table -
+    which says the same thing to a model and says it more precisely, and the old
+    assertion went red on the better prompt. A gate that checks a word instead
+    of what the word stood for is the comment-versus-code defect, moved into a
+    string.
+
+    Known-bad, four: drop the sentence about decoration; drop the marks it
+    names; ask for "plain text" again; and put an emoji or an em dash in the
+    prompt itself - one that decorates while asking for restraint teaches the
+    habit it is trying to curb.
     """
-    assert "emoji" in SYSTEM_PROMPT.lower(), (
-        "nothing tells the model to answer without emoji, and it will: %r"
-        % SYSTEM_PROMPT)
-    assert "markdown" in SYSTEM_PROMPT.lower(), (
-        "the pane draws markdown now, and the prompt has to say so or the model "
-        "is being asked for something else")
-    assert "plain text" not in SYSTEM_PROMPT.lower(), (
-        "asking for plain text and for markdown in the same breath is two "
+    low = SYSTEM_PROMPT.lower()
+    assert "emoji" in low, (
+        "nothing says anything about decoration, and the recap of a long task "
+        "is exactly where a model reaches for a tick: %r" % SYSTEM_PROMPT)
+    named = [mark for mark in ("heading", "list", "table") if mark in low]
+    assert len(named) == 3, (
+        "the pane draws these and the prompt names %s, so the model is guessing "
+        "which of them it may use" % (named or "none of them"))
+    assert "plain text" not in low, (
+        "asking for plain text and for a table in the same breath is two "
         "instructions that disagree")
+    for tell in ("the answer first", "say it once"):
+        assert tell in low, (
+            "the prompt no longer asks for the shape that was measured: %r" % tell)
     decorative = [c for c in SYSTEM_PROMPT
-                  if ord(c) > 0x2100 or c in "\u2705\u274c\u26d4"]
+                  if ord(c) > 0x2100 or c in "✅❌⛔—–"]
     assert not decorative, (
-        "the prompt asks for no emoji while using %r" % decorative)
-
-
+        "the prompt asks for restraint while using %r" % decorative)
 def test_a_reopened_conversation_gets_THIS_build_instructions():
     """⛔ A SAVED TRANSCRIPT CARRIES THE PROMPT OF THE DAY IT STARTED, and
     restoring it wholesale let the file win against the code.

--- a/tests/test_the_session_column.py
+++ b/tests/test_the_session_column.py
@@ -21,7 +21,8 @@ import json
 import pytest
 
 from aihawk.mcp import store
-from aihawk.web import DEFAULT_CHAT_ID, UNNAMED, ChatService, Sessions, build_app
+from aihawk.web import (PAGE, DEFAULT_CHAT_ID, UNNAMED, ChatService, Sessions,
+                        build_app)
 
 pytestmark = pytest.mark.asyncio
 
@@ -426,3 +427,46 @@ async def test_a_queued_message_is_not_lost_when_the_page_goes_away():
     assert not stray, (
         "these assign the queue outside its single writer, so they do not save "
         "it: %s" % stray)
+
+
+def test_the_sessions_control_is_named_by_the_word_on_it():
+    """⛔ AN aria-label REPLACES THE VISIBLE NAME, IT DOES NOT ADD TO IT.
+
+    The control was three lines and an `aria-label` reading "Show sessions" /
+    "Hide sessions", which was the only name it had. On 2026-09-09 it became a
+    bar with the word Sessions written on it, and the label became a defect:
+    a screen reader would announce a word that is not on the button, and
+    somebody driving by voice who says "Sessions" would find nothing to click.
+    WCAG 2.5.3 Label in Name is the criterion, and the open state is carried by
+    `aria-expanded`, which is the attribute for it.
+
+    Found by reading the live DOM after the change rather than the source:
+    taking the attribute out of the markup left the script putting it back on
+    every open and close.
+
+    Known-bad, two: put `aria-label` back on the button, and put the
+    `setAttribute('aria-label', ...)` line back in `showRail`.
+    """
+    import re
+
+    button = re.search(r"<button id=\"rails\"[^>]*>(.*?)</button>", PAGE, re.S)
+    assert button, "the sessions control is gone"
+    assert "aria-label" not in button.group(0), (
+        "the control carries an aria-label as well as a visible word, and the "
+        "label is what a screen reader reads instead of the word: %s"
+        % button.group(0))
+    assert "Sessions" in button.group(1), (
+        "the control has no visible word, so it has no accessible name either")
+    assert 'aria-expanded' in button.group(0), (
+        "nothing says whether the column is open")
+
+    script = PAGE[PAGE.index("<script"):]
+    code = re.sub(r"/\*.*?\*/", "", script, flags=re.S)
+    # Every place the script names this control, and not the 400 characters
+    # after the first one: the first `$('rails')` in the file is not the one
+    # in `showRail`, so that window read the wrong code and the known-bad
+    # walked straight through it.
+    sets = re.findall(r"\$\('rails'\)\s*\.setAttribute\(\s*'aria-label'", code)
+    assert not sets, (
+        "the script puts an aria-label back on the control, which replaces the "
+        "word written on it every time the column opens or closes")


### PR DESCRIPTION
The prompt asked for no emoji, which is a ban, and what was wanted was much less decoration and answers people are glad to read. The ban also bought nothing.

Measured against the model this product runs, on eight finished tasks with the answer asked for three ways, interleaved: the arm carrying **no instruction at all** produced ONE emoji in eight.

What it produced instead is the actual complaint:

| | emoji | bold labels | checklists | em dashes | preambles | closing summaries |
|---|---|---|---|---|---|---|
| no instruction | 1 | 19 | 8 | 7 | 2 | 2 |
| the emoji ban | 0 | 9 | 6 | 11 | 1 | 2 |
| this change | 0 | 3 | 0 | 0 | 0 | 0 |

So the prompt asks for the shape instead of banning a character: the answer first and then what supports it, no announcing what is about to be said, no repeating the question back, no closing summary of what was just written, prose by default with a heading or a list or a table only when the content really is one, decoration rare rather than forbidden, and every dash a plain hyphen.

The same question, before and after, same model and same temperature:

> Ecco il riepilogo di quello che ho trovato sui tre siti: [...] In sintesi: due siti su tre funzionano e hanno restituito annunci, mentre il secondo blocca l'accesso in modo costante, quindi i suoi contenuti restano sconosciuti.

> Su due siti su tre ho trovato gli annunci; il secondo mi ha bloccato l'accesso. [...] Se ti serve il contenuto di due.test, servono credenziali valide o un permesso lato server.

## The gate

It asserted the WORD `markdown` where the requirement is a meaning. The prompt now names the marks it allows - a heading, a list, a table - which says the same thing to a model and says it more precisely, and the old assertion went red on the better prompt. A gate that checks a word instead of what the word stood for is the comment-versus-code defect moved into a string.

Four known-bads kill the new one: no sentence on decoration, the marks unnamed, "plain text" back in, and an emoji or an em dash in the prompt itself - one that decorates while asking for restraint teaches the habit it is trying to curb.

## And the sessions control says Sessions

Three lines mean "there is a menu here" only to somebody who has already learned that they do, and what is behind this one is a list of sessions - which the column's own header says in words. The two read as one word in one voice now.

The `aria-label` had to go with the icon. It said "Show sessions" / "Hide sessions", which was the only name the control had while it was three lines; with a word written on it, an aria-label REPLACES that name, so a screen reader would announce something that is not on the button and voice control would not find it (WCAG 2.5.3). Found by reading the live DOM: taking the attribute out of the markup left `showRail` putting it back on every open and close.

Its gate was blind on the first write - it read the 400 characters after the FIRST `$('rails')`, which is not the one in `showRail` - and now matches every place the script names the control. Three known-bads kill it.