### PR TITLE
Less chrome, a readable body, and a layout that holds at 320px (0.33.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.32.0"
+version = "0.33.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/agent.py
+++ b/src/aihawk/agent.py
@@ -181,8 +181,12 @@ class Conversation:
                 tools=self.tool_defs, tool_choice="auto", temperature=0,
                 max_tokens=self.max_tokens,
             )
+            # Counted, saved with the transcript, and not announced:
+            # the page drew it in a meter that is gone. The accounting
+            # stays, because it is what the conversation cost; the
+            # event went, because an event nobody draws is drawn as
+            # raw JSON at the end of the transcript.
             self._note_usage(resp)
-            await say("usage", json.dumps(self.usage))
             msg = resp.choices[0].message
             self.messages.append(msg.model_dump())
 

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -130,10 +130,29 @@ PAGE = r"""<!doctype html>
      accessibility guidance marks `font-size: 16px` "Don't" and `1rem` "Do" for
      exactly this. Same pixels at the default 16px root, so nothing moves for
      anybody who never changed it. */
-  --t-label:.6875rem; --t-mono:.8125rem; --t-ui:.8125rem; --t-body:.875rem;
-  /* Steps that read as steps: 17 and 15 sat a single pixel apart from the body
-     under them, so the hierarchy was carried by weight alone. */
-  --t-h1:1.125rem; --t-h2:1rem; --t-h3:.8125rem;       /* the answer's headings */
+  /* ⛔ ONE RATIO, AND THE STEPS ARE STEPS. Measured on the running page, the
+     left column drew NINE size/weight pairs at 11, 12, 13, 14 and 16px: four
+     sizes inside three pixels, which is a scale in name only. A step of 1.08
+     is not a step - the eye reads it as an accident - and the fix is not more
+     sizes but fewer, with weight and colour carrying the tiers that size no
+     longer does.
+
+     Three prose steps on ~1.2: 12 / 15 / 18. Body is 15 because this column
+     exists to be read and 14 is under the floor every source gives for reading
+     text. */
+  --t-label:.75rem;                            /* 12 - labels, meta, counts */
+  --t-body:.9375rem;                           /* 15 - prose, and the base */
+  --t-ui:.9375rem;                             /* 15 - chrome reads as prose */
+  /* ⛔ MONO IS OFF THIS SCALE BY DECISION, NOT BY OVERSIGHT. A mono face runs
+     wider and reads larger at the same pixel, so it does not belong on a scale
+     built for a proportional one - and the step track is MEASURED against it:
+     `LONG` is how many characters fit in 416px at this size, so moving it moves
+     a threshold that a gate checks. It is the data face, and it says so here. */
+  --t-mono:.8125rem;                           /* 13 - steps, code, addresses */
+  /* The answer's headings. One size above the body, then weight and colour:
+     three sizes a pixel apart carried nothing that 600 and a quieter ink do
+     not carry better. `--t-h1` is the off-screen page heading's size too. */
+  --t-h1:1.125rem; --t-h2:.9375rem; --t-h3:.9375rem;
 
   --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s5:20px; --s6:32px;
   --r-sm:4px; --r:8px; --r-lg:12px; --r-pill:999px;
@@ -258,8 +277,11 @@ code,pre,.g,.meta,.badge,#url{
    whole box with it, so the border and the accent below would be drawn on the
    edge away from the column instead of the one beside it - correct in the
    element's own coordinates and backwards on the screen. */
+/* On the label step like every other tracked uppercase word on the page: it
+   was the last size in this column that belonged to no scale. The tracking
+   stays wider than `.label` because the letters are stacked, not set. */
 #railtab span{ writing-mode:vertical-rl; transform:rotate(180deg);
-               font:600 .875rem/1 var(--sans); letter-spacing:.2em;
+               font:600 var(--t-label)/1 var(--sans); letter-spacing:.2em;
                text-transform:uppercase }
 #railtab:hover{ background:var(--raised); color:var(--fg) }
 /* Open: the spine lifts a rung and the word goes to full ink. The state is
@@ -440,7 +462,7 @@ code,pre,.g,.meta,.badge,#url{
 #hint .eg{ font:var(--t-mono)/1.9 var(--mono); color:var(--fg-2);
            background:var(--raised); border:1px solid var(--line-1);
            border-radius:var(--r); padding:var(--s3) var(--s4); text-align:left }
-#hint .sm{ font-size:.75rem; color:var(--fg-3) }
+#hint .sm{ font-size:var(--t-label); color:var(--fg-3) }
 
 #jump{ position:absolute; bottom:100%; margin-bottom:var(--s2);
        left:50%; transform:translateX(-50%); z-index:2;
@@ -495,8 +517,8 @@ h3.md-h, h4.md-h, h5.md-h, h6.md-h{
    heading and not as a bold line: at 14px it was the size of the body text
    under it, which is a hierarchy only the weight was carrying. */
 h3.md-h{ font-size:var(--t-h1) }
-h4.md-h{ font-size:var(--t-h2) }
-h5.md-h, h6.md-h{ font-size:var(--t-h3); color:var(--fg-2) }
+h4.md-h{ font-size:var(--t-h2); font-weight:600 }
+h5.md-h, h6.md-h{ font-size:var(--t-h3); font-weight:600; color:var(--fg-2) }
 /* A fenced block inside an answer is already inside the answer's indent, and
    `.out` carries its own for the tool output it was written for: the two
    stacked, so code sat a step to the right of the prose describing it. */
@@ -691,7 +713,7 @@ form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
    made this bar look assembled rather than designed. */
 #url{ flex:1; min-width:0; height:var(--h-ctl); line-height:calc(var(--h-ctl) - 2px);
       padding:0 var(--s3); border-radius:var(--r); background:var(--well);
-      border:1px solid var(--line-1); font-size:.75rem;
+      border:1px solid var(--line-1); font-size:var(--t-mono);
       white-space:nowrap; overflow:hidden; text-overflow:ellipsis }
 /* ⛔ BOTH FORMS, BECAUSE THE INTENT LIVED IN TWO PLACES AND MATCHED IN
    NEITHER. The script sets `dim` on the address bar ITSELF when there is no

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -149,13 +149,13 @@ PAGE = r"""<!doctype html>
 body{ margin:0; height:100vh; display:flex; position:relative;
       background:var(--base); color:var(--fg);
       font:var(--t-body)/1.55 var(--sans); }
