### PR TITLE
A restored browser comes back on the engine this build was given (0.26.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.26.0"
+version = "0.26.1"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/mcp/plan.py
+++ b/src/aihawk/mcp/plan.py
@@ -162,6 +162,32 @@ def _describe_exit(proxy: Optional[dict], explicit: Optional[str],
     return proxy["server"]
 
 
+def engine_here(env: Optional[Mapping[str, str]] = None) -> dict:
+    """The engine THIS process was told to launch, if it was told one.
+
+    ⛔ THE ENGINE IS A PROPERTY OF THE PROCESS, NOT OF THE SESSION, and keeping
+    those two apart is the whole reason this exists. `WHO_A_BROWSER_IS` leaves
+    `binary_path` out of what a session writes down, and rightly: it is a path
+    on THIS machine, and a session carried to another one must resolve an engine
+    rather than insist on a path that means nothing there. But leaving it out of
+    the FILE was read as leaving it out of the browser, so a browser restored
+    from a saved session came back without the engine the person had asked for.
+
+    Measured 2026-09-09, and it is not only a developer's problem. Somebody
+    running `aihawk ui --binary <their build>` and reopening a session got
+    browsers on a DIFFERENT engine than the one they named, silently; on a build
+    whose seal has no published assets - anything built locally - they got no
+    browser at all, because there was nothing to download and nothing to run.
+
+    The transcript is what happened; the engine is what this build was asked
+    for. Same shape as the system prompt, which a saved conversation used to
+    carry back in place of the current one.
+    """
+    env = os.environ if env is None else env
+    named = env.get("STEALTHFOX_BINARY")
+    return {"binary_path": named} if named else {}
+
+
 def plan_session(seed: Optional[int] = None, proxy: Optional[str] = None,
                  profile: Optional[str] = None,
                  env: Optional[Mapping[str, str]] = None) -> SessionPlan:
@@ -202,8 +228,7 @@ def plan_session(seed: Optional[int] = None, proxy: Optional[str] = None,
         "seed": chosen_seed,
         "headless": env.get("STEALTHFOX_HEADLESS", "1") != "0",
     }
-    if env.get("STEALTHFOX_BINARY"):
-        kwargs["binary_path"] = env["STEALTHFOX_BINARY"]
+    kwargs.update(engine_here(env))
     if chosen_proxy is not None:
         kwargs["proxy"] = chosen_proxy
     if directory is not None:

--- a/src/aihawk/mcp/server.py
+++ b/src/aihawk/mcp/server.py
@@ -311,7 +311,16 @@ def restore(session_id: str | None = None) -> bool:
         # make it carry a fact about pages, which is the one thing it has
         # deliberately never known.
         owed = config.pop("urls", None)
-        registry.declare(key, config)
+        # ⛔ AND THE ENGINE COMES FROM THIS PROCESS, NOT FROM THE FILE. The file
+        # deliberately does not carry `binary_path` - it is a path on this
+        # machine, and a session opened on another one must resolve an engine
+        # rather than insist on one that is not there. Leaving it out of the
+        # file was read as leaving it out of the BROWSER, so a restored browser
+        # came back without the engine the person had named on the command
+        # line: on a locally built one, with nothing to download, it could not
+        # start at all. What the file says is who this browser is; what this
+        # build was asked to run it on is not the file's to say.
+        registry.declare(key, dict(config, **plan.engine_here()))
         if owed:
             _tabs_owed[key] = list(owed)
     if saved.get("focus"):

--- a/tests/mcp_server/test_a_session_survives_the_process.py
+++ b/tests/mcp_server/test_a_session_survives_the_process.py
@@ -407,3 +407,58 @@ async def test_closing_the_last_browser_stops_the_session_being_listed(registry)
 
     assert store.load("default") is None
     assert "no saved sessions yet" in await server.session_list()
+
+
+async def test_a_restored_browser_runs_on_the_engine_this_build_was_given(
+        registry, monkeypatch):
+    """⛔ THE ENGINE IS A PROPERTY OF THE PROCESS, NOT OF THE SESSION, and
+    leaving it out of the FILE was read as leaving it out of the BROWSER.
+
+    `WHO_A_BROWSER_IS` keeps `binary_path` out of what a session writes down,
+    and rightly: it is a path on THIS machine, and a session carried to another
+    one must resolve an engine rather than insist on a path that means nothing
+    there. But a browser restored from that file was then declared without an
+    engine at all, so it came back on whatever the seal resolved instead of on
+    the one the person had named.
+
+    Measured 2026-09-09, and not only a developer's problem: somebody running
+    `aihawk ui --binary <their build>` and reopening a session got browsers on a
+    DIFFERENT engine, silently. On a locally built one - a seal with no
+    published assets - they got no browser at all, because there was nothing to
+    download and nothing to run. The interface's own agent hit it live and
+    worked around it by closing and reopening every browser under the same name,
+    which works precisely because `browser_open` goes through the launch plan
+    and a restore does not.
+
+    Same shape as the system prompt a saved conversation used to carry back in
+    place of the current one: the file says what happened, the build says what
+    it runs on.
+
+    Known-bad: `registry.declare(key, config)` without the engine.
+    """
+    monkeypatch.setenv("STEALTHFOX_BINARY", "C:/an/engine/firefox.exe")
+    store.save("default", {"uno": {"seed": 4242, "headless": True}})
+
+    session = await server.ready(browser_id="uno")
+
+    assert session.kwargs.get("seed") == 4242, "it came back as somebody else"
+    assert session.kwargs.get("binary_path") == "C:/an/engine/firefox.exe", (
+        "the browser came back without the engine this process was told to "
+        "run, so it resolved one from the seal instead: %r" % session.kwargs)
+
+
+async def test_and_the_engine_is_still_never_written_into_the_file(registry,
+                                                                  monkeypatch):
+    """The other half, and the reason the first half is not simply adding
+    `binary_path` to what a session saves. A path on this machine written into a
+    session file is a session that only opens here.
+
+    Known-bad: put "binary_path" into WHO_A_BROWSER_IS.
+    """
+    monkeypatch.setenv("STEALTHFOX_BINARY", "C:/an/engine/firefox.exe")
+    await server.browser_open(browser_id="uno", seed=4242)
+
+    saved = store.load("default")
+    assert "binary_path" not in saved["browsers"]["uno"], (
+        "the session file carries a path that means nothing on another "
+        "machine: %r" % saved["browsers"]["uno"])


### PR DESCRIPTION
Leaving the engine out of the FILE was read as leaving it out of the BROWSER.

`WHO_A_BROWSER_IS` keeps `binary_path` out of what a session writes down, and that is right: it is a path on THIS machine, and a session carried to another one must resolve an engine rather than insist on a path that means nothing there. But a browser restored from that file was then declared with no engine at all, so it came back on whatever the seal resolved instead of on the one the person had named.

Not only a developer's problem. Somebody running `aihawk ui --binary <their build>` and reopening a session gets browsers on a **different engine** than the one they asked for, silently. On a locally built one - a seal with no published assets - they get no browser at all, because there is nothing to download and nothing to run.

## How it was found

By reading what the interface's own agent said while working:

> The same engine bug struck again - all four browsers had died since the last round and couldn't relaunch on their own (the local-seal/binary_path error). I closed and reopened them under the same names, and the navigations then succeeded.

That workaround states the shape of the defect: `browser_open` goes through the launch plan, and a restore does not.

Measured before the fix, on a saved session with `STEALTHFOX_BINARY` set:

```
what a RESTORED browser would be launched with:
    {'seed': 7, 'headless': True}
what a FRESH one is launched with:
    {'seed': ..., 'headless': True, 'binary_path': 'C:/ff/.../firefox.exe'}
```

## The fix

The engine is a property of the PROCESS, so `plan.engine_here()` is the one place that knows what this build was told to run, and both the launch plan and the restore read it from there. Same shape as the system prompt that a saved conversation used to carry back in place of the current one: the file says what happened, the build says what it runs on.

Two known-bads, both killed: declare without the engine, and put `binary_path` into what the session file saves - which would make a session that only opens on the machine that wrote it.

490 tests green.