### PR TITLE
Contrast, target size and a stage that fits what is on it (0.27.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.26.1"
+version = "0.26.2"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.26.2"
+version = "0.27.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -82,10 +82,16 @@ PAGE = r"""<!doctype html>
   --lip:    inset 0 1px 0 rgba(255,255,255,.045);
 
   /* Ink, with the contrast each one carries against --base. */
-  --fg:   #e8ebed;   /* 15.0:1  what the user typed, what the model answered */
-  --fg-2: #a8b1b9;   /*  8.7:1  narration and chrome labels */
-  --fg-3: #78828a;   /*  4.8:1  tool output and arguments */
-  --fg-4: #4a545c;   /*  2.2:1  step numbers and placeholder: decorative only */
+  --fg:   #e8ebed;   /* 15.6:1  what the user typed, what the model answered */
+  --fg-2: #a8b1b9;   /*  8.6:1  narration and chrome labels */
+  --fg-3: #78828a;   /*  4.8:1  tool output and arguments, and now every quiet word */
+  /* ⛔ AND `--fg-4` NEVER COLOURS WORDS. It was carrying the count beside a
+     conversation, the address under a link, the timing on a step, the marker of
+     a list, the dim halves of the URL and the placeholder inside a preview -
+     nine rules, all of them text, all of them at 2.4:1 where AA asks 4.5. The
+     worst was the address: it is printed precisely so an injected link can be
+     read, and it was the hardest thing on the page to read. */
+  --fg-4: #4a545c;   /*  2.4:1  decoration only - a dot, a chevron, never a word */
 
   --accent:    #e38a5d;
   --on-accent: #101317;
@@ -108,13 +114,16 @@ PAGE = r"""<!doctype html>
 
   --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s5:20px; --s6:32px;
   --r-sm:4px; --r:8px; --r-lg:12px; --r-pill:999px;
+  --spine:54px;                               /* the sessions band */
+  --topbar:50px;                              /* every header, one height */
   --gutter:1.75rem;                            /* three digits of 11px mono */
   --gap:.55rem;
   --indent:calc(var(--gutter) + var(--gap));   /* ONE source for the step indent */
 }
 
 *{ box-sizing:border-box }
-body{ margin:0; height:100vh; display:flex; background:var(--base); color:var(--fg);
+body{ margin:0; height:100vh; display:flex; position:relative;
+      background:var(--base); color:var(--fg);
       font:var(--t-body)/1.55 var(--sans); }
 code,pre,.g,.meta,.badge,#url,#tok{
   font-family:var(--mono);
@@ -123,8 +132,15 @@ code,pre,.g,.meta,.badge,#url,#tok{
      being the text the model emitted. */
   font-variant-ligatures:none; }
 .meta,.g,#tok{ font-variant-numeric:tabular-nums }
+/* ⛔ `--fg-4` IS DECLARED DECORATIVE AT 2.4:1 AND THIS CLASS PUT WORDS ON IT.
+   Measured on the running page: the state beside the browser read at 2.23:1,
+   the meter at 2.71, the placeholder inside a screen at 2.51, the layout icons
+   at 2.51. WCAG AA wants 4.5:1 for text and 3:1 for a graphic that carries
+   meaning, and the token's own comment in this file says what it is for. A
+   label is a small word, not a faint one: `--fg-3` is 4.8:1 and still reads as
+   quieter than the thing it labels. */
 .label{ font-size:var(--t-label); font-weight:600; letter-spacing:.07em;
-        text-transform:uppercase; color:var(--fg-4); line-height:1 }
+        text-transform:uppercase; color:var(--fg-3); line-height:1 }
 .sr{ position:absolute; width:1px; height:1px; overflow:hidden; clip-path:inset(50%) }
 /* `hidden` must beat any display an id or class sets, or an element the script
    believes it has hidden stays on screen. This shipped once on the live image
@@ -144,12 +160,24 @@ code,pre,.g,.meta,.badge,#url,#tok{
    a choice. It is one keystroke away, it remembers what you last did with it,
    and the toggle lives IN the header row rather than above the list - a control
    floating over a panel is what "bolted on" looks like. */
-#rail { width:224px; flex:none; display:flex; flex-direction:column;
-        background:var(--well); border-right:1px solid var(--line-1) }
+/* ⛔ IT FLOATS OVER THE CONVERSATION, IT DOES NOT PUSH IT. As a flex sibling
+   the column took its width out of the room and everything to its right moved
+   the moment it opened, which for a panel you open and shut twenty times an
+   hour is the whole layout twitching. Out of flow it costs nothing: the
+   conversation stays exactly where it was, the panel lies on top of the near
+   edge of it, and because the panel is narrower than the conversation the rest
+   of the words are still there to come back to.
+   Anchored to the spine's own width so the two are one object, and lifted with
+   a shadow rather than a border, because what says "this is over that" is the
+   shadow. */
+#rail { position:absolute; top:0; bottom:0; left:var(--spine); width:224px;
+        z-index:5; display:flex; flex-direction:column;
+        background:var(--well); border-right:1px solid var(--line-1);
+        box-shadow:14px 0 34px -18px #000 }
 /* The header of the column lines up with the header of the conversation beside
    it: same height, same padding, so the two read as one row across the app. */
-#railhead{ display:flex; align-items:center; gap:8px;
-           padding:var(--s3) var(--s3) var(--s3) var(--s4);
+#railhead{ flex:none; height:var(--topbar); display:flex; align-items:center;
+           gap:8px; padding:0 var(--s3) 0 var(--s4);
            border-bottom:1px solid var(--line-1) }
 #railhead .label{ flex:1 }
 #newchat{ flex:none; width:26px; height:26px; display:grid;
@@ -176,9 +204,9 @@ code,pre,.g,.meta,.badge,#url,#tok{
    the background, while a line that is always there is the edge of the room,
    and the open state has the background and the ink to say it. It also replaces
    the hairline that used to separate this from what follows. */
-#railtab{ flex:none; width:44px; padding:0; cursor:pointer; border:0;
+#railtab{ flex:none; width:var(--spine); padding:0; cursor:pointer; border:0;
           position:relative; background:var(--base); color:var(--fg-3);
-          box-shadow:inset -1.5px 0 0 var(--accent);
+          box-shadow:inset -1px 0 0 var(--accent);
           /* The chevron and the word are two rows of one grid, centred
              together: pinned to the top the arrow sat 450px from the word and
              the two read as separate things on the same strip. */
@@ -201,12 +229,13 @@ code,pre,.g,.meta,.badge,#url,#tok{
    edge away from the column instead of the one beside it - correct in the
    element's own coordinates and backwards on the screen. */
 #railtab span{ writing-mode:vertical-rl; transform:rotate(180deg);
-               font:600 .75rem/1 var(--sans); letter-spacing:.18em;
+               font:600 .875rem/1 var(--sans); letter-spacing:.2em;
                text-transform:uppercase }
 #railtab:hover{ background:var(--raised); color:var(--fg) }
 /* Open: the spine lifts a rung and the word goes to full ink. The state is
    drawn on the thing you press, where a hand already is. */
 #railtab[aria-expanded="true"]{ background:var(--raised); color:var(--fg) }
+#railtab[aria-expanded="true"] span{ display:none }
 @media (max-width:900px){ #railtab{ display:none } }
 #chats{ flex:1; min-height:0; overflow-y:auto; padding:var(--s2) var(--s2) var(--s3);
         /* A long list is cheap to skip past: the rows below the fold are not
@@ -230,9 +259,12 @@ code,pre,.g,.meta,.badge,#url,#tok{
            white-space:nowrap; border:0; background:none; color:inherit;
            font:inherit; text-align:left; padding:0; cursor:pointer }
 .chat .cnt{ flex:none; font-family:var(--mono); font-size:var(--t-label);
-            color:var(--fg-4) }
-.chat .x{ flex:none; width:18px; height:18px; border:0; border-radius:4px;
-          background:none; color:var(--fg-4); cursor:pointer; line-height:1;
+            color:var(--fg-3) }
+/* 24 and not 18: WCAG 2.2 puts the floor at 24px and this is the control
+   that DELETES a conversation, so it is also the one where a near miss costs
+   the most. */
+.chat .x{ flex:none; width:24px; height:24px; border:0; border-radius:4px;
+          background:none; color:var(--fg-3); cursor:pointer; line-height:1;
           visibility:hidden }
 .chat:hover .x, .chat:focus-within .x{ visibility:visible }
 .chat .x:hover{ background:var(--line-2); color:var(--fg) }
@@ -265,13 +297,17 @@ code,pre,.g,.meta,.badge,#url,#tok{
 #split:focus-visible{ outline:none }
 #split:focus-visible::after, #split[data-drag]::after{ background:var(--accent); width:2px }
 #right{ flex:1; min-width:0; display:flex; flex-direction:column; background:var(--well) }
-#head { display:flex; align-items:center; gap:10px; padding:var(--s3) var(--s4);
+#head { flex:none; height:var(--topbar); display:flex; align-items:center;
+        gap:10px; padding:0 var(--s4);
         border-bottom:1px solid var(--line-1) }
 #head b{ font-size:var(--t-ui); font-weight:600 }
-.badge{ margin-left:auto; font-size:var(--t-label); color:var(--fg-2);
+.badge{ font-size:var(--t-label); color:var(--fg-2);
         background:var(--raised); border:1px solid var(--line-2);
         padding:3px 9px; border-radius:var(--r-pill) }
-#fresh{ font-size:var(--t-label); font-family:var(--sans); color:var(--fg-2);
+/* 24px is the floor WCAG 2.2 sets for a target, and these three sat at 21,
+   22 and 23 - close enough to look fine and short enough to fail. */
+#fresh{ min-height:24px; font-size:var(--t-label); font-family:var(--sans);
+        color:var(--fg-2);
         background:var(--raised); border:1px solid var(--line-2); cursor:pointer;
         padding:3px 9px; border-radius:var(--r-pill);
         transition:background-color 120ms ease-out, color 120ms ease-out }
@@ -323,7 +359,7 @@ code,pre,.g,.meta,.badge,#url,#tok{
 #hint .eg{ font:var(--t-mono)/1.9 var(--mono); color:var(--fg-2);
            background:var(--raised); border:1px solid var(--line-1);
            border-radius:var(--r); padding:var(--s3) var(--s4); text-align:left }
-#hint .sm{ font-size:.75rem; color:var(--fg-4) }
+#hint .sm{ font-size:.75rem; color:var(--fg-3) }
 
 #jump{ position:absolute; bottom:110px; left:50%; transform:translateX(-50%); z-index:2;
        background:var(--top); border:1px solid var(--line-2); color:var(--fg);
@@ -394,7 +430,7 @@ h5.md-h, h6.md-h{ font-size:var(--t-h3); color:var(--fg-2) }
 .md-l{ margin:0 1.4em var(--s4) 0; padding-left:2.6em }
 .md-l .md-l{ margin:var(--s2) 0 0 }        /* a nested list continues its item */
 .md-i{ margin:0 0 var(--s2); white-space:pre-wrap; overflow-wrap:anywhere }
-.md-i::marker{ color:var(--fg-4) }
+.md-i::marker{ color:var(--fg-3) }
 .md-q{ margin:0 0 var(--s4); padding:2px 0 2px var(--s4); color:var(--fg-2);
        box-shadow:inset 2px 0 0 var(--line-3) }
 .md-hr{ margin:var(--s5) 0; border:0; border-top:1px solid var(--line-2) }
@@ -410,7 +446,7 @@ h5.md-h, h6.md-h{ font-size:var(--t-h3); color:var(--fg-2) }
    whatever page the agent last read, and the browser it drives is right there.
    The address is printed next to them so an injected one is legible. */
 .lk  { color:var(--fg) }
-.href{ color:var(--fg-4); font:.75rem/1.5 var(--mono); overflow-wrap:anywhere }
+.href{ color:var(--fg-3); font:.75rem/1.5 var(--mono); overflow-wrap:anywhere }
 .href::before{ content:" " }
 .orph  { display:flex; gap:8px; font-size:var(--t-mono); color:var(--err);
          background:rgba(232,131,107,.08); border-radius:var(--r-sm);
@@ -423,13 +459,13 @@ h5.md-h, h6.md-h{ font-size:var(--t-h3); color:var(--fg-2) }
       transition:background-color 120ms ease-out }
 .row::-webkit-details-marker{ display:none }
 .row:hover{ background:var(--raised) }
-.g   { grid-column:1; justify-self:end; font-size:var(--t-label); color:var(--fg-4) }
+.g   { grid-column:1; justify-self:end; font-size:var(--t-label); color:var(--fg-3) }
 .lab { grid-column:2; min-width:0; overflow:hidden; text-overflow:ellipsis;
        white-space:nowrap; font-size:var(--t-mono) }
 .lab b   { font-family:var(--sans); font-weight:600; color:var(--fg) }  /* the verb */
 .lab code{ color:var(--accent) }                                        /* the object */
 .lab .inline{ color:var(--fg-3) }                    /* a short result, on the row */
-.meta{ grid-column:3; white-space:nowrap; font-size:var(--t-label); color:var(--fg-4) }
+.meta{ grid-column:3; white-space:nowrap; font-size:var(--t-label); color:var(--fg-3) }
 
 /* The chevron is the row's own pseudo-element in its own track: no svg, no icon
    font, and it cannot shift the label when it turns. */
@@ -481,9 +517,9 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
     font:var(--t-body)/1.55 var(--sans); min-height:24px; max-height:200px;
     overflow-y:hidden; padding:0; caret-color:var(--accent) }
 /* --fg-3 and not --fg-4: the placeholder is the only hint the composer gives,
-   so it is text that has to be read, and --fg-4 sits at 2.2:1 against 4.5:1.
-   The step numbers keep --fg-4, which is what it was picked for: decoration
-   beside a label that carries the meaning. */
+   so it is text that has to be read, and --fg-4 sits at 2.4:1 against 4.5:1.
+   This was the first rule to be moved and it stayed the only one for a while;
+   the other nine went the same way once somebody counted them. */
 #i::placeholder{ color:var(--fg-3) }
 #go, #halt{ width:32px; height:32px; flex:none; border:0; border-radius:50%; display:grid;
      place-items:center; cursor:pointer; background:var(--accent);
@@ -500,12 +536,7 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
        background:var(--hover); border:1px solid var(--line-2); color:var(--fg-2);
        font-size:var(--t-label); padding:3px 9px; border-radius:var(--r-pill);
        cursor:pointer }
-/* flex-end and not space-between: with the label gone there is one thing in
-   this row, and space-between would leave it on the LEFT, which is where the
-   word used to be. */
-#under{ display:flex; align-items:center; justify-content:flex-end;
-        gap:var(--s2); padding:var(--s2) var(--s1) 0; min-height:1lh }
-#tok{ display:inline-flex; align-items:center; gap:6px;
+#tok{ margin-left:auto; display:inline-flex; align-items:center; gap:6px;
       font-size:var(--t-label); color:var(--fg-3) }
 
 /* ---------------- browser pane ---------------- */
@@ -523,13 +554,17 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
 #tabs button[aria-selected="true"]{ background:var(--base); color:var(--fg) }
 #tabs .t{ overflow:hidden; text-overflow:ellipsis }
 
-#chrome{ flex:none; height:38px; display:flex; align-items:center; gap:var(--s2);
-         padding:0 10px; background:var(--raised); border-bottom:1px solid var(--line-1) }
+/* The same height as the conversation's header beside it. They were 38 and
+   50, so the top edge of the product broke by twelve pixels on its main
+   seam - the one place a misalignment is read as the whole thing being
+   loose rather than as one box being wrong. */
+#chrome{ flex:none; height:var(--topbar); display:flex; align-items:center;
+         gap:var(--s2); padding:0 10px; background:var(--raised); border-bottom:1px solid var(--line-1) }
 /* The honesty contract: nothing in here is interactive except what is, so
    nothing in here gets a pointer cursor except what does. */
 #chrome, #chrome *{ cursor:default; user-select:none }
 #url{ user-select:text }
-#mode button{ cursor:pointer }
+#mode button{ cursor:pointer; min-height:24px }
 #dot{ width:7px; height:7px; flex:none; border-radius:50%; background:var(--fg-4) }
 [data-state="live"]  #dot{ background:var(--ok); animation:breathe 1.8s ease-in-out infinite }
 [data-state="busy"]  #dot{ background:var(--accent); animation:breathe .9s ease-in-out infinite }
@@ -538,7 +573,7 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
 #url{ flex:1; min-width:0; height:24px; line-height:24px; padding:0 10px;
       border-radius:var(--r-pill); background:var(--well); border:1px solid var(--line-1);
       font-size:.75rem; white-space:nowrap; overflow:hidden; text-overflow:ellipsis }
-#url .dim{ color:var(--fg-4) }
+#url .dim{ color:var(--fg-3) }
 #url .host{ color:var(--fg) }
 #mode{ display:inline-flex; gap:2px; flex:none; background:var(--base);
        border-radius:var(--r); padding:3px }
@@ -572,17 +607,17 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
         display:flex; flex-direction:column; text-align:left; font:inherit;
         color:var(--fg-3) }
 .thumb:hover{ border-color:var(--line-3); color:var(--fg) }
-.thumb[aria-current="true"]{ border-color:var(--fg-4); color:var(--fg) }
+.thumb[aria-current="true"]{ border-color:var(--fg-2); color:var(--fg) }
 .thumb .pic{ width:100%; aspect-ratio:16/10; background:var(--well);
              display:grid; place-items:center; overflow:hidden }
 .thumb .pic img{ width:100%; height:100%; object-fit:cover; display:block }
-.thumb .pic span{ font-size:var(--t-label); color:var(--fg-4); padding:4px;
+.thumb .pic span{ font-size:var(--t-label); color:var(--fg-3); padding:4px;
                   text-align:center }
 .thumb .cap{ display:flex; align-items:center; gap:6px; padding:5px 7px;
              font-family:var(--mono); font-size:var(--t-label) }
 .thumb .cap .id{ flex:1; min-width:0; overflow:hidden; text-overflow:ellipsis;
                  white-space:nowrap }
-.thumb .cap .st{ flex:none; color:var(--fg-4) }
+.thumb .cap .st{ flex:none; color:var(--fg-3) }
 
 /* ⛔ THE STAGE IS A GRID NOW, AND HOW MANY CELLS IT HAS IS A MEASURED
    DECISION. A frame costs 5 to 6 ms of pipe, not the 22 this file assumed
@@ -596,6 +631,9 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
         container-type:size }
 #stage[data-grid="1"]{ grid-template-columns:1fr }
 #stage[data-grid="2"]{ grid-template-columns:1fr 1fr }
+/* Three on a 2x2 with one slot empty, because three equal screens and a gap
+   is what a control room does: the alternative makes one of them special. */
+#stage[data-grid="3"],
 #stage[data-grid="4"]{ grid-template-columns:1fr 1fr; grid-template-rows:1fr 1fr }
 .screen{ min-width:0; min-height:0; display:flex; flex-direction:column;
          background:var(--raised); border:1px solid var(--line-2);
@@ -604,7 +642,10 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
          transition:border-color 120ms ease-out }
 .screen:hover{ border-color:var(--line-3) }
 /* The one you are looking at, when there is more than one to look at. */
-.screen[aria-current="true"]{ border-color:var(--fg-4) }
+/* A graphic that carries meaning wants 3:1, and this one carries the answer
+   to "which screen is the address bar describing" - which at 2.4:1 was a
+   question you had to ask twice. */
+.screen[aria-current="true"]{ border-color:var(--fg-2) }
 .screen .shot{ flex:1; min-height:0; position:relative; background:var(--well);
                display:grid; place-items:center }
 /* contain and not cover: cropping a browser window hides part of what the
@@ -622,7 +663,12 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
    falls back on a stylesheet rule hiding it: the pane stayed black with the
    pixels already decoded inside it, and every structural assertion passed. */
 .screen .shot img[hidden]{ display:none }
-.screen .ph{ color:var(--fg-4); font-size:var(--t-ui) }
+/* The second half of the address bar when nobody has picked a screen: the count
+   is the fact, this is what to do about it. */
+#url .hint{ color:var(--fg-3); font-family:var(--sans); font-size:var(--t-label) }
+#url .hint::before{ content:"  -  "; white-space:pre }
+.screen .ph{ color:var(--fg-3); font-size:var(--t-ui); text-align:center;
+             padding:0 16px }
 .screen .cap{ flex:none; display:flex; align-items:center; gap:7px;
               padding:5px 9px; border-top:1px solid var(--line-1);
               font-family:var(--mono); font-size:var(--t-label);
@@ -639,9 +685,9 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
 
 #grid{ flex:none; display:flex; gap:2px; background:var(--well);
        border:1px solid var(--line-2); border-radius:var(--r-pill); padding:2px }
-#grid button{ min-width:24px; height:20px; padding:0 6px; border:0;
+#grid button{ min-width:30px; height:24px; padding:0 5px; border:0;
               border-radius:var(--r-pill); background:none; cursor:pointer;
-              font:600 var(--t-label)/1 var(--mono); color:var(--fg-4);
+              display:grid; place-items:center; color:var(--fg-3);
               transition:background-color 120ms ease-out, color 120ms ease-out }
 #grid button:hover{ color:var(--fg-2) }
 #grid button[aria-pressed="true"]{ background:var(--raised); color:var(--fg) }
@@ -689,8 +735,15 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
 </nav>
 
 <div id="left">
+  <!-- The meter lives up here with the other things that describe the
+       conversation rather than under the box you type in. What is under the box
+       should be the box: a number that grows all session long, sitting between
+       the composer and the edge of the window, is the one place a person looks
+       twenty times an hour for something else. -->
   <div id="head">
-    <b>AIHawk</b><span class="badge" id="model">no model</span>
+    <b>AIHawk</b>
+    <span id="tok" hidden></span>
+    <span class="badge" id="model">no model</span>
     <button id="fresh" type="button" title="Clear this conversation">Clear</button></div>
   <div id="log">
     <div id="thread">
@@ -720,13 +773,6 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
           <rect width="12" height="12" rx="2" fill="#fff"/></svg>
       </button>
     </div>
-    <!-- No word here any more. It said `agent`, which is what the whole left
-         column is: a label that names the thing you are already looking at
-         earns nothing and takes a line of the frame. The meter keeps the row,
-         pushed to its end. -->
-    <div id="under">
-      <span id="tok" hidden></span>
-    </div>
   </form>
 </div>
 
@@ -752,10 +798,28 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
     <!-- How many browsers are on the stage at once. The vocabulary of a
          control room, because that is the job: one when you are watching the
          work, four when you are keeping an eye on it. -->
+    <!-- Drawn rather than numbered: the icon IS the layout, where a digit is a
+         label for it. Each carries its own name because there is no text in it
+         to read - the opposite of the sessions spine, where the word is the
+         name and an aria-label would replace it. -->
     <span id="grid" role="group" aria-label="Screens at once">
-      <button type="button" data-n="1" aria-pressed="true">1</button>
-      <button type="button" data-n="2" aria-pressed="false">2</button>
-      <button type="button" data-n="4" aria-pressed="false">4</button>
+      <button type="button" data-n="1" aria-pressed="true"
+              aria-label="One screen" title="One screen">
+        <svg viewBox="0 0 18 12" width="18" height="12" fill="none"
+             stroke="currentColor" stroke-width="1.3">
+          <rect x="1" y="1" width="16" height="10" rx="1.6"/></svg></button>
+      <button type="button" data-n="2" aria-pressed="false"
+              aria-label="Two screens" title="Two screens">
+        <svg viewBox="0 0 18 12" width="18" height="12" fill="none"
+             stroke="currentColor" stroke-width="1.3">
+          <rect x="1" y="1" width="16" height="10" rx="1.6"/>
+          <path d="M9 1v10"/></svg></button>
+      <button type="button" data-n="4" aria-pressed="false"
+              aria-label="Four screens" title="Four screens">
+        <svg viewBox="0 0 18 12" width="18" height="12" fill="none"
+             stroke="currentColor" stroke-width="1.3">
+          <rect x="1" y="1" width="16" height="10" rx="1.6"/>
+          <path d="M9 1v10M1 6h16"/></svg></button>
     </span>
   </div>
   <div id="stage" data-grid="1"></div>
@@ -1236,7 +1300,13 @@ let frozen = false;
 /* The second argument is the sentence behind a one-word state, shown on hover:
    an "error" with no reason is a thing to restart, an "error" that says the
    engine has no screencast is a thing to upgrade. */
+/* ⛔ AND IT SAYS NOTHING WHEN IT WOULD ONLY REPEAT THE TAB NEXT TO IT.
+   `Live` selected with the word `live` printed beside it is one fact twice,
+   one of them in the place the eye goes for news. `idle`, `busy` and `error`
+   are news, and they are now the only things that appear there; the dot keeps
+   carrying live and frozen, which is what a dot is for. */
 function say(s, why){ right.dataset.state = s; stateEl.textContent = s;
+                      stateEl.hidden = (s === 'live' || s === 'frozen');
                       stateEl.title = why || ''; }
 async function reason(r){ try { return (await r.json()).error || ''; } catch(err) { return ''; } }
 
@@ -1262,8 +1332,18 @@ $('mode').onclick = (e) => {
    the 25 the engine is asked to produce, two get 20 each, four get 10 each -
    40 requests a second at most, about a quarter of what the pipe can carry,
    leaving the rest to the agent whose clicks share it. */
-const FPS = {1: 25, 2: 20, 4: 10};
-const pause = () => Math.round(1000 / (FPS[grid] * grid));
+/* And it is paced on the screens that are ACTUALLY on the stage, never on
+   the layout picked. Two browsers in a four-up layout are two browsers: the
+   table this used to be gave them 10 frames a second each because the
+   BUTTON said four, halving the thing the person asked for by reading the
+   wrong number. The ceiling below is the measured budget - 40 requests a
+   second, about a quarter of the pipe - and the top rate is what the engine
+   is asked to produce, so asking for more would make frames to throw away. */
+const LAYOUTS = [1, 2, 4];
+const TOPRATE = 25, CEILING = 40;
+const fps = (n) => Math.min(TOPRATE, Math.floor(CEILING / n));
+const onScreen = () => Math.max(1, $('stage').children.length);
+const pause = () => Math.round(1000 / (fps(onScreen()) * onScreen()));
 
 /* One scheduler for the whole stage. It used to be two - a fast one for the
    single live pane and a slow one for the previews - and with a grid that
@@ -1298,6 +1378,7 @@ async function onePass(){
         im.src = URL.createObjectURL(blob);
         if(old && old.startsWith('blob:')) URL.revokeObjectURL(old);
         im.hidden = false;
+        cutTheChrome(cell, im);
         const ph = cell.querySelector('.ph'); if(ph) ph.hidden = true;
         cell.dataset.at = String(Date.now());
         if(id === watched()) say('live');
@@ -1312,6 +1393,46 @@ async function onePass(){
     } catch(err){ if(id === watched()) say('offline'); }
     ageAll(cells);
   }
+}
+
+/* ⛔ THE BROWSER'S OWN CHROME IS CUT OFF THE TOP OF EVERY SCREEN. The capture
+   is the WINDOW - deliberately, because that is the only way the pointer is in
+   the picture - and the tab strip and the address bar come with it. They say
+   nothing the frame above does not already say, and at four-up they cost a
+   tenth of every screen to repeat it four times.
+
+   MEASURED rather than guessed, on four real captures: the chrome is 8.3% of
+   the picture (57 rows of 688, 43 of 515, 57 of 688). It is a fraction and not
+   a pixel count because the engine scales the window into the frame it sends,
+   so the rows change with the window while the proportion does not.
+
+   Clipped and shifted rather than scaled: the page keeps its size and its
+   shape, and what was the chrome becomes empty frame at the bottom. Scaling the
+   rest up to fill would make one screen's pixels a different size from
+   another's, which for pictures meant to be compared is worse than a band. */
+const CHROME = 0.083;
+function cutTheChrome(cell, im){
+  if(!im.naturalWidth) return;
+  const box = im.getBoundingClientRect();
+  /* What `object-fit:contain` with `object-position:top center` actually draws:
+     as wide as the box or as tall, whichever runs out first, anchored to the
+     top - so the top of the drawing is the top of the box. */
+  const drawn = Math.min(box.height, box.width * im.naturalHeight / im.naturalWidth);
+  const cut = Math.round(CHROME * drawn);
+  /* ⛔ AND THEN THE PICTURE IS CENTRED IN ITS CELL. Every browser here has
+     a window of a different shape - that is the point of the fingerprint, not a
+     bug to iron out - so on a 2x2 the pictures come out different heights.
+     Measured on four live browsers: three cells drawing 304px of image and one
+     drawing 237px. Top-anchored, that one read as a smaller screen with a hole
+     under it, 29% of the cell empty against 8% for its neighbours. The leftover
+     split above and below reads as a frame instead, which is what it is: same
+     cell, same border, a picture of a different shape inside it. */
+  const lift = Math.round((box.height - (drawn - cut)) / 2);
+  const both = cut + ':' + lift;
+  if(cell.dataset.cut === both) return;
+  cell.dataset.cut = both;
+  im.style.clipPath = 'inset(' + cut + 'px 0 0 0)';
+  im.style.transform = 'translateY(' + (lift - cut) + 'px)';
 }
 
 /* ⛔ A PICTURE THAT HAS STOPPED MUST NOT READ AS ONE THAT IS RUNNING. On a
@@ -1369,11 +1490,37 @@ $('tabs').onclick = (e) => {
                          body: JSON.stringify({id: b.dataset.id})});
 };
 
-async function where(){
-  try { const r = await fetch(at('/live/tabs'), {cache:'no-store'});
-        if(r.ok){ const j = await r.json(); paintUrl(j.url || ''); paintTabs(j.tabs); } }
-  catch(err){}
-  setTimeout(where, 2000);
+/* ⛔ THE ADDRESS FOLLOWS THE SCREEN YOU ARE LOOKING AT, and with four of them
+   there is a case where no single address is the honest answer: nobody has
+   picked one, so the bar would be showing whichever browser the agent happens
+   to be in while three other pages sit beside it, unnamed. It says how many
+   instead, and how to choose. Once a screen has been clicked the bar follows
+   that one, at any layout. */
+function severalOpen(n){
+  urlEl.textContent = ''; urlEl.className = 'dim'; urlEl.title = '';
+  urlEl.append(el('span', null, n + ' pages open'),
+               el('span', 'hint', 'click a screen to follow it'));
+}
+
+/* ⛔ THE WORK AND THE TIMER ARE SEPARATE, for the reason the strip beside it
+   was: changing the layout changes what the address should say, and there is
+   nothing to wait for. While this was one function the bar kept the old answer
+   until the next poll landed - two seconds showing one page's address over four
+   screens. Calling `where` itself from a click would start a SECOND timer
+   chain, which is how a pace stops being one number. */
+async function where(){ await paintWhere(); setTimeout(where, 2000); }
+
+async function paintWhere(){
+  const many = grid > 1 && !pinned2 && onStage().length > 1;
+  if(many){ severalOpen(onStage().length); paintTabs([]); }
+  else try {
+    const who = watched();
+    /* `at` is what adds the question mark, so the browser goes in as one too
+       and it appends its own with an ampersand. */
+    const r = await fetch(at(who ? '/live/tabs?b=' + encodeURIComponent(who)
+                                 : '/live/tabs'), {cache:'no-store'});
+    if(r.ok){ const j = await r.json(); paintUrl(j.url || ''); paintTabs(j.tabs); }
+  } catch(err){}
 }
 /* ---------------- the session column ----------------
    Drawn from the server every time it changes rather than kept in step by hand:
@@ -1528,7 +1675,7 @@ function thumbFor(b){
    the view back to the agent, so there is a way out of a choice as well as in. */
 function watchThis(id){
   pinned2 = (pinned2 === id) ? null : id;
-  drawFleet();
+  drawStage(); drawStrip(); paintWhere();
 }
 
 /* ---- the stage: one screen, or two, or four ----
@@ -1582,7 +1729,12 @@ function screenFor(b, current){
 
 function drawStage(){
   const box = $('stage'), show = onStage();
-  box.dataset.grid = String(grid);
+  /* ⛔ THE TEMPLATE FOLLOWS THE CELLS THAT EXIST. Two running browsers in
+     a four-up layout used to be laid on a 2x2 whose second row was empty, so
+     each of them got half the height for nothing - the layout control is a
+     ceiling on how many you watch at once, not a promise that there are that
+     many. */
+  box.dataset.grid = String(Math.min(grid, Math.max(1, show.length)));
   /* Only when the SET changes, or every poll would throw away the pictures and
      make the whole stage flash once a second for no new fact. */
   const sig = show.map(b => b.id + ((b.urls || []).length ? 'p' : '')
@@ -1596,7 +1748,10 @@ function drawStage(){
     const cell = el('div','screen');
     cell.dataset.blank = '1';
     const shot = el('div','shot');
-    shot.appendChild(el('span','ph', 'nothing running yet'));
+    /* An empty state that only reports the emptiness leaves the person to
+       guess where the button is. There is no button - browsers are opened by
+       asking - so this is the one place that has to say so. */
+    shot.appendChild(el('span','ph', 'no browser yet - ask for one in the chat'));
     cell.append(shot, el('div','cap'));
     box.appendChild(cell);
     return;
@@ -1610,7 +1765,7 @@ function setGrid(n){
   for(const b of $('grid').children)
     b.setAttribute('aria-pressed', String(Number(b.dataset.n) === n));
   try { localStorage.setItem(GRIDKEY, String(n)); } catch(err){}
-  drawStage();
+  drawStage(); drawStrip(); paintWhere();
 }
 $('grid').onclick = (e) => {
   const b = e.target.closest('button');
@@ -1625,6 +1780,15 @@ async function drawFleet(){
   fleet = got.browsers || [];
   focusHere = got.focus || '';
   drawStage();
+  drawStrip();
+}
+
+/* ⛔ SEPARATE FROM THE POLL, because changing the layout changes what the strip
+   holds and there is nothing to ask the server about it. While this lived
+   inside `drawFleet` the strip stayed wrong until the next poll landed - up to
+   three seconds showing browsers that were already on the stage, or missing the
+   ones that had just left it. It reads the fleet that is already here. */
+function drawStrip(){
   /* The strip carries what the stage does not, so at four-up with four
      browsers it is empty and at one-up with eight it holds seven. */
   const up = new Set(onStage().map(b => b.id));
@@ -1755,7 +1919,7 @@ function splitter(){
 
 let sawGrid = null;
 try { sawGrid = localStorage.getItem(GRIDKEY); } catch(err){}
-setGrid(FPS[Number(sawGrid)] ? Number(sawGrid) : 1);
+setGrid(LAYOUTS.includes(Number(sawGrid)) ? Number(sawGrid) : 1);
 
 paint(); listen(); tick(); where(); fleetPoll(); slowTick(); splitter();
 if(!$('rail').hidden) drawChats();
@@ -2359,8 +2523,15 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
         seen = which(request)
         if not seen.link.touched:
             return JSONResponse({"url": "", "tabs": []})
+        # ⛔ WHICH BROWSER, like the frame route beside it. The address above the
+        # stage has to be the address of the screen being looked at, and with
+        # more than one screen the answer stopped being "the focused one" the
+        # moment clicking a screen became a way to look somewhere else.
+        watching = request.query_params.get("b") or None
         try:
-            raw = await seen.link.call_text("session_list_pages")
+            raw = await seen.link.call_text(
+                "session_list_pages",
+                {"browser_id": watching} if watching else None)
             rows = json.loads(raw)
         except Exception:
             return JSONResponse({"url": "", "tabs": []})

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -178,7 +178,7 @@ code,pre,.g,.meta,.badge,#url,#tok{
    the hairline that used to separate this from what follows. */
 #railtab{ flex:none; width:44px; padding:0; cursor:pointer; border:0;
           position:relative; background:var(--base); color:var(--fg-3);
-          box-shadow:inset -2px 0 0 var(--accent);
+          box-shadow:inset -1.5px 0 0 var(--accent);
           /* The chevron and the word are two rows of one grid, centred
              together: pinned to the top the arrow sat 450px from the word and
              the two read as separate things on the same strip. */
@@ -201,7 +201,7 @@ code,pre,.g,.meta,.badge,#url,#tok{
    edge away from the column instead of the one beside it - correct in the
    element's own coordinates and backwards on the screen. */
 #railtab span{ writing-mode:vertical-rl; transform:rotate(180deg);
-               font:600 var(--t-label)/1 var(--sans); letter-spacing:.16em;
+               font:600 .75rem/1 var(--sans); letter-spacing:.18em;
                text-transform:uppercase }
 #railtab:hover{ background:var(--raised); color:var(--fg) }
 /* Open: the spine lifts a rung and the word goes to full ink. The state is
@@ -500,8 +500,11 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
        background:var(--hover); border:1px solid var(--line-2); color:var(--fg-2);
        font-size:var(--t-label); padding:3px 9px; border-radius:var(--r-pill);
        cursor:pointer }
-#under{ display:flex; align-items:center; justify-content:space-between;
-        gap:var(--s2); padding:var(--s2) var(--s1) 0 }
+/* flex-end and not space-between: with the label gone there is one thing in
+   this row, and space-between would leave it on the LEFT, which is where the
+   word used to be. */
+#under{ display:flex; align-items:center; justify-content:flex-end;
+        gap:var(--s2); padding:var(--s2) var(--s1) 0; min-height:1lh }
 #tok{ display:inline-flex; align-items:center; gap:6px;
       font-size:var(--t-label); color:var(--fg-3) }
 
@@ -717,8 +720,11 @@ form{ padding:var(--s3) var(--s4) var(--s4); border-top:1px solid var(--line-1);
           <rect width="12" height="12" rx="2" fill="#fff"/></svg>
       </button>
     </div>
+    <!-- No word here any more. It said `agent`, which is what the whole left
+         column is: a label that names the thing you are already looking at
+         earns nothing and takes a line of the frame. The meter keeps the row,
+         pushed to its end. -->
     <div id="under">
-      <span class="label">agent</span>
       <span id="tok" hidden></span>
     </div>
   </form>

--- a/tests/test_the_page_can_be_read.py
+++ b/tests/test_the_page_can_be_read.py
@@ -1,0 +1,117 @@
+"""The two things a page has to get right before anything else it does.
+
+⛔ CONTRAST AND TARGET SIZE ARE ARITHMETIC, WHICH IS WHY THEY ARE HERE. Every
+other judgement about this interface is a matter of taste and belongs in a
+screenshot; these two are numbers with a threshold, and a threshold that nobody
+computes is a threshold that drifts. WCAG 2.2 asks 4.5:1 for text, 3:1 for a
+graphic that carries meaning, and 24 by 24 pixels for anything you have to hit.
+
+Measured on the running page before this was written: the state beside the
+browser read at 2.23:1, the token meter at 2.71, the placeholder inside a screen
+at 2.51, the layout icons at 2.51 - and nine more rules had put words on the ink
+this file's own palette annotates as `decorative only`. The worst of them was
+`.href`, the address printed beneath a link precisely so that an injected one
+can be read; it was the hardest text on the page to read.
+"""
+from __future__ import annotations
+
+import re
+
+from aihawk.web import PAGE
+
+#: The palette declares its own ratios in a comment beside each hex. This is
+#: what makes that comment checkable rather than decorative in its own right.
+INK = re.compile(r"--(fg(?:-\d)?):\s*(#[0-9a-fA-F]{6});\s*/\*\s*([\d.]+):1")
+
+
+def channel(c):
+    c = c / 255
+    return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+
+def luminance(hexcolour):
+    r, g, b = (int(hexcolour[i:i + 2], 16) for i in (1, 3, 5))
+    return 0.2126 * channel(r) + 0.7152 * channel(g) + 0.0722 * channel(b)
+
+
+def contrast(one, two):
+    a, b = sorted((luminance(one), luminance(two)))
+    return (b + 0.05) / (a + 0.05)
+
+
+def blocks():
+    """Every CSS rule in the page as (selector, declarations), comments gone."""
+    css = PAGE[PAGE.index("<style>"):PAGE.index("</style>")]
+    css = re.sub(r"/\*.*?\*/", "", css, flags=re.S)
+    return re.findall(r"([^{}]+)\{([^{}]*)\}", css)
+
+
+def test_the_palette_carries_the_ratios_it_claims():
+    """⛔ THE NUMBER IN THE COMMENT IS THE REASON THE RULE ABOVE EXISTS. Four
+    inks, each annotated with its contrast against the page's base, and every
+    decision about which one a thing gets was made by reading those. A hex
+    nudged for taste moves the ratio and leaves the comment describing the old
+    one, which is how a palette stops meaning anything.
+
+    Known-bad: lighten the base, or darken any ink, without moving its number.
+    """
+    base = re.search(r"--base:\s*(#[0-9a-fA-F]{6})", PAGE)
+    assert base, "the page no longer declares the colour everything sits on"
+    claimed = {name: (hexc, float(ratio)) for name, hexc, ratio in INK.findall(PAGE)}
+    assert set(claimed) >= {"fg", "fg-2", "fg-3", "fg-4"}, \
+        "the ink ladder is %s" % sorted(claimed)
+
+    for name, (hexc, ratio) in claimed.items():
+        real = contrast(hexc, base.group(1))
+        assert abs(real - ratio) < 0.1, (
+            "--%s is %s, which reads at %.1f:1 against the base while the "
+            "palette says %.1f:1" % (name, hexc, real, ratio))
+
+
+def test_no_word_on_this_page_is_painted_with_the_decorative_ink():
+    """⛔ THE CLASS, NOT THE INSTANCE. `--fg-4` is annotated `decorative only`
+    and eleven rules used it as a text colour anyway: the message count beside a
+    conversation, the address under a link, the timing on a step, a list marker,
+    the dim halves of the URL, the placeholder inside a preview. Each one read
+    as a small deliberate choice; together they were most of the quiet text in
+    the product, at half the contrast the same file says it needs.
+
+    Known-bad: give any rule `color:var(--fg-4)` back.
+    """
+    claimed = {name: (hexc, float(r)) for name, hexc, r in INK.findall(PAGE)}
+    assert claimed["fg-4"][1] < 4.5, (
+        "--fg-4 now meets AA for text, so this gate is guarding a rule that no "
+        "longer exists - decide what the ladder means before deleting it")
+    assert claimed["fg-3"][1] >= 4.5, (
+        "--fg-3 is where the words moved TO, and at %.1f:1 it does not meet AA "
+        "either" % claimed["fg-3"][1])
+
+    guilty = [sel.strip() for sel, decl in blocks()
+              if re.search(r"(^|[^-])color:\s*var\(--fg-4\)", decl)]
+    assert not guilty, (
+        "%d rule(s) paint text with the ink this page annotates as decorative: %s"
+        % (len(guilty), ", ".join(guilty)))
+
+
+def test_nothing_you_have_to_click_is_smaller_than_the_floor():
+    """⛔ 24 BY 24, AND THREE CONTROLS SAT AT 21, 22 AND 23. Close enough to
+    look deliberate and short enough to fail: the Live/Frozen tabs, the Clear
+    button, the layout icons - and the delete-a-conversation cross at 18, which
+    is the control where a near miss costs the most.
+
+    What this can see is a declared pixel size, not a computed one, so it is a
+    floor and not a proof. That is still the shape every one of those defects
+    had: a height typed into the rule.
+
+    Known-bad: put any of them back under 24.
+    """
+    small = []
+    for sel, decl in blocks():
+        if "cursor:pointer" not in decl and "button" not in sel:
+            continue
+        for prop, px in re.findall(r"(?:min-)?(height|width):\s*(\d+)px", decl):
+            if int(px) < 24:
+                small.append("%s %s:%spx" % (sel.strip(), prop, px))
+    assert not small, (
+        "%d control(s) declare less than the 24px WCAG 2.2 asks for: %s"
+        % (len(small), ", ".join(small)))

--- a/tests/test_the_stage_of_screens.py
+++ b/tests/test_the_stage_of_screens.py
@@ -57,6 +57,29 @@ def up(*ids):
     return [{"id": i, "running": True, "urls": ["http://x/"]} for i in ids]
 
 
+FIRST_CUT = "const CHROME ="
+LAST_CUT = "function ageAll(cells)"
+
+#: Four windows of different shapes in cells of different shapes, which is the
+#: case the fingerprint guarantees: every browser here gets a window of its own.
+CUT_PROBE = r"""
+const shots = [];
+for(const [w, h, bw, bh] of [[1280,800,600,400],[1024,768,600,400],
+                             [1440,900,300,260],[800,600,520,300]]){
+  const im = { naturalWidth:w, naturalHeight:h, style:{},
+               getBoundingClientRect: () => ({width:bw, height:bh}) };
+  cutTheChrome({dataset:{}}, im);
+  const cut = Number(/inset\((\d+)px/.exec(im.style.clipPath)[1]);
+  const move = Number(/translateY\((-?\d+)px/.exec(im.style.transform)[1]);
+  const drawn = Math.min(bh, bw * h / w);
+  const above = cut + move;
+  shots.push({w, h, bw, bh, cut, drawn: Math.round(drawn), above,
+              below: Math.round(bh - above - (drawn - cut))});
+}
+process.stdout.write(JSON.stringify(shots));
+"""
+
+
 pytestmark = pytest.mark.skipif(
     not NODE, reason="needs node to EXECUTE the stage chooser")
 
@@ -117,7 +140,8 @@ def test_the_layout_is_remembered_and_read_back_through_one_door():
     """
     code = re.sub(r"/\*.*?\*/", "", PAGE, flags=re.S)
     assert "localStorage.setItem(GRIDKEY" in code, "the layout is not remembered"
-    assert re.search(r"setGrid\(FPS\[Number\(sawGrid\)\] \? Number\(sawGrid\) : 1\)", code), (
+    assert re.search(r"setGrid\(LAYOUTS\.includes\(Number\(sawGrid\)\) \? Number\(sawGrid\) : 1\)",
+                     code), (
         "the saved layout is not restored through setGrid, or is trusted "
         "without checking it is one of the layouts on offer")
 
@@ -138,6 +162,76 @@ def test_a_screen_says_how_old_its_picture_is():
     assert re.search(r"el\('span','age'", code), "a screen has nowhere to say its age"
     assert re.search(r"\(now - at2\) > 2000", code), (
         "no threshold decides when a picture stops counting as current")
+
+
+def test_the_template_follows_the_screens_that_exist():
+    """⛔ A LAYOUT IS A CEILING, NOT A PROMISE. Two running browsers in a
+    four-up layout were laid on a 2x2 whose second row was empty, so each of
+    them drew at half the height for nothing: the person asked to watch up to
+    four and got two small pictures instead of two large ones.
+
+    Known-bad: write the chosen layout into the stage, which is what it did.
+    """
+    code = re.sub(r"/\*.*?\*/", "", PAGE, flags=re.S)
+    assert "box.dataset.grid = String(Math.min(grid, Math.max(1, show.length)))" in code, (
+        "the stage template is not solved from the screens actually drawn")
+    assert '#stage[data-grid="3"]' in PAGE, (
+        "three screens have no template, so a four-up layout with three "
+        "browsers running falls back on whichever rule happens to match")
+
+
+def test_a_picture_is_centred_in_its_screen_whatever_shape_its_window_is():
+    """⛔ EVERY BROWSER HERE HAS A WINDOW OF A DIFFERENT SHAPE, BY DESIGN. That
+    is the fingerprint doing its job rather than something to iron out, so on a
+    2x2 the pictures genuinely come out different heights: measured on four live
+    browsers, three cells drew 304px of image and one drew 237px. Anchored to
+    the top, that one read as a smaller screen with a hole underneath it - 29%
+    of the cell empty against 8% for its neighbours. The same leftover split
+    above and below reads as a frame instead.
+
+    Executed rather than read: it is arithmetic over the box and the picture,
+    and those two are the only things that decide it.
+
+    Known-bad, two: drop the lift and go back to top-anchored, or drop the cut
+    and let the browser's own tab strip back into the picture.
+    """
+    body = PAGE[PAGE.index(FIRST_CUT):PAGE.index(LAST_CUT)]
+    done = subprocess.run([NODE, "-e", body + CUT_PROBE], capture_output=True,
+                          text=True, encoding="utf-8", timeout=30)
+    assert done.returncode == 0, "the crop threw:\n%s" % done.stderr
+    for shot in json.loads(done.stdout):
+        assert abs(shot["above"] - shot["below"]) <= 1, (
+            "a %(w)dx%(h)d window in a %(bw)dx%(bh)d cell is drawn with %(above)d px "
+            "above it and %(below)d below" % shot)
+        assert 0.06 < shot["cut"] / shot["drawn"] < 0.11, (
+            "%(cut)d px comes off a drawing %(drawn)d tall, and the browser's own "
+            "chrome measured 8.3%% of the window" % shot)
+
+
+def test_the_state_word_says_nothing_when_it_would_repeat_the_tab():
+    """The Live/Frozen tabs are a control that shows its own state, and the word
+    beside them said `live` while Live was selected: one fact printed twice, the
+    second time in the place the eye goes for news. `idle`, `busy` and `error`
+    are news and still appear, and the dot goes on carrying live and frozen,
+    which is what a dot is for.
+
+    Known-bad: print every state, which is what it did.
+    """
+    code = re.sub(r"/\*.*?\*/", "", PAGE, flags=re.S)
+    assert "stateEl.hidden = (s === 'live' || s === 'frozen')" in code, (
+        "the state word is shown even when it only repeats the selected tab")
+
+
+def test_an_empty_stage_says_what_to_do_about_being_empty():
+    """There is no button that opens a browser - they are opened by asking, on
+    purpose - so the empty stage is the one place that has to say so. An empty
+    state that only reports the emptiness leaves the person hunting for a
+    control that was never going to be there.
+
+    Known-bad: go back to naming the condition and stopping.
+    """
+    assert "ask for one in the chat" in PAGE, (
+        "the empty stage no longer says how a browser gets opened")
 
 
 def test_the_pump_cannot_be_killed_by_a_bad_pass():

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -16,6 +16,8 @@ import asyncio
 import base64
 import json
 import re
+import shutil
+import subprocess
 
 import pytest
 
@@ -553,11 +555,13 @@ async def test_the_stage_asks_for_frames_at_a_rate_it_has_measured():
     picture. Both edges, and both numbers measured rather than chosen.
 
     ⛔ THE PACE IS NO LONGER ONE LITERAL, because the stage is no longer one
-    screen. It is a table of frames-a-second by how many screens are showing,
-    and the loop's pause is derived from it. The old gate read
-    `setTimeout(tick, 18)` and asserted on 18; that number does not exist any
-    more, so this reads the table instead - the same question asked of the
-    thing that now answers it.
+    screen. It is a rate per screen, decided by how many screens are drawn, and
+    the loop's pause is derived from it. The old gate read `setTimeout(tick,
+    18)` and asserted on 18; then it read a table of three entries. Both of
+    those are gone: what the page declares now is a function, so this gate runs
+    it - which is also the only way to ask what it answers for three screens, a
+    case a table of 1, 2 and 4 could not express and a four-up layout produces
+    the moment three browsers are running.
 
     ⛔ AND THE COST OF A FRAME WAS WRONG BY A FACTOR OF FOUR. This file said 22
     ms of pipe, and everything about the old design followed from it: one live
@@ -586,30 +590,59 @@ async def test_the_stage_asks_for_frames_at_a_rate_it_has_measured():
     assert len(re.findall(r"setTimeout\(tick,", code)) == 1, (
         "the pump is scheduled from more than one place, so its pace is no "
         "longer one number anybody can read")
-    table = re.search(r"const FPS = \{([^}]*)\}", code)
-    assert table, "the stage no longer declares its frames a second"
-    fps = {int(k): int(v) for k, v in re.findall(r"(\d+)\s*:\s*(\d+)", table.group(1))}
-    assert set(fps) == {1, 2, 4}, "the layouts on offer are %s" % sorted(fps)
+    # ⛔ AND THE RATE IS PACED ON THE STAGE, NOT ON THE BUTTON. A layout is a
+    # ceiling on how many screens you watch at once; how many there ARE is a
+    # different number, and pacing two browsers as though they were four gave
+    # them half the frames the measurement says they can have.
+    assert "fps(onScreen()) * onScreen()" in code, (
+        "the pause is no longer derived from the screens actually on the stage")
+
+    decl = re.search(r"const LAYOUTS = \[[^\]]*\];\s*"
+                     r"const TOPRATE = \d+, CEILING = \d+;\s*"
+                     r"const fps = \(n\) => .+", code)
+    assert decl, "the stage no longer declares the pace it keeps"
+
+    node = shutil.which("node")
+    if not node:  # pragma: no cover - every runner here has one
+        pytest.skip("needs node to EXECUTE the pace")
+
+    # ⛔ EXECUTED, NOT READ. The pace used to be a literal table a regex could
+    # check entry by entry. It is a function now, so the only honest way to ask
+    # what it answers for three screens is to run it - and three screens is a
+    # real case the table never had, because a four-up layout with three
+    # browsers running draws exactly three.
+    js = decl.group(0) + chr(10) + (
+        "process.stdout.write(JSON.stringify("
+        "[LAYOUTS, CEILING, [1,2,3,4].map(n => fps(n))]));")
+    done = subprocess.run([node, "-e", js], capture_output=True, text=True,
+                          encoding="utf-8", timeout=30)
+    assert done.returncode == 0, "the pace threw: %s" % done.stderr
+    layouts, ceiling, each = json.loads(done.stdout)
+
+    assert layouts == [1, 2, 4], "the layouts on offer are %s" % layouts
 
     from aihawk.mcp.session import StealthSession
 
-    assert fps[1] >= StealthSession.WATCH_FPS, (
+    assert each[0] >= StealthSession.WATCH_FPS, (
         "one screen is asked for %d frames a second while the engine is told to "
         "produce %d: the difference is made, held and thrown away, which is the "
         "defect this gate was written for"
-        % (fps[1], StealthSession.WATCH_FPS))
+        % (each[0], StealthSession.WATCH_FPS))
 
-    #: Measured 2026-09-09, four browsers, this pipe. The ceiling is the rate at
-    #: which the measurement showed an action still landing promptly: 80 frames
-    #: a second cost about half the pipe, so half of that is the budget spent.
-    A_FRAME_MS, CEILING = 6, 40
-    for screens, each in fps.items():
-        total = screens * each
-        assert total <= CEILING, (
-            "%d screens at %d frames a second each is %d requests a second, and "
-            "at about %d ms of pipe apiece that is %d%% of it - the agent's "
-            "clicks go down the same pipe"
-            % (screens, each, total, A_FRAME_MS, total * A_FRAME_MS / 10))
+    #: Measured 2026-09-09, four browsers, this pipe. 80 frames a second cost
+    #: about half of it, so a quarter of the pipe is the budget spent.
+    A_FRAME_MS, A_QUARTER_MS = 6, 250
+    assert ceiling * A_FRAME_MS <= A_QUARTER_MS, (
+        "the stage may ask for %d frames a second, which at about %d ms apiece "
+        "is %d ms of every second - the agent's clicks go down the same pipe"
+        % (ceiling, A_FRAME_MS, ceiling * A_FRAME_MS))
+    for screens, rate in enumerate(each, start=1):
+        assert rate >= 1, "%d screens are paced at %d frames a second" % (screens, rate)
+        assert screens * rate <= ceiling, (
+            "%d screens at %d frames a second each is %d requests a second, over "
+            "the %d the pipe was measured to have room for"
+            % (screens, rate, screens * rate, ceiling))
+
 async def test_the_answer_is_built_from_nodes_and_never_from_html():
     """The model's Markdown is drawn, and it is drawn without `innerHTML`.
 


### PR DESCRIPTION
An expert read of the interface, and the seven things it found. Four of them are arithmetic with a threshold, so they are gates now rather than opinions.

**Contrast.** `--fg-4` is annotated `decorative only` in the palette that declares it, and eleven rules used it as a text colour: the count beside a conversation, the address printed under a link, the timing on a step, a list marker, the dim halves of the URL, the placeholder inside a preview. They read between 2.2 and 2.7 to one where AA asks 4.5. The worst was the address, which is printed beside a link precisely so an injected one is legible - and it was the hardest text in the product to read. Every word moves to `--fg-3` at 4.8, and the two borders that say which screen you are watching move to `--fg-2`, because a graphic that carries meaning wants 3:1.

Checking the palette against itself turned up three of the four inks annotated with a ratio they no longer had, so the numbers in the comments are the measured ones now.

**Target size.** WCAG 2.2 puts the floor at 24px. The Live/Frozen tabs were 21, the Clear button 23, and the cross that deletes a conversation was 18 - close enough to look deliberate, short enough to fail, and the last of them is where a near miss costs the most.

**The top edge.** The conversation header was 50px and the browser chrome beside it 38, so the product broke along its main seam by twelve pixels. One token, both of them.

**The stage.** A layout is a ceiling on how many screens you watch at once, not a promise that there are that many: two running browsers in a four-up layout were laid on a 2x2 whose second row was empty, so each drew at half the height for nothing. The template follows the screens that exist, three of them included. The pace follows them too - it was reading the button - and it is a function of that number now rather than a table of three entries, which is also how three screens got a rate at all.

And a picture is centred in its screen. Every browser here has a window of a different shape because the fingerprint gives it one, so on a 2x2 the pictures come out different heights: three cells drew 304px of image and one drew 237px. Anchored to the top that one read as a smaller screen with a hole under it, 29% of the cell empty against 8% for its neighbours.

**Two smaller things.** The word beside the Live/Frozen tabs said `live` while Live was selected - one fact printed twice, the second time where the eye goes for news - so it now says nothing unless it has something to add. And the empty stage said nothing was running; there is no button that opens a browser, on purpose, so it is the one place that has to say they are opened by asking.

Sixteen known-bad mutations, sixteen killed, across three gates. The pace gate executes the formula now instead of reading a table, and the centring is executed over four window shapes in four cell shapes.

This also carries the three small things in the frame from 0.26.2, which was never published.