-code,pre,.g,.meta,.badge,#url,#tok{
+code,pre,.g,.meta,.badge,#url{
   font-family:var(--mono);
   /* Not cosmetic: a step reads `#email <- ada@example.com`, and a mono face with
      contextual alternates draws `<-` as one arrow. The text on screen would stop
      being the text the model emitted. */
   font-variant-ligatures:none; }
-.meta,.g,#tok{ font-variant-numeric:tabular-nums }
+.meta,.g{ font-variant-numeric:tabular-nums }
 /* ⛔ `--fg-4` IS DECLARED DECORATIVE AT 2.4:1 AND THIS CLASS PUT WORDS ON IT.
    Measured on the running page: the state beside the browser read at 2.23:1,
    the meter at 2.71, the placeholder inside a screen at 2.51, the layout icons
@@ -362,6 +362,15 @@ code,pre,.g,.meta,.badge,#url,#tok{
         border-bottom:1px solid var(--line-1) }
 #head .vr{ width:1px; height:18px; flex:none; background:var(--line-2);
            margin:0 var(--s1) }
+/* ⛔ THE GROUP STAYS ON THE RIGHT, AND THE THING THAT KEPT IT THERE WAS THE
+   METER. `margin-left:auto` lived on the meter, so removing it dropped the
+   model and Clear against the left edge, under the transcript's own margin and
+   nowhere near the edge they had always sat on. The push belongs to the first
+   of whatever survives, not to whichever element happened to be there. */
+#head #model{ margin-left:auto }
+/* The heading is out of flow (`.sr` is absolute), so it is not one of the
+   things being pushed, and this rule only describes the size it is announced
+   at rather than drawn at. */
 #head h1{ margin:0; font-size:var(--t-ui); font-weight:600 }
 .badge{ font-size:var(--t-label); color:var(--fg-2);
         background:var(--raised); border:1px solid var(--line-2);
@@ -634,8 +643,6 @@ form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
        background:var(--hover); border:1px solid var(--line-2); color:var(--fg-2);
        font-size:var(--t-label); padding:3px 9px; border-radius:var(--r-pill);
        cursor:pointer }
-#tok{ margin-left:auto; display:inline-flex; align-items:center; gap:6px;
-      font-size:var(--t-label); color:var(--fg-3) }
 
 /* ---------------- browser pane ---------------- */
 /* The strip only exists when there is more than one tab: a single tab labelled
@@ -960,17 +967,15 @@ form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
 <!-- Two landmarks, so somebody moving by region can go straight to the
      conversation or to the browsers instead of walking the whole page. -->
 <main id="left" aria-label="Conversation">
-  <!-- The meter lives up here with the other things that describe the
-       conversation rather than under the box you type in. What is under the box
-       should be the box: a number that grows all session long, sitting between
-       the composer and the edge of the window, is the one place a person looks
-       twenty times an hour for something else. -->
   <div id="head">
-    <!-- ⛔ A HEADING AND NOT A BOLD WORD. The page had no h1 at all, so the
-         answers' own headings - which start at h3 on the reasoning that the
-         product's name sits above them - hung under nothing. -->
-    <h1>AIHawk</h1>
-    <span id="tok" hidden></span>
+    <!-- ⛔ THE HEADING IS OFF-SCREEN, NOT ABSENT, AND IT IS LOAD-BEARING WHERE
+         IT CANNOT BE SEEN. The answers' own headings start at h3 on the
+         reasoning that the product's name sits above them, so deleting this
+         leaves every one of them hanging under nothing and the document with no
+         outline at all. It reads as dead markup and it is not: a gate holds it
+         here. What was removed is the NAME ON THE SCREEN, which said the same
+         thing as the tab, the window and the address bar. -->
+    <h1 class="sr">AIHawk</h1>
     <span class="badge" id="model">no model</span>
     <span class="vr" aria-hidden="true"></span>
     <button id="fresh" type="button" title="Clear this conversation">Clear</button></div>
@@ -1463,7 +1468,6 @@ const onEvent = (e) => {
   const m = JSON.parse(e.data), r = m.replay;
   switch(m.kind){
     case 'model': $('model').textContent = m.text; break;
-    case 'usage': meter(m.text); break;
     /* Sent to every listener, so a second tab clears too instead of showing a
        transcript the server has already forgotten. */
     case 'fresh': wipe(); break;
@@ -1586,7 +1590,6 @@ function wipe(){
   thread.textContent = '';
   turn = null; live = null; hold = null; n = 0;
   clearInterval(timer);
-  $('tok').hidden = true;
   /* Idle until told otherwise. On a reconnection the server sends this wipe
      first and the run state after it, so a page that reconnects to a RESTARTED
      process stops believing in a run that died with the old one - which
@@ -1675,15 +1678,6 @@ f.onsubmit = (e) => {
   send(t); paint();
 };
 
-/* The meter reads the LAST turn's prompt, never a sum: every turn is sent the
-   whole transcript, so the newest prompt IS the current occupancy. */
-function meter(json){
-  let u; try { u = JSON.parse(json); } catch(err) { return; }
-  const k = v => v >= 1000 ? (v/1000).toFixed(1) + 'k' : String(v);
-  $('tok').hidden = false;
-  $('tok').textContent = k(u.last_prompt || 0) + ' ctx  /  ' +
-                         k((u.prompt || 0) + (u.completion || 0)) + ' total';
-}
 
 /* ---- the browser pane ---- */
 const right = $('right'), stateEl = $('state'), urlEl = $('url');
@@ -2591,10 +2585,10 @@ class ChatService:
 
     async def emit(self, kind: str, text: str) -> None:
         event = {"kind": kind, "text": text}
-        # `busy` and `usage` are STATE, not conversation: replaying them to
-        # somebody who opens the page later would show a spinner for work that
-        # finished an hour ago, and a meter for a turn nobody is watching.
-        if kind not in ("busy", "usage"):
+        # `busy` is STATE, not conversation: replaying it to somebody who
+        # opens the page later would show a spinner for work that finished
+        # an hour ago.
+        if kind != "busy":
             self.history.append(event)
         for q in list(self._listeners):
             q.put_nowait(event)
@@ -2635,10 +2629,13 @@ class ChatService:
 
     @property
     def usage(self) -> dict:
-        """What the meter would show right now, for a listener joining late.
+        """What this conversation has cost, for the file it is saved into.
 
         Read through the brain rather than kept here: the brain owns the
-        transcript, so it owns what the transcript has cost.
+        transcript, so it owns what the transcript has cost. It is no longer
+        sent anywhere - the meter that drew it is gone - but it is still counted
+        and still saved, so putting a number back on the screen is a question of
+        where to draw it and not of measuring it again.
         """
         got = getattr(self._brain, "usage", None)
         return dict(got) if isinstance(got, dict) else {}
@@ -2965,7 +2962,6 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
         # Taken with the snapshot, for the same reason: whether a run is in
         # flight is part of the state this listener is joining.
         joining_a_run = service.busy
-        current_usage = service.usage
 
         # ⛔ WHERE THIS LISTENER GOT TO, AND WHETHER IT IS EVEN THE SAME
         # CONVERSATION. `EventSource` reconnects by itself after any drop, and
@@ -3039,20 +3035,13 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
                 else:
                     yield b"data: " + json.dumps(
                         {"kind": "busy", "text": "0", "replay": True}).encode() + b"\n\n"
-                # The meter is state too, and it was silent for exactly the
-                # same reason: a page joining after a turn ended showed no
-                # context size at all, on the one screen whose whole job is to
-                # say how big the transcript has become.
-                if current_usage.get("calls"):
-                    yield b"data: " + json.dumps(
-                        {"kind": "usage", "text": json.dumps(current_usage)}).encode() + b"\n\n"
                 while True:
                     event = await q.get()
                     # Only what the history keeps is numbered: an id moves the
-                    # resume point, and `busy` or `usage` are not places to
-                    # resume from. Leaving the field out keeps the last one,
+                    # resume point, and `busy` is not a place to resume from.
+                    # Leaving the field out keeps the last one,
                     # which is what the spec says and what is wanted here.
-                    if event["kind"] in ("busy", "usage", "fresh"):
+                    if event["kind"] in ("busy", "fresh"):
                         yield b"data: " + json.dumps(event).encode() + b"\n\n"
                     else:
                         yield (b"id: " + ("%s:%d" % (service.epoch,

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -376,6 +376,32 @@ code,pre,.g,.meta,.badge,#url{
 #split:focus-visible{ outline:none }
 #split:focus-visible::after, #split[data-drag]::after{ background:var(--accent); width:2px }
 #right{ flex:1; min-width:0; display:flex; flex-direction:column; background:var(--well) }
+/* ⛔ UNDER 720px THE TWO PANES STOP BEING SIDE BY SIDE, or the right one is
+   allotted nothing and its bar spills out of the window. Measured in a frame
+   320px wide, which is what WCAG 1.4.10 asks a layout to survive: the document
+   scrolled sideways to 482px, the conversation was squeezed to 270 and the
+   browser pane was FOUR HUNDRED AND EIGHTY-TWO minus everything, which is to
+   say zero, with the Live/Frozen pair and the layout picker drawn past the
+   edge of the screen.
+
+   Stacked, both halves keep a full width and the page scrolls in one direction
+   only. The spine stays where it is - it belongs to the frame, and that was
+   decided - so it keeps the conversation company on the first row.
+
+   ⛔ AND THE MEASUREMENT NEEDED A REAL VIEWPORT. The `zoom` property scales
+   what is drawn and does NOT move the CSS viewport, so media queries do not
+   fire under it: a first pass "at 400%" reported a failure that was an artefact
+   of the instrument. An iframe of a fixed width has a viewport of its own, and
+   that is what these numbers come from. */
+@media (max-width:720px){
+  body{ flex-wrap:wrap }
+  /* `min-width:0` or the pane refuses to go under its content's own minimum,
+     the flex line overflows, and the pane wraps to a row of its own - leaving
+     the spine alone above it as a 93px stub with the word clipped inside. */
+  #left{ width:calc(100% - var(--spine)); min-width:0; height:60vh }
+  #split{ display:none }
+  #right{ flex:1 0 100%; height:40vh }
+}
 /* Three groups and not four things in a row: the name, then what this
    conversation is costing and running, then the one thing you can do to it.
    The rule that separates the last is the same hairline the panes use. */
@@ -692,8 +718,19 @@ form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
    50, so the top edge of the product broke by twelve pixels on its main
    seam - the one place a misalignment is read as the whole thing being
    loose rather than as one box being wrong. */
-#chrome{ flex:none; height:var(--topbar); display:flex; align-items:center;
-         gap:var(--s2); padding:0 var(--s3); background:var(--raised);
+/* ⛔ IT WRAPS, AND THE HEIGHT IS A FLOOR RATHER THAN A CEILING. Measured at
+   400% zoom, which WCAG 1.4.10 asks a layout to survive and which is the same
+   thing as a 320px window: this bar was the only place on the page that pushed
+   the document sideways. The address can shrink to nothing, but the Live/Frozen
+   pair and the layout picker cannot, so three fixed-width groups in a row on a
+   fixed 50px line had nowhere to go and went past the edge. A `height` would
+   then have clipped the second row, so it is a `min-height`: the bar is one
+   line whenever one line fits, and it is the bar's own business when it does
+   not. Found by the reflow check and not by looking - at 100% there is room,
+   so nothing shows. */
+#chrome{ flex:none; min-height:var(--topbar); display:flex; align-items:center;
+         flex-wrap:wrap; row-gap:var(--s1);
+         gap:var(--s2); padding:var(--s1) var(--s3); background:var(--raised);
          border-bottom:1px solid var(--line-1) }
 /* The honesty contract: nothing in here is interactive except what is, so
    nothing in here gets a pointer cursor except what does. */

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -143,7 +143,11 @@ class ScriptedModel:
     silently measures the end. That was observed here before the copy was added.
     """
 
-    def __init__(self, replies, *, repeat_last: bool = False):
+    def __init__(self, replies, *, repeat_last: bool = False, usage=None):
+        # The response carries the token counts, not the client: the loop
+        # reads `resp.usage`, so a stand-in that keeps them anywhere else
+        # lets the accounting look untested while it is untouched.
+        self.usage = usage
         self.replies = list(replies)
         self.repeat_last = repeat_last
         self.requests: list[dict] = []
@@ -162,6 +166,7 @@ class ScriptedModel:
         msg = self.replies[i]
         return ChatCompletion(
             id="chatcmpl-test",
+            usage=self.usage,
             created=0,
             model=kwargs.get("model", "stub"),
             object="chat.completion",
@@ -968,6 +973,42 @@ async def test_two_calls_to_the_same_tool_keep_distinct_ids_and_results():
     assert [m["tool_call_id"] for m in results] == ["c1", "c2"]
     assert [m["content"] for m in results] == ["read #1", "read #2"]
 
+
+async def test_the_turn_is_counted_even_though_nothing_announces_it():
+    """⛔ THE MEASURING OUTLIVED THE METER, AND THAT IS THE RISKY HALF. The
+    page drew these numbers in a header meter and no longer does, so the `usage`
+    EVENT went with it. The counting stayed, because it is what the transcript
+    is saved with and what any number put back anywhere would read - and an
+    accounting nobody watches is exactly the kind that stops working with
+    nothing going red.
+
+    Known-bad, two: drop `_note_usage` along with the event it used to feed,
+    and put the announcement back.
+    """
+    from openai.types import CompletionUsage
+
+    mcp = ScriptedMCP(tools=tools_result(tool("browser_navigate")))
+    model = ScriptedModel([assistant_answer("done")],
+                          usage=CompletionUsage(prompt_tokens=120,
+                                               completion_tokens=8,
+                                               total_tokens=128))
+    said = []
+
+    async def watch(kind, text):
+        said.append((kind, text))
+
+    convo = Conversation(model, "m")
+    await convo.run("open it", mcp.call_tool,
+                    (await mcp.list_tools()).tools, say=watch)
+
+    assert convo.usage["calls"] == 1, (
+        "the turn was not counted: %r" % convo.usage)
+    assert convo.usage["prompt"] == 120 and convo.usage["completion"] == 8
+    assert convo.usage["last_prompt"] == 120, (
+        "the last turn's prompt is what occupancy is read from")
+    assert "usage" not in [k for k, _ in said], (
+        "the numbers are announced again, and nothing on the page draws them - "
+        "an event with no case is written into the transcript as raw JSON")
 
 def test_the_answer_is_asked_for_the_way_a_person_would_write_it():
     """⛔ THE WRITING COMES FROM THE MODEL, SO THE FIX IS THE PROMPT. A renderer

--- a/tests/test_the_page_meets_the_craft_floor.py
+++ b/tests/test_the_page_meets_the_craft_floor.py
@@ -118,16 +118,49 @@ def test_the_surfaces_the_browser_would_have_picked_are_picked_here():
 
 
 def test_the_type_scale_has_steps_a_reader_can_see():
-    """Two heading sizes a single pixel apart are one size with two names: the
-    hierarchy then rests on weight alone, which is one signal doing two jobs.
+    """⛔ EITHER THE SAME SIZE OR A REAL STEP, NEVER A HAIR APART. Measured on
+    the running page, this column drew NINE size/weight pairs at 11, 12, 13, 14
+    and 16px - four sizes inside three pixels. A 1.08 step is not read as a
+    step, it is read as an accident, and a scale that fine is a scale in name
+    only.
 
-    Known-bad: move the two headings back within a pixel of each other.
+    So two levels may share a size, and then weight or colour separates them,
+    which is the stronger signal anyway. What is forbidden is the middle: one or
+    two pixels, carrying nothing and costing a step.
+
+    This gate used to demand every pair be at least 1.9px apart, which forbade
+    the sharing as well as the hair. That was the wrong half to forbid.
+
+    Known-bad, three: put two levels one pixel apart; drop the body under the
+    reading floor; give two levels the same size AND the same weight.
     """
-    got = {name: float(v) for name, v in
-           re.findall(r"--t-(h1|h2|h3|body):([\d.]+)rem", CODE)}
-    assert {"h1", "h2", "body"} <= set(got), "the type scale lost a role: %s" % got
-    for big, small in (("h1", "h2"), ("h2", "body")):
-        step = (got[big] - got[small]) * 16
-        assert step >= 1.9, (
-            "%s and %s are %.1fpx apart, which is not a step anybody sees"
-            % (big, small, step))
+    got = {name: float(v) * 16 for name, v in
+           re.findall(r"--t-(h1|h2|h3|body|label):([\d.]+)rem", CODE)}
+    assert {"h1", "h2", "body", "label"} <= set(got), (
+        "the type scale lost a role: %s" % got)
+
+    assert got["body"] >= 15, (
+        "the body is %.0fpx on a column that exists to be read, and every "
+        "source puts the floor at 15" % got["body"])
+
+    for big, small in (("h1", "h2"), ("h2", "body"), ("body", "label")):
+        step = got[big] - got[small]
+        assert step == 0 or step >= 2, (
+            "%s and %s are %.1fpx apart: too far to be one level, too close to "
+            "read as two" % (big, small, step))
+
+    # One ratio: the distinct sizes, in order, step by a consistent amount.
+    sizes = sorted(set(got.values()))
+    for a, b in zip(sizes, sizes[1:]):
+        assert 1.15 <= b / a <= 1.35, (
+            "%.0f to %.0f is a ratio of %.2f, off the scale this page declares "
+            "(~1.2)" % (a, b, b / a))
+
+    # A level that shares a size has to say what carries it instead.
+    for role in ("h2", "h3"):
+        if got.get(role) == got["body"]:
+            rule = re.search(r"h[45]\.md-h[^{]*\{([^}]*)\}", CODE) if role == "h3" \
+                else re.search(r"h4\.md-h\{([^}]*)\}", CODE)
+            assert rule and ("font-weight" in rule.group(1)
+                             or "color" in rule.group(1)), (
+                "%s is the body's size and nothing else separates it" % role)

--- a/tests/test_the_page_meets_the_craft_floor.py
+++ b/tests/test_the_page_meets_the_craft_floor.py
@@ -20,6 +20,10 @@ from aihawk.web import PAGE
 #: comment explaining why something is not done must not read as doing it.
 CODE = re.sub(r"/\*.*?\*/", "", PAGE, flags=re.S)
 
+#: The stylesheet alone. A brace count over the whole page would count
+#: every block in the script too, and answer about the wrong thing.
+CSS = PAGE[PAGE.index("<style>"):PAGE.index("</style>")]
+
 
 def test_no_glyph_stands_in_for_an_icon():
     """⛔ AN ICON IS DRAWN. A pencil, an arrow or an emoji borrowed from the text
@@ -116,6 +120,52 @@ def test_the_surfaces_the_browser_would_have_picked_are_picked_here():
         "%d rules turn the focus ring off; the splitter is the only element "
         "that draws its own" % len(off))
 
+
+def test_the_stylesheet_closes_everything_it_opens():
+    """⛔ A MISSING BRACE DOES NOT FAIL, IT SWALLOWS. An `@media` block left
+    unclosed while being moved took every rule after it inside itself, so the
+    whole page above the breakpoint quietly lost its header height, its browser
+    bar and its composer width - and nothing went red, because a stylesheet
+    with an unbalanced brace is still one the browser parses. It was found by
+    measuring a layout whose numbers made no sense.
+
+    Counting is the whole check, and it is enough.
+
+    Known-bad: drop any closing brace.
+    """
+    css = re.sub(r"/\*.*?\*/", "", CSS, flags=re.S)
+    opened, closed = css.count("{"), css.count("}")
+    assert opened == closed, (
+        "the stylesheet opens %d blocks and closes %d, so everything after "
+        "the unclosed one is inside it" % (opened, closed))
+
+
+def test_the_narrow_layout_comes_after_the_layout_it_overrides():
+    """⛔ SAME SPECIFICITY, SO SOURCE ORDER DECIDES, and the first version of
+    this rule sat ABOVE the rules it meant to override: it changed nothing, and
+    measured as though the breakpoint did not exist.
+
+    Under 720px the two panes stack, because side by side the right one is
+    allotted nothing and its bar is drawn past the edge of the window. Measured
+    in a frame 320px wide, which is what WCAG 1.4.10 asks a layout to survive:
+    the document scrolled sideways to 482px before this rule and not at all
+    after it, at every width from 320 to 1400.
+
+    Known-bad, three: move the block above `#right`, drop the wrap, drop the
+    hidden splitter.
+    """
+    narrow = CSS.find("@media (max-width:720px)")
+    assert narrow > 0, "nothing stacks the panes when they no longer fit"
+    base = CSS.find("#right{ flex:1; min-width:0")
+    assert base > 0, "the base rule for the browser pane is gone"
+    assert narrow > base, (
+        "the narrow layout is declared before the layout it overrides, so at "
+        "equal specificity the base rule wins and the breakpoint does nothing")
+    block = CSS[narrow:CSS.index("}", CSS.index("#right{ flex:1 0 100%", narrow))]
+    for needed in ("flex-wrap:wrap", "#split{ display:none }"):
+        assert needed in block, (
+            "the stacked layout is missing %r, without which the panes do not "
+            "stack at all" % needed)
 
 def test_the_type_scale_has_steps_a_reader_can_see():
     """⛔ EITHER THE SAME SIZE OR A REAL STEP, NEVER A HAIR APART. Measured on

--- a/tests/test_the_page_tells_the_truth.py
+++ b/tests/test_the_page_tells_the_truth.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import re
 
+from pathlib import Path
+
 from aihawk.web import PAGE
 
 #: ⛔ BOTH COMMENT SYNTAXES. This page explains its own rules in prose
@@ -50,6 +52,74 @@ def test_a_refused_delete_is_not_drawn_as_a_delete():
     body = body[:body.index("\n}")]
     assert "forgotten" in body, "the answer to the delete is never read"
     assert "orphan(" in body, "a refused delete says nothing to the person who asked"
+
+
+def test_every_event_the_server_can_send_is_drawn():
+    """⛔ AN EVENT WITH NO CASE IS DRAWN AS RAW JSON, and the suite cannot see
+    it. The page ends its switch with a `default` that appends the text to the
+    transcript, which is right for a kind added on the server before the page
+    learns it - a row of prose beats silence. It is wrong for a kind the page
+    used to draw and stopped: removing the meter left `usage` falling through,
+    and the transcript ended with
+    `{"prompt": 2341240, "completion": 19714, "calls": 75, ...}` under the last
+    answer. 528 tests were green. It was found by opening the page.
+
+    So the two sides are compared here instead: whatever the server can emit,
+    the page names.
+
+    Known-bad: emit a kind the page does not name, or drop a case for one it
+    does.
+    """
+    web = (Path(__file__).resolve().parents[1]
+           / "src" / "aihawk" / "web.py").read_bytes().decode("utf-8")
+    loop = (Path(__file__).resolve().parents[1]
+            / "src" / "aihawk" / "agent.py").read_bytes().decode("utf-8")
+    # Comments stripped from both sides, because this project has recorded the
+    # gate-accused-by-a-comment defect more times than any other.
+    server = re.sub(r"#[^\n]*", "", web + loop)
+    sends = set(re.findall(r"(?:emit|say)\(\s*\"([a-z]+)\"", server))
+    sends |= set(re.findall(r'"kind":\s*"([a-z]+)"', server))
+    sends -= {"kind"}
+    drawn = set(re.findall(r"case '([a-z]+)':", CODE))
+    assert sends, "found no event kinds at all, so this gate is not looking"
+    missing = sorted(sends - drawn)
+    assert not missing, (
+        "the server can send %s and the page names none of them, so each one "
+        "lands in the transcript as raw JSON" % missing)
+
+
+def test_the_heading_survives_being_invisible():
+    """⛔ IT READS AS DEAD MARKUP AND IT IS LOAD-BEARING. The product's name was
+    taken off the screen because it said what the tab, the window and the
+    address bar already said. The heading stayed, because the answers' own
+    headings start at h3 on the reasoning that a name sits above them: delete it
+    and every one of them hangs under nothing and the document has no outline at
+    all. An h1 nobody can see is the single most deletable-looking line on this
+    page, so it is held here.
+
+    And it is hidden the ONE way that keeps it: `display:none` and
+    `visibility:hidden` take an element out of the accessibility tree as well as
+    off the screen, which would delete it in the only sense that still mattered.
+    Same family as `pointer-events` versus `inert` elsewhere in this file - the
+    property that hides has to be the one that hides only what was meant.
+
+    Known-bad: drop the class and it is visible again; drop the heading and the
+    outline goes; hide it with `display:none` and it is gone for a reader.
+    """
+    assert re.search(r'<h1[^>]*>', CODE), (
+        "the page has no heading, so every answer's own headings hang under "
+        "nothing")
+    assert re.search(r'<h1 class="sr">', CODE), (
+        "the heading is either back on the screen or hidden by some other means")
+    assert "h3.md-h" in CODE, (
+        "the answers no longer start at h3, so the reason this heading has to "
+        "exist may have changed - check before touching it")
+    rule = re.search(r"\.sr\{([^}]*)\}", CODE)
+    assert rule, "the class that hides the heading is gone"
+    for kills in ("display:none", "visibility:hidden"):
+        assert kills not in rule.group(1).replace(" ", ""), (
+            "`.sr` uses %r, which takes the heading out of the accessibility "
+            "tree too: %r" % (kills, rule.group(1)))
 
 
 def test_the_transcript_is_announced_and_not_only_drawn():

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -115,17 +115,19 @@ async def test_a_turn_brackets_itself_with_busy():
 
 
 async def test_state_is_not_transcript():
-    """`busy` and `usage` must NOT be replayed to somebody who opens the page an
-    hour later: a spinner for work that finished, and a meter for a turn nobody
-    is watching. Everything else is the conversation and is kept.
+    """`busy` must NOT be replayed to somebody who opens the page an hour later:
+    a spinner for work that finished. Everything else is the conversation and is
+    kept.
+
+    It said `busy` and `usage`, and the second one is gone with the meter that
+    drew it: the numbers are still counted and still saved with the transcript,
+    they are simply not an event any more.
     """
     svc = ChatService(FakeLink(), TalkingBrain())
     await svc.send("go")
-    await svc.emit("usage", json.dumps({"last_prompt": 10}))
 
     kinds = [e["kind"] for e in svc.history]
     assert "busy" not in kinds
-    assert "usage" not in kinds
     assert kinds == ["you", "said", "tool", "result"]
 
 


### PR DESCRIPTION
Three passes over the conversation column, each one measured on the running page rather than argued about.

**The header says the model and nothing else.** The product's name came off the screen, because it said what the tab, the window and the address bar already said. The token meter went with it: a number that grows all session long does not belong in the corner of a screen nobody opens to read accounting. The counting stays, saved with the transcript, so putting a number back anywhere later is a question of where to draw it rather than of measuring it again.

The heading did not go with the name. It is off-screen now and load-bearing where it cannot be seen: the answers' own headings start at h3 on the reasoning that a name sits above them. An h1 nobody can see is the most deletable-looking line on the page, so a gate holds it there, and holds the way it is hidden, because `display:none` would take it out of the accessibility tree as well.

Removing the case for an event the server still sent put a line of raw JSON at the end of the transcript, under the last answer. 528 tests were green; it was found by opening the page. The two sides are compared now: whatever the server can emit, the page names.

**Three type sizes where there were five.** The column drew nine size/weight pairs at 11, 12, 13, 14 and 16px - four sizes inside three pixels. A step of 1.08 is not read as a step. It is 12 / 15 / 18 on one ratio now, and the levels that sat a pixel apart share a size and are separated by weight and colour. The body went from 14 to 15, which is the floor every source puts on reading text; the measure is unchanged at 71 characters. Monospace stays at 13 and says why: the step track is measured against it, so moving it moves a threshold a gate checks.

**The panes stack before the window runs out of room.** Measured in a frame 320px wide: the document scrolled sideways to 482px, the conversation was squeezed to 270 and the browser pane was allotted nothing, with its bar drawn past the edge. Under 720px the two panes stack, and there is no sideways scroll at any width from 320 to 1400.

Two things about how that one was found. The first measurement was wrong: the `zoom` property scales what is drawn and does not move the CSS viewport, so no media query fires under it. And moving the rule to where it would actually win left its closing brace behind - an `@media` block missing one does not fail, it swallows every rule after it, and the whole page above the breakpoint quietly lost its header height with nothing going red. Both now have a gate; one of them just counts braces.

Eleven known-bad mutations across the new gates, all killed. 533 tests pass.
