### PR TITLE
An icon on the rail, a pane that is the measure, and every size from a guideline (0.34.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.33.0"
+version = "0.34.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -233,9 +233,7 @@ code,pre,.g,.meta,.badge,#url{
    Anchored to the spine's own width so the two are one object, and lifted with
    a shadow rather than a border, because what says "this is over that" is the
    shadow. */
-/* Under the bar, like the rail that opens it: the band across the top is not
-   something a drawer may cover. */
-#rail { position:absolute; top:var(--topbar); bottom:0; left:0; width:var(--drawer);
+#rail { position:absolute; top:0; bottom:0; left:0; width:var(--drawer);
         z-index:5; display:flex; flex-direction:column;
         background:var(--well); border-right:1px solid var(--line-1);
         box-shadow:14px 0 34px -18px #000 }
@@ -272,17 +270,13 @@ code,pre,.g,.meta,.badge,#url{
    The icon sits at the TOP and not in the middle. That is where a rail's first
    control goes in every product that has one, and it leaves the strip able to
    grow a second icon without anything being re-thought. */
-/* ⛔ THE BAR RUNS THE WHOLE WIDTH AND THE RAIL HANGS UNDER IT. From the
-   owner's drawing: the horizontal band is the top of the room, unbroken from
-   edge to edge, and the vertical strip starts below it - so the rail cannot
-   be a column in the same row as the panes, or it would cut the band in two
-   at the left and the header would start 48px in.
-
-   Out of the flow, then, and the conversation carries the width it used to
-   take as a margin. Same pixels, different owner. */
-#railtab{ position:absolute; top:var(--topbar); left:0; bottom:0; z-index:4;
-          width:var(--spine); padding:11px 0 0; cursor:pointer; border:0;
-          background:var(--base); color:var(--fg-3);
+/* ⛔ THE RAIL IS THE FULL HEIGHT OF THE WINDOW AND STARTS AT THE TOP, so the
+   icon sits in the corner ABOVE the header's line rather than under it. Tried
+   the other way round for one commit - band across the whole width, rail
+   hanging below - and the owner asked for this one back. It is also the older
+   of the two: the strip belongs to the room, not to the pane beside it. */
+#railtab{ flex:none; width:var(--spine); padding:11px 0 0; cursor:pointer; border:0;
+          position:relative; background:var(--base); color:var(--fg-3);
 
           /* Half the weight it was: a hairline that says where the room ends
              rather than a rule that draws attention to itself. */
@@ -321,8 +315,7 @@ code,pre,.g,.meta,.badge,#url{
    where it belonged, 48 by 56 at the top-left corner, and invisible. The
    ladder this page uses is 2 for the jump button, 5 for the panel, 6 above it,
    20 for the skip link. */
-#railtab[aria-expanded="true"]{ position:absolute; top:var(--topbar); left:0;
-                                z-index:6; bottom:auto;
+#railtab[aria-expanded="true"]{ position:absolute; top:0; left:0; z-index:6;
                                 width:var(--spine); height:var(--topbar);
                                 padding:0; display:grid; place-items:center;
                                 background:transparent; box-shadow:none;
@@ -493,7 +486,7 @@ code,pre,.g,.meta,.badge,#url{
 [inert]{ opacity:.3 }
 
 #log{ flex:1; overflow:auto; scrollbar-gutter:stable;
-      padding:var(--s5) var(--s4) var(--s5) calc(var(--s4) + var(--spine));
+      padding:var(--s5) var(--s4);
       transition:padding-left 180ms cubic-bezier(.23,1,.32,1) }
 /* ⛔ IT PUSHES, IT DOES NOT COVER. An overlay drawer is the phone pattern;
    on a desktop the standard one moves the content over, and covering it here
@@ -502,7 +495,7 @@ code,pre,.g,.meta,.badge,#url{
    above the drawer, which is what the drawing asked for. */
 #rail:not([hidden]) ~ #left #log,
 #rail:not([hidden]) ~ #left form{
-  padding-left:calc(var(--s4) + var(--drawer)) }
+  padding-left:calc(var(--s4) + var(--drawer) - var(--spine)) }
 /* Capped in CHARACTERS and not in pixels, because the thing being limited is
    the measure and 680px is only one screen's worth of it: on a 1920 window the
    same column ran to about 92 characters, past the 80 the WCAG asks for and
@@ -739,8 +732,7 @@ h5.md-h, h6.md-h{ font-size:var(--t-h3); font-weight:600; color:var(--fg-2) }
       border-radius:0 var(--r-sm) var(--r-sm) 0; padding:8px 10px }
 
 /* ---------------- composer ---------------- */
-form{ position:relative;
-      padding:var(--s3) var(--s4) var(--s4) calc(var(--s4) + var(--spine));
+form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
       border-top:1px solid var(--line-1);
       background:var(--raised);
       box-shadow:0 -1px 0 rgba(0,0,0,.5), 0 -12px 28px -12px rgba(0,0,0,.65) }

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -156,7 +156,7 @@ PAGE = r"""<!doctype html>
 
   --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s5:20px; --s6:32px;
   --r-sm:4px; --r:8px; --r-lg:12px; --r-pill:999px;
-  --spine:54px;                               /* the sessions band */
+  --spine:44px;                               /* the sessions rail */
   --topbar:50px;                              /* every header, one height */
   --h-ctl:28px;                               /* every control on a bar */
   --gutter:1.75rem;                            /* three digits of 11px mono */
@@ -237,57 +237,45 @@ code,pre,.g,.meta,.badge,#url{
 #newchat:hover{ background:var(--raised); color:var(--fg);
                 border-color:var(--line-2) }
 
-/* ⛔ THE THREE LINES WERE A GUESS AND THE WORD IS NOT, and the word belongs on
-   the EDGE. A hamburger says "there is a menu here" only to somebody who has
-   already learned that it does. Written into the frame instead, the full height
-   of the window, it is not a control among the header's other controls: it is
-   part of the room, always there, and the only way in or out of the column.
-   The type is `.label`'s, so the spine and the column it opens read as one word
-   in one voice.
-   `vertical-rl` turned upside down gives the word bottom to top, which is the
-   direction every spine on a shelf uses in this alphabet, and the direction the
-   napkin had it. */
-/* The accent runs the full height of the spine and stays there whether the
-   column is open or shut: asked for on 2026-09-09, and it is the better of the
-   two - a line that appears and disappears is a state indicator competing with
-   the background, while a line that is always there is the edge of the room,
-   and the open state has the background and the ink to say it. It also replaces
-   the hairline that used to separate this from what follows. */
-#railtab{ flex:none; width:var(--spine); padding:0; cursor:pointer; border:0;
+/* ⛔ AN ICON, AND THE WORD WHEN IT IS WANTED. The rail carried SESSIONS set
+   vertically, and the word was the whole objection: it is the only thing on
+   this page a person has to tilt their head for, and it names a category where
+   everything else on screen names an action - Clear, Live, Frozen, jump to
+   latest. Chosen from four variants drawn side by side at real proportions,
+   which is how it finally got decided after two guesses were wrong: a bar in
+   the header, and then leaving it alone.
+
+   44px instead of 54, so ten pixels go back to the conversation. The target is
+   still the full height of the window, as far above the 24px WCAG floor and the
+   44px Fitts figure as a target gets, and the accent on the edge stays: it was
+   asked for, and a line that is always there is the edge of the room rather
+   than a state indicator competing with the background.
+
+   The icon sits at the TOP and not in the middle. That is where a rail's first
+   control goes in every product that has one, and it leaves the strip able to
+   grow a second icon without anything being re-thought. */
+#railtab{ flex:none; width:var(--spine); padding:11px 0 0; cursor:pointer; border:0;
           position:relative; background:var(--base); color:var(--fg-3);
           box-shadow:inset -1px 0 0 var(--accent);
-          /* The chevron and the word are two rows of one grid, centred
-             together: pinned to the top the arrow sat 450px from the word and
-             the two read as separate things on the same strip. */
-          display:grid; align-content:center; justify-items:center; gap:12px;
+          display:flex; justify-content:center; align-items:flex-start;
           transition:background-color 120ms ease-out, color 120ms ease-out }
-/* ⛔ A WORD ON A WALL IS NOT A BUTTON. At 34px with nothing but letters it read
-   as a label somebody had printed on the frame, which is the one thing it must
-   not read as - said in those words on 2026-09-09. Wider, and with the same
-   chevron the step rows use, drawn from borders rather than an icon: it points
-   into the room when the column is shut and back out when it is open, so the
-   thing you press also says which way it goes. */
-#railtab::before{ content:""; width:5px; height:5px;
-                  border-right:1.5px solid currentColor;
-                  border-bottom:1.5px solid currentColor;
-                  transform:rotate(-45deg) translate(-1px, -1px);
-                  transition:transform 150ms ease }
-#railtab[aria-expanded="true"]::before{ transform:rotate(135deg) translate(-1px, -1px) }
-/* ⛔ THE TEXT TURNS, NOT THE BUTTON. `transform` on the button would rotate the
-   whole box with it, so the border and the accent below would be drawn on the
-   edge away from the column instead of the one beside it - correct in the
-   element's own coordinates and backwards on the screen. */
-/* On the label step like every other tracked uppercase word on the page: it
-   was the last size in this column that belonged to no scale. The tracking
-   stays wider than `.label` because the letters are stacked, not set. */
-#railtab span{ writing-mode:vertical-rl; transform:rotate(180deg);
-               font:600 var(--t-label)/1 var(--sans); letter-spacing:.2em;
-               text-transform:uppercase }
+#railtab svg{ flex:none; display:block }
+/* The word, on screen, the moment a pointer or the keyboard arrives. Drawn
+   rather than left to `title`: the native tooltip waits about a second, takes
+   the operating system's colours, and never appears for a keyboard at all. */
+#railtab::after{ content:attr(data-tip); position:absolute; left:calc(100% + var(--s2));
+                 top:9px; white-space:nowrap; pointer-events:none; z-index:6;
+                 background:var(--top); color:var(--fg); font-size:var(--t-label);
+                 padding:4px 8px; border-radius:var(--r-sm);
+                 box-shadow:0 2px 8px rgba(0,0,0,.4);
+                 opacity:0; transition:opacity 125ms ease-out }
+#railtab:hover::after, #railtab:focus-visible::after{ opacity:1 }
+/* Open: the rail lifts a rung and the icon goes to full ink. The state is drawn
+   on the thing you press, where a hand already is - and the word goes quiet,
+   because the column beside it is now saying its own name. */
 #railtab:hover{ background:var(--raised); color:var(--fg) }
-/* Open: the spine lifts a rung and the word goes to full ink. The state is
-   drawn on the thing you press, where a hand already is. */
 #railtab[aria-expanded="true"]{ background:var(--raised); color:var(--fg) }
-#railtab[aria-expanded="true"] span{ display:none }
+#railtab[aria-expanded="true"]::after{ content:none }
 /* ⛔ THE PANEL FOLDS, THE WAY IN DOES NOT. Both used to disappear at the
    same breakpoint, and `#newchat` lives inside the panel - so a window snapped
    to half a 1366-wide laptop lost every session control at once, with the only
@@ -320,8 +308,14 @@ code,pre,.g,.meta,.badge,#url{
    has no handler: the padding around the name was a pointer cursor over
    nothing, which is the honesty contract this file states for the browser bar
    thirty lines earlier and did not keep here. */
+/* 24px tall, because 23 is a miss. WCAG 2.5.8 puts the floor at 24 CSS px and
+   this row was one pixel under it - measured on the running page, not guessed.
+   The height comes from a min-height rather than padding: the row is a flex
+   child and padding would move the text off the baseline it shares with the
+   count beside it. */
 .chat .nm{ cursor:pointer; flex:1; min-width:0; overflow:hidden;
-           text-overflow:ellipsis;
+           text-overflow:ellipsis; min-height:24px; display:flex;
+           align-items:center;
            white-space:nowrap; border:0; background:none; color:inherit;
            font:inherit; text-align:left; padding:0 }
 #chats .none{ margin:0; padding:var(--s3) var(--s2); color:var(--fg-3);
@@ -1005,16 +999,32 @@ form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
      sits behind the entire transcript, and the queue grows with the run. One
      link, first in the document, off-screen until it is focused. -->
 <a class="skip" href="#i">Skip to the message box</a>
+<!-- ⛔ THE NAME IS AN `aria-label` HERE AND THAT IS NOT THE DEFECT IT WAS.
+     While the word was ON the button, a label REPLACED it: a screen reader read
+     something that was not on screen and a voice user could not say what they
+     saw. With a drawn icon there is no visible word to contradict, so the label
+     IS the name - and `data-tip` puts the same word on screen the moment a
+     pointer or the keyboard arrives, so the two can never disagree. -->
 <button id="railtab" type="button" aria-expanded="false" aria-controls="rail"
-        title="Sessions"><span>Sessions</span></button>
+        aria-label="Sessions" data-tip="Sessions">
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+    <rect x="1.8" y="2.8" width="12.4" height="10.4" rx="2"
+          stroke="currentColor" stroke-width="1.6"/>
+    <path d="M6.1 2.8v10.4" stroke="currentColor" stroke-width="1.6"/>
+  </svg></button>
 
-<nav id="rail" aria-label="Sessions" hidden>
+<nav id="rail" aria-labelledby="railtitle" hidden>
   <!-- No title here any more: the spine to the left of this column carries the
        word, and with the column open the two sat twenty pixels apart saying the
        same thing. The row keeps its height from its padding, so it still lines
        up with the app header beside it. -->
+  <!-- ⛔ THE WORD LIVES HERE NOW. It used to be on the rail, and this span was
+       deliberately empty because the two sat twenty pixels apart saying the same
+       thing. The rail draws an icon since 2026-09-10, so nothing carried the word
+       any more: the column opened with a plus button and no title, which is a
+       rule that stopped being enforced one step past where it was written. -->
   <div id="railhead">
-    <span class="label" aria-hidden="true"></span>
+    <span class="label" id="railtitle">Sessions</span>
     <button id="newchat" type="button" aria-label="New session" title="New session">
       <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor"
            stroke-width="1.6" stroke-linecap="round"><path d="M7 2.5v9M2.5 7h9"/></svg>

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -130,50 +130,49 @@ PAGE = r"""<!doctype html>
      accessibility guidance marks `font-size: 16px` "Don't" and `1rem` "Do" for
      exactly this. Same pixels at the default 16px root, so nothing moves for
      anybody who never changed it. */
-  /* ⛔ ONE RATIO, AND THE STEPS ARE STEPS. Measured on the running page, the
-     left column drew NINE size/weight pairs at 11, 12, 13, 14 and 16px: four
-     sizes inside three pixels, which is a scale in name only. A step of 1.08
-     is not a step - the eye reads it as an accident - and the fix is not more
-     sizes but fewer, with weight and colour carrying the tiers that size no
-     longer does.
+  /* ⛔ EVERY SIZE HERE IS A PUBLISHED NUMBER, NOT A JUDGEMENT. Asked for in
+     those words, and it is the right way round: a scale somebody invents is a
+     scale nobody can check.
 
-     Three prose steps on ~1.2: 12 / 15 / 18. Body is 15 because this column
-     exists to be read and 14 is under the floor every source gives for reading
-     text. */
+       16px body    Material's default body size and the web's, and the number
+                    every one of the sources names first.
+       12px label   the comfortable floor for labels and captions; 11 is the
+                    absolute minimum and this is a step above it.
+       20px heading 1.25 from the body, inside the 1.2 to 1.333 ratio band all
+                    of them give for a type scale.
+
+     12 / 16 / 20, so the steps are 1.33 and 1.25. Levels that share a size are
+     separated by weight and colour, which those sources prefer to size anyway.
+
+     ⛔ MONO IS OFF THIS SCALE BY DECISION, at the 13px those same sources put
+     on code - a mono face runs wider and reads larger at the same pixel, and
+     the step track is MEASURED against it, so moving it moves a threshold a
+     gate checks. */
   --t-label:.75rem;                            /* 12 - labels, meta, counts */
-  --t-body:.9375rem;                           /* 15 - prose, and the base */
-  --t-ui:.9375rem;                             /* 15 - chrome reads as prose */
-  /* ⛔ MONO IS OFF THIS SCALE BY DECISION, NOT BY OVERSIGHT. A mono face runs
-     wider and reads larger at the same pixel, so it does not belong on a scale
-     built for a proportional one - and the step track is MEASURED against it:
-     `LONG` is how many characters fit in 416px at this size, so moving it moves
-     a threshold that a gate checks. It is the data face, and it says so here. */
+  --t-body:1rem;                               /* 16 - prose, and the base */
+  --t-ui:1rem;                                 /* 16 - chrome reads as prose */
   --t-mono:.8125rem;                           /* 13 - steps, code, addresses */
-  /* The answer's headings. One size above the body, then weight and colour:
-     three sizes a pixel apart carried nothing that 600 and a quieter ink do
-     not carry better. `--t-h1` is the off-screen page heading's size too. */
-  --t-h1:1.125rem; --t-h2:.9375rem; --t-h3:.9375rem;
+  --t-h1:1.25rem; --t-h2:1rem; --t-h3:1rem;    /* 20, then weight and colour */
 
   --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s5:20px; --s6:32px;
   --r-sm:4px; --r:8px; --r-lg:12px; --r-pill:999px;
-  /* ⛔ BOTH OF THESE ARE ON THE 4px GRID NOW, AND ONE OF THEM WAS NOT. This
-     file declares a 4px base and spends it everywhere else, and the header sat
-     at 50 - twelve and a half steps, which is not a step. A spacing system with
-     one number off it is the clearest sign there is no system, and it is the
-     kind of number nobody questions because it looks round in decimal.
+  /* ⛔ AND SO IS EVERY BOX, FOR THE SAME REASON.
 
-     48 for the rail: a step wider than it was, and the figure Material puts on
-     a touch target, so the strip is comfortable for a hand without taking width
-     the conversation can use. 56 for the headers: six pixels taller, on the
-     grid, and the height an app bar has almost everywhere - which by Jakob's
-     law is the height a person's eye is already expecting.
+       48px rail    Material's touch target, and the width a strip of icon
+                    buttons has in every product that ships one.
+       56px bar     Material's top app bar. By Jakob's law that is the height
+                    an eye already expects at the top of a window.
+       40px control the standard button height these sources give (36 to 40),
+                    taken at the top so a pill in a bar is comfortable rather
+                    than merely legal.
 
-     The control height stays 28, which is exactly half of 56: the bar and the
-     things in it are now one ratio rather than two numbers that happened to
-     leave enough room. */
+     All three are multiples of the 4px base this file spends everywhere else.
+     The header used to be 50 - twelve and a half steps, which is not a step,
+     and the kind of number nobody questions because it looks round in decimal. */
   --spine:48px;                               /* the sessions rail */
+  --drawer:256px;                             /* the standard drawer's width */
   --topbar:56px;                              /* every header, one height */
-  --h-ctl:28px;                               /* every control on a bar */
+  --h-ctl:40px;                               /* every control on a bar */
   --gutter:1.75rem;                            /* three digits of 11px mono */
   --gap:.55rem;
   --indent:calc(var(--gutter) + var(--gap));   /* ONE source for the step indent */
@@ -234,18 +233,22 @@ code,pre,.g,.meta,.badge,#url{
    Anchored to the spine's own width so the two are one object, and lifted with
    a shadow rather than a border, because what says "this is over that" is the
    shadow. */
-#rail { position:absolute; top:0; bottom:0; left:var(--spine); width:224px;
+/* Under the bar, like the rail that opens it: the band across the top is not
+   something a drawer may cover. */
+#rail { position:absolute; top:var(--topbar); bottom:0; left:0; width:var(--drawer);
         z-index:5; display:flex; flex-direction:column;
         background:var(--well); border-right:1px solid var(--line-1);
         box-shadow:14px 0 34px -18px #000 }
 /* The header of the column lines up with the header of the conversation beside
    it: same height, same padding, so the two read as one row across the app. */
+/* The left padding is the button's: it is drawn over this header now, so the
+   word starts after it instead of under it. */
 #railhead{ flex:none; height:var(--topbar); display:flex; align-items:center;
-           gap:8px; padding:0 var(--s3) 0 var(--s4);
+           gap:8px; padding:0 var(--s3) 0 var(--spine);
            border-bottom:1px solid var(--line-1) }
 #railhead .label{ flex:1 }
-#newchat{ flex:none; width:26px; height:26px; display:grid;
-          place-items:center; padding:0; border-radius:7px;
+#newchat{ flex:none; width:48px; height:48px; display:grid;
+          place-items:center; padding:0; border-radius:var(--r);
           border:1px solid transparent; background:none;
           color:var(--fg-3); cursor:pointer;
           transition:background-color 120ms ease-out, color 120ms ease-out }
@@ -269,8 +272,18 @@ code,pre,.g,.meta,.badge,#url{
    The icon sits at the TOP and not in the middle. That is where a rail's first
    control goes in every product that has one, and it leaves the strip able to
    grow a second icon without anything being re-thought. */
-#railtab{ flex:none; width:var(--spine); padding:11px 0 0; cursor:pointer; border:0;
-          position:relative; background:var(--base); color:var(--fg-3);
+/* ⛔ THE BAR RUNS THE WHOLE WIDTH AND THE RAIL HANGS UNDER IT. From the
+   owner's drawing: the horizontal band is the top of the room, unbroken from
+   edge to edge, and the vertical strip starts below it - so the rail cannot
+   be a column in the same row as the panes, or it would cut the band in two
+   at the left and the header would start 48px in.
+
+   Out of the flow, then, and the conversation carries the width it used to
+   take as a margin. Same pixels, different owner. */
+#railtab{ position:absolute; top:var(--topbar); left:0; bottom:0; z-index:4;
+          width:var(--spine); padding:11px 0 0; cursor:pointer; border:0;
+          background:var(--base); color:var(--fg-3);
+
           /* Half the weight it was: a hairline that says where the room ends
              rather than a rule that draws attention to itself. */
           box-shadow:inset -.5px 0 0 var(--accent);
@@ -291,7 +304,30 @@ code,pre,.g,.meta,.badge,#url{
    on the thing you press, where a hand already is - and the word goes quiet,
    because the column beside it is now saying its own name. */
 #railtab:hover{ background:var(--raised); color:var(--fg) }
-#railtab[aria-expanded="true"]{ background:var(--raised); color:var(--fg) }
+/* ⛔ OPEN, THE RAIL GIVES ITS WIDTH AWAY. A 48px strip beside an open column is
+   48px that says nothing: the column beside it already carries the name, the
+   state and the way out. So the button leaves the flow - the conversation gets
+   those pixels back and the panel starts at the edge of the window - and is
+   drawn over the panel's own header, in the same place on screen it was a
+   moment ago.
+
+   Moved, not duplicated. It is the same button, and it has to be: a second
+   control that opens the same column is a second thing to keep in step with the
+   first, which this page carried for half an hour once and a gate now forbids.
+   It is also the only thing that CLOSES the column, so it cannot simply be
+   hidden. */
+/* ⛔ ABOVE THE PANEL, AND 5 IS THE PANEL. Both were 5, and the panel comes
+   later in the document, so it painted over the button: the icon was exactly
+   where it belonged, 48 by 56 at the top-left corner, and invisible. The
+   ladder this page uses is 2 for the jump button, 5 for the panel, 6 above it,
+   20 for the skip link. */
+#railtab[aria-expanded="true"]{ position:absolute; top:var(--topbar); left:0;
+                                z-index:6; bottom:auto;
+                                width:var(--spine); height:var(--topbar);
+                                padding:0; display:grid; place-items:center;
+                                background:transparent; box-shadow:none;
+                                color:var(--fg-2) }
+#railtab[aria-expanded="true"]:hover{ color:var(--fg); background:transparent }
 #railtab[aria-expanded="true"]::after{ content:none }
 /* ⛔ THE PANEL FOLDS, THE WAY IN DOES NOT. Both used to disappear at the
    same breakpoint, and `#newchat` lives inside the panel - so a window snapped
@@ -438,7 +474,7 @@ code,pre,.g,.meta,.badge,#url{
         padding:3px 9px; border-radius:var(--r-pill) }
 /* 24px is the floor WCAG 2.2 sets for a target, and these three sat at 21,
    22 and 23 - close enough to look fine and short enough to fail. */
-#fresh{ min-height:24px; font-size:var(--t-label); font-family:var(--sans);
+#fresh{ min-height:var(--h-ctl); font-size:var(--t-label); font-family:var(--sans);
         color:var(--fg-2);
         background:var(--raised); border:1px solid var(--line-2); cursor:pointer;
         padding:3px 9px; border-radius:var(--r-pill);
@@ -456,7 +492,17 @@ code,pre,.g,.meta,.badge,#url{
    One rule, so the look follows the mechanism rather than whoever remembers. */
 [inert]{ opacity:.3 }
 
-#log{ flex:1; overflow:auto; padding:var(--s5) var(--s4); scrollbar-gutter:stable }
+#log{ flex:1; overflow:auto; scrollbar-gutter:stable;
+      padding:var(--s5) var(--s4) var(--s5) calc(var(--s4) + var(--spine));
+      transition:padding-left 180ms cubic-bezier(.23,1,.32,1) }
+/* ⛔ IT PUSHES, IT DOES NOT COVER. An overlay drawer is the phone pattern;
+   on a desktop the standard one moves the content over, and covering it here
+   sliced every line of the conversation down the middle - readable text with
+   a panel sitting on its first 224 pixels. The header is not moved: it lives
+   above the drawer, which is what the drawing asked for. */
+#rail:not([hidden]) ~ #left #log,
+#rail:not([hidden]) ~ #left form{
+  padding-left:calc(var(--s4) + var(--drawer)) }
 /* Capped in CHARACTERS and not in pixels, because the thing being limited is
    the measure and 680px is only one screen's worth of it: on a 1920 window the
    same column ran to about 92 characters, past the 80 the WCAG asks for and
@@ -693,7 +739,8 @@ h5.md-h, h6.md-h{ font-size:var(--t-h3); font-weight:600; color:var(--fg-2) }
       border-radius:0 var(--r-sm) var(--r-sm) 0; padding:8px 10px }
 
 /* ---------------- composer ---------------- */
-form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
+form{ position:relative;
+      padding:var(--s3) var(--s4) var(--s4) calc(var(--s4) + var(--spine));
       border-top:1px solid var(--line-1);
       background:var(--raised);
       box-shadow:0 -1px 0 rgba(0,0,0,.5), 0 -12px 28px -12px rgba(0,0,0,.65) }
@@ -781,7 +828,7 @@ form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
    nothing in here gets a pointer cursor except what does. */
 #chrome, #chrome *{ cursor:default; user-select:none }
 #url{ user-select:text }
-#mode button{ cursor:pointer; min-height:24px }
+#mode button{ cursor:pointer; min-height:var(--h-ctl) }
 #dot{ width:7px; height:7px; flex:none; border-radius:50%; background:var(--fg-4) }
 [data-state="live"]  #dot{ background:var(--ok); animation:breathe 1.8s ease-in-out infinite }
 [data-state="busy"]  #dot{ background:var(--accent); animation:breathe .9s ease-in-out infinite }
@@ -1058,10 +1105,10 @@ form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
      pointer or the keyboard arrives, so the two can never disagree. -->
 <button id="railtab" type="button" aria-expanded="false" aria-controls="rail"
         aria-label="Sessions" data-tip="Sessions">
-  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-    <rect x="1.8" y="2.8" width="12.4" height="10.4" rx="2"
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <rect x="2.8" y="4.4" width="18.4" height="15.2" rx="3"
           stroke="currentColor" stroke-width="1.6"/>
-    <path d="M6.1 2.8v10.4" stroke="currentColor" stroke-width="1.6"/>
+    <path d="M9.2 4.4v15.2" stroke="currentColor" stroke-width="1.6"/>
   </svg></button>
 
 <nav id="rail" aria-labelledby="railtitle" hidden>
@@ -1077,8 +1124,8 @@ form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
   <div id="railhead">
     <span class="label" id="railtitle">Sessions</span>
     <button id="newchat" type="button" aria-label="New session" title="New session">
-      <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor"
-           stroke-width="1.6" stroke-linecap="round"><path d="M7 2.5v9M2.5 7h9"/></svg>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor"
+           stroke-width="1.6" stroke-linecap="round"><path d="M9 3.5v11M3.5 9h11"/></svg>
     </button>
   </div>
   <div id="chats" role="list"></div>
@@ -1124,21 +1171,21 @@ form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
          it floats above. -->
     <button id="jump" hidden type="button">jump to latest</button>
     <button id="chip" type="button" hidden>1 message queued
-      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true"
+      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"
            stroke="currentColor" stroke-width="1.6" stroke-linecap="round"
            stroke-linejoin="round"><path d="M10.6 2.9l2.5 2.5L5.6 12.9 2.5 13.5l.6-3.1z"/></svg></button>
     <div class="composer">
       <label class="sr" for="i">What should the agent do?</label>
       <textarea id="i" rows="1" placeholder="What should the agent do?"></textarea>
       <button id="go" type="submit" aria-label="Send" disabled>
-        <svg width="14" height="14" viewBox="0 0 14 14" fill="none"
+        <svg width="18" height="18" viewBox="0 0 18 18" fill="none"
              stroke="currentColor" stroke-width="1.6" stroke-linecap="round"
              stroke-linejoin="round">
-          <path d="M7 12V2M2.5 6.5L7 2l4.5 4.5"/></svg>
+          <path d="M9 15.5V2.5M3.5 8L9 2.5l5.5 5.5"/></svg>
       </button>
       <button id="halt" type="button" hidden aria-label="Stop">
-        <svg width="12" height="12" viewBox="0 0 12 12">
-          <rect width="12" height="12" rx="2" fill="currentColor"/></svg>
+        <svg width="14" height="14" viewBox="0 0 14 14">
+          <rect width="14" height="14" rx="3" fill="currentColor"/></svg>
       </button>
     </div>
   </form>

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -156,8 +156,23 @@ PAGE = r"""<!doctype html>
 
   --s1:4px; --s2:8px; --s3:12px; --s4:16px; --s5:20px; --s6:32px;
   --r-sm:4px; --r:8px; --r-lg:12px; --r-pill:999px;
-  --spine:44px;                               /* the sessions rail */
-  --topbar:50px;                              /* every header, one height */
+  /* ⛔ BOTH OF THESE ARE ON THE 4px GRID NOW, AND ONE OF THEM WAS NOT. This
+     file declares a 4px base and spends it everywhere else, and the header sat
+     at 50 - twelve and a half steps, which is not a step. A spacing system with
+     one number off it is the clearest sign there is no system, and it is the
+     kind of number nobody questions because it looks round in decimal.
+
+     48 for the rail: a step wider than it was, and the figure Material puts on
+     a touch target, so the strip is comfortable for a hand without taking width
+     the conversation can use. 56 for the headers: six pixels taller, on the
+     grid, and the height an app bar has almost everywhere - which by Jakob's
+     law is the height a person's eye is already expecting.
+
+     The control height stays 28, which is exactly half of 56: the bar and the
+     things in it are now one ratio rather than two numbers that happened to
+     leave enough room. */
+  --spine:48px;                               /* the sessions rail */
+  --topbar:56px;                              /* every header, one height */
   --h-ctl:28px;                               /* every control on a bar */
   --gutter:1.75rem;                            /* three digits of 11px mono */
   --gap:.55rem;
@@ -491,12 +506,19 @@ code,pre,.g,.meta,.badge,#url{
    compound starting with `h3.md-h` sits earlier in the file than the heading's
    own rule, and two gates that read this stylesheet as text then find this one
    first and check the wrong declarations. */
-/* 58ch and not 66: the cap used to sit OUTSIDE the answer's indent and now
-   sits inside it, so the same number would buy 82 characters where it used to
-   buy 75. Recomputed rather than carried over - that arithmetic is exactly
-   what this page has already got wrong twice. */
-.answer > *, .say{ max-width:58ch }
-.answer > .md-t, .answer > pre, .answer > .md-pre{ max-width:100% }
+/* ⛔ AND THEN THE CAP CAME OFF THE PROSE TOO, BECAUSE IT WAS THE PROSE THE
+   OWNER WAS LOOKING AT. Moving it off the transcript widened the step rows and
+   left the answer exactly where it was, which is the text a person actually
+   reads: dragged wide, the sentences still wrapped at the same place. Said
+   twice, the second time with a screenshot.
+
+   So the measure is not a number this file picks any more - it is the width of
+   the pane, and the separator is the control that sets it. That is a better
+   answer than a cap in either place: the person reading decides how wide their
+   own reading is, which is the one thing a fixed number can never get right for
+   everybody. The DEFAULT still lands inside 65-80 characters for anybody who
+   never drags, and there is a gate that recomputes exactly that from the pane's
+   own declared width rather than from a number written down here. */
 
 
 /* Bottom-pinning with no scroll handler and no epsilon: the sentinel is the only

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -256,7 +256,9 @@ code,pre,.g,.meta,.badge,#url{
    grow a second icon without anything being re-thought. */
 #railtab{ flex:none; width:var(--spine); padding:11px 0 0; cursor:pointer; border:0;
           position:relative; background:var(--base); color:var(--fg-3);
-          box-shadow:inset -1px 0 0 var(--accent);
+          /* Half the weight it was: a hairline that says where the room ends
+             rather than a rule that draws attention to itself. */
+          box-shadow:inset -.5px 0 0 var(--accent);
           display:flex; justify-content:center; align-items:flex-start;
           transition:background-color 120ms ease-out, color 120ms ease-out }
 #railtab svg{ flex:none; display:block }
@@ -347,10 +349,12 @@ code,pre,.g,.meta,.badge,#url{
    hands the rest to the right. Only desktops run this, so the floor is the
    narrow end of a laptop and there is no phone case to carry.
 
-   The ceiling is derived, not chosen: the thread caps at 66ch, which is 498px
-   in this font, plus the 32px of log padding it sits in. Anything wider would
-   be slack inside this pane rather than measure, and it is worth more to the
-   picture on the right. */
+   The ceiling here is the DEFAULT, not a limit: it is where the pane starts on
+   a screen nobody has dragged, chosen so the prose sits at its measure without
+   taking width the picture on the right can use. The splitter goes well past
+   it - up to the window minus 480 - and since the measure cap moved off the
+   transcript onto the prose, every pixel past this one goes to the step rows,
+   which is where it does something. Dragging used to widen nothing at all. */
 #left { width:clamp(420px, 44%, 530px); display:flex; flex-direction:column;
         position:relative }
 /* The separator carries the line that used to be `#left`'s right border, so
@@ -468,7 +472,32 @@ code,pre,.g,.meta,.badge,#url{
    half on the LEFT, which reads as the column having been pushed away from the
    edge for no reason - 185px of nothing before the first character, in a
    screenshot. */
-#thread{ max-width:66ch; margin:0 }
+/* ⛔ THE MEASURE BELONGS TO THE PROSE, NOT TO THE COLUMN. The cap used to sit
+   here, on the whole transcript, so widening the pane widened NOTHING: dragged
+   from 530 to 1440, the conversation stopped growing at 534 and the rest of the
+   pane became margin. A control that offers a range in which nothing happens is
+   a control that lies, and this one was measured doing it.
+
+   Prose keeps the cap, because 200 characters a line is unreadable whatever the
+   window is. The step rows do NOT: they are monospace data, they were already
+   cut off at 48 characters with the rest behind a disclosure, and every pixel
+   the drag gives them is a pixel of address a person can read without opening
+   anything. Same for code blocks and tables, which scroll in their own box.
+
+   So dragging wider now widens the thing that was actually short. */
+#thread{ margin:0 }
+/* Every block of an answer, and then the two that are not prose taken back
+   out. Written as `> *` and not as a list of element selectors on purpose: a
+   compound starting with `h3.md-h` sits earlier in the file than the heading's
+   own rule, and two gates that read this stylesheet as text then find this one
+   first and check the wrong declarations. */
+/* 58ch and not 66: the cap used to sit OUTSIDE the answer's indent and now
+   sits inside it, so the same number would buy 82 characters where it used to
+   buy 75. Recomputed rather than carried over - that arithmetic is exactly
+   what this page has already got wrong twice. */
+.answer > *, .say{ max-width:58ch }
+.answer > .md-t, .answer > pre, .answer > .md-pre{ max-width:100% }
+
 
 /* Bottom-pinning with no scroll handler and no epsilon: the sentinel is the only
    anchor the browser may keep, so content inserted before it pushes the view

--- a/tests/test_the_browser_workspace.py
+++ b/tests/test_the_browser_workspace.py
@@ -456,19 +456,23 @@ def test_the_answer_measure_is_inside_the_range_every_source_agrees_on():
     So the conversion lives here rather than in a comment, and it reads the page
     instead of repeating it: change the cap or the gutter and this recomputes.
 
-    Known-bad, both real: 84ch gives 98 and 72ch gives 83, and both go red.
+    Known-bad, both real at the cap's new home: 66ch gives 82 and 50ch gives 62,
+    and both go red.
     """
     import re
 
-    cap = float(re.search(r"#thread\{ max-width:([\d.]+)ch", PAGE).group(1))
-    gutter = float(re.search(r"--gutter:([\d.]+)rem", PAGE).group(1))
-    gap = float(re.search(r"--gap:([\d.]+)rem", PAGE).group(1))
+    # ⛔ AND THE CAP MOVED, WHICH MOVED THE ARITHMETIC WITH IT. It used to sit
+    # on `#thread`, OUTSIDE the indent an answer carries, so the indent came off
+    # the text. It sits on the answer's own blocks now - inside that indent, so
+    # nothing comes off - because on `#thread` it also capped the step rows, and
+    # dragging the pane wider then widened nothing at all.
+    cap = float(re.search(r"\.answer > \*, \.say\{ max-width:([\d.]+)ch", PAGE)
+                .group(1))
 
     #: Both measured in the browser, on the font the page actually declares.
     CH_PX, AVG_CHAR_PX, ROOT_PX = 7.55, 6.11, 16.0
 
-    indent = (gutter + gap) * ROOT_PX          # --indent, which an answer carries
-    chars = (cap * CH_PX - indent) / AVG_CHAR_PX
+    chars = cap * CH_PX / AVG_CHAR_PX
     assert 65 <= chars <= 80, (
         "the answer is %.0f characters per line. Under 65 the eye returns too "
         "often; over 80 it loses the line, and 80 is the WCAG 2.1 AAA cap. "

--- a/tests/test_the_browser_workspace.py
+++ b/tests/test_the_browser_workspace.py
@@ -438,43 +438,53 @@ def test_every_handler_the_page_wires_up_exists():
 
 
 def test_the_answer_measure_is_inside_the_range_every_source_agrees_on():
-    """⛔ THIS NUMBER HAS BEEN WRONG TWICE, THE SAME WAY BOTH TIMES: computed in
-    `ch` and read as characters.
+    """⛔ THIS NUMBER HAS BEEN WRONG THREE TIMES, TWICE THE SAME WAY: computed
+    in `ch` and read as characters.
 
     `ch` is the advance width of the digit zero. In a proportional font that is
     much wider than an average letter, so a cap written in `ch` looks like a
-    character count and is not one. Measured on this font with a canvas, on real
-    prose in both languages this interface serves: `0` is 7.55px at 14px
-    system-ui, the average character of a sentence is 6.11px, so one `ch` is
-    1.24 characters.
+    character count and is not one. Measured on this font with a canvas: `0` is
+    7.55px at 14px system-ui and the average character of a sentence is 6.11px,
+    so one `ch` is 1.24 characters. First the cap was 72ch believing it was 72
+    characters, and was 83; then 84ch to make up for an indent, and was 98.
 
-    First the cap was 72ch believing it was 72 characters, and minus the indent
-    an answer carries it was 83. Then it was widened to 84ch to make up for that
-    indent, in `ch` again, and became 98 - past 65-72 (chat design guidance), 75
-    (Baymard's upper bound) and 80 (WCAG 2.1 AAA, SC 1.4.8).
+    ⛔ THE THIRD TIME THERE WAS NO CAP LEFT TO CHECK. It came off: the measure
+    is the width of the pane now and the separator is the control that sets it,
+    because a fixed number widened nothing when somebody dragged the pane in
+    order to read more - reported twice, the second time with a screenshot.
 
-    So the conversion lives here rather than in a comment, and it reads the page
-    instead of repeating it: change the cap or the gutter and this recomputes.
+    What still has to hold is the DEFAULT, the width the pane opens at for
+    anybody who never drags. So that is what this computes, from the pane's own
+    declared ceiling rather than from a number written down anywhere.
 
-    Known-bad, both real at the cap's new home: 66ch gives 82 and 50ch gives 62,
-    and both go red.
+    Known-bad, three: widen the default pane past what the measure allows; put a
+    cap back on the transcript; drop the log's padding so the text runs to the
+    edge.
     """
     import re
 
-    # ⛔ AND THE CAP MOVED, WHICH MOVED THE ARITHMETIC WITH IT. It used to sit
-    # on `#thread`, OUTSIDE the indent an answer carries, so the indent came off
-    # the text. It sits on the answer's own blocks now - inside that indent, so
-    # nothing comes off - because on `#thread` it also capped the step rows, and
-    # dragging the pane wider then widened nothing at all.
-    cap = float(re.search(r"\.answer > \*, \.say\{ max-width:([\d.]+)ch", PAGE)
-                .group(1))
+    pane = float(re.search(r"#left \{ width:clamp\([\d.]+px, ?\d+%, ?([\d.]+)px\)",
+                           PAGE).group(1))
+    assert re.search(r"#log\{[^}]*padding:var\(--s5\) var\(--s4\)", PAGE), (
+        "the transcript no longer states its own padding, so this cannot be "
+        "computed from the file")
+    pad = float(re.search(r"--s4:([\d.]+)px", PAGE).group(1))
+    gutter = float(re.search(r"--gutter:([\d.]+)rem", PAGE).group(1))
+    gap = float(re.search(r"--gap:([\d.]+)rem", PAGE).group(1))
+    body = float(re.search(r"--t-body:([\d.]+)rem", PAGE).group(1))
 
-    #: Both measured in the browser, on the font the page actually declares.
-    CH_PX, AVG_CHAR_PX, ROOT_PX = 7.55, 6.11, 16.0
+    #: Measured in the browser on the face this page declares, at 14px.
+    AVG_AT_14, ROOT_PX = 6.11, 16.0
+    avg = AVG_AT_14 * (body * ROOT_PX) / 14.0     # same face, one size up
 
-    chars = cap * CH_PX / AVG_CHAR_PX
+    indent = (gutter + gap) * ROOT_PX             # --indent, which an answer carries
+    chars = (pane - pad * 2 - indent) / avg
     assert 65 <= chars <= 80, (
-        "the answer is %.0f characters per line. Under 65 the eye returns too "
-        "often; over 80 it loses the line, and 80 is the WCAG 2.1 AAA cap. "
-        "The cap is %.0fch, which is NOT %.0f characters: one ch is 1.24 of "
-        "them in this font" % (chars, cap, cap))
+        "the answer opens at %.0f characters a line, outside the 65 to 80 that "
+        "chat design guidance, Baymard and WCAG 2.1 AAA all land inside" % chars)
+
+    # And nothing pins it there once somebody drags, which is the whole point of
+    # the pane being the control.
+    assert not re.search(r"#thread\{[^}]*max-width", PAGE), (
+        "the transcript is capped again, so dragging the pane widens nothing")
+

--- a/tests/test_the_page_meets_the_craft_floor.py
+++ b/tests/test_the_page_meets_the_craft_floor.py
@@ -64,6 +64,25 @@ def test_the_drawn_icons_share_one_stroke():
         % (len(widths), ", ".join(sorted(widths))))
 
 
+def test_an_icon_draws_the_stroke_it_declares():
+    """⛔ THE ONE-STROKE RULE WAS TRUE IN THE ATTRIBUTE AND FALSE ON THE SCREEN.
+    An `svg` drawn at 12px from a 16-unit viewBox scales everything inside it by
+    three quarters, so `stroke-width="1.6"` reaches the glass at 1.2 - beside
+    icons drawing 1.6. The gate above counts the attribute and passed it happily.
+
+    So the viewBox has to match the drawn size. Then the number in the file is
+    the number on the screen, and one stroke means one stroke.
+
+    Known-bad: draw any icon at a size its viewBox does not have.
+    """
+    icons = re.findall(r'<svg width="(\d+)" height="(\d+)" viewBox="0 0 (\d+) (\d+)"',
+                       PAGE)
+    assert icons, "the page draws no icons at all, so this gate is not looking"
+    off = [(w, h, vw, vh) for w, h, vw, vh in icons if (w, h) != (vw, vh)]
+    assert not off, (
+        "%d icon(s) are drawn at a size their viewBox does not have, so their "
+        "stroke is scaled away from the one they declare: %s" % (len(off), off))
+
 def test_no_callout_wears_a_coloured_bar_down_its_left_edge():
     """⛔ THE 2px STRIPE IS A COSTUME. A coloured bar on the left of an alert is
     the house style of every framework and belongs to none of them; a tint plus

--- a/tests/test_the_page_tells_the_truth.py
+++ b/tests/test_the_page_tells_the_truth.py
@@ -88,6 +88,40 @@ def test_every_event_the_server_can_send_is_drawn():
         "lands in the transcript as raw JSON" % missing)
 
 
+def test_dragging_the_pane_wider_widens_something():
+    """⛔ A CONTROL THAT OFFERS A RANGE WHERE NOTHING HAPPENS IS A CONTROL THAT
+    LIES. The measure cap sat on the whole transcript, so the separator could be
+    dragged from 530px to 1440 and the conversation stopped growing at 534: the
+    rest of the pane turned into margin. Reported by the owner as "the chat does
+    not get wider", and measured exactly that.
+
+    The cap belongs to the PROSE, which is unreadable at 200 characters a line
+    whatever the window is. It does not belong to the step rows, which are
+    monospace data already cut off at 48 characters with the rest behind a
+    disclosure: measured after, the track goes from 416px at the default width to
+    1326px dragged wide, and an address that was truncated fits whole.
+
+    Known-bad, three: put the cap back on `#thread`; take it off the prose so a
+    line runs the whole pane; pin the row's middle column to something fixed so
+    the slack stops reaching it.
+    """
+    thread = re.search(r"#thread\{([^}]*)\}", CODE)
+    assert thread, "the transcript has no rule of its own"
+    assert "max-width" not in thread.group(1), (
+        "the cap is back on the whole transcript, so widening the pane widens "
+        "nothing: %s" % thread.group(1))
+
+    prose = re.search(r"\.answer > \*, \.say\{[^}]*max-width:([\d.]+)ch", CODE)
+    assert prose, (
+        "nothing caps the prose, so an answer runs the full width of a pane "
+        "somebody dragged wide")
+
+    row = re.search(r"\.row\{([^}]*)\}", CODE)
+    assert row and "minmax(0,1fr)" in row.group(1), (
+        "the step row no longer takes the slack, so the width the drag hands "
+        "over stops before the one thing that was short: %s"
+        % (row.group(1) if row else "no rule"))
+
 def test_the_heading_survives_being_invisible():
     """⛔ IT READS AS DEAD MARKUP AND IT IS LOAD-BEARING. The product's name was
     taken off the screen because it said what the tab, the window and the

--- a/tests/test_the_page_tells_the_truth.py
+++ b/tests/test_the_page_tells_the_truth.py
@@ -111,10 +111,14 @@ def test_dragging_the_pane_wider_widens_something():
         "the cap is back on the whole transcript, so widening the pane widens "
         "nothing: %s" % thread.group(1))
 
-    prose = re.search(r"\.answer > \*, \.say\{[^}]*max-width:([\d.]+)ch", CODE)
-    assert prose, (
-        "nothing caps the prose, so an answer runs the full width of a pane "
-        "somebody dragged wide")
+    # ⛔ AND NO CAP ON THE PROSE EITHER, WHICH IS WHERE THIS GATE FIRST LANDED.
+    # Moving the cap off the transcript widened the step rows and left the
+    # answer exactly where it was - the text a person actually reads - so the
+    # report came back a second time, with a screenshot. The pane IS the
+    # measure now; the default width is what keeps it sane, and that is
+    # checked where it can be computed, in the workspace gate.
+    assert not re.search(r"\.answer > \*[^}]*max-width", CODE), (
+        "the prose is capped again, so the sentences wrap in the same place however wide the pane is dragged")
 
     row = re.search(r"\.row\{([^}]*)\}", CODE)
     assert row and "minmax(0,1fr)" in row.group(1), (

--- a/tests/test_the_session_column.py
+++ b/tests/test_the_session_column.py
@@ -502,36 +502,54 @@ async def test_a_queued_message_is_not_lost_when_the_page_goes_away():
         "it: %s" % stray)
 
 
-def test_the_sessions_control_is_named_by_the_word_on_it():
-    """⛔ AN aria-label REPLACES THE VISIBLE NAME, IT DOES NOT ADD TO IT.
+def test_the_sessions_control_says_the_same_word_it_is_called():
+    """⛔ A NAME AND A LABEL MAY NEVER DISAGREE, and which of the two is the
+    defect depends on what is drawn.
 
-    The control was three lines and an `aria-label` reading "Show sessions" /
-    "Hide sessions", which was the only name it had. On 2026-09-09 it became a
-    bar with the word Sessions written on it, and the label became a defect:
-    a screen reader would announce a word that is not on the button, and
-    somebody driving by voice who says "Sessions" would find nothing to click.
-    WCAG 2.5.3 Label in Name is the criterion, and the open state is carried by
-    `aria-expanded`, which is the attribute for it.
+    First the control was three lines with an `aria-label` reading "Show
+    sessions", which was the only name it had. Then it became a bar with the
+    word Sessions written on it, and the label became the defect: a screen
+    reader announced a word that was not on the button and a voice user saying
+    "Sessions" found nothing to click. WCAG 2.5.3, Label in Name.
 
-    Found by reading the live DOM after the change rather than the source:
-    taking the attribute out of the markup left the script putting it back on
-    every open and close.
+    On 2026-09-10 the word came off the wall - it was the only thing on the page
+    a person had to tilt their head for - and an `aria-label` stopped being a
+    defect the moment there was no visible word left to contradict. So this gate
+    asks the question that survives both shapes: is there a name, and does
+    everything that says a name say the SAME one.
 
-    Known-bad, two: put `aria-label` back on the button, and put the
-    `setAttribute('aria-label', ...)` line back in `showRail`.
+    Known-bad, four: drop the label from an icon-only button; drop the tip so
+    the word is never on screen; make the two say different words; put the
+    `setAttribute('aria-label', ...)` line back in `showRail`, where it wrote a
+    changing name over a fixed one on every open and close.
     """
     import re
 
     button = re.search(r"<button id=\"railtab\"[^>]*>(.*?)</button>", PAGE, re.S)
     assert button, "the sessions control is gone"
-    assert "aria-label" not in button.group(0), (
-        "the control carries an aria-label as well as a visible word, and the "
-        "label is what a screen reader reads instead of the word: %s"
-        % button.group(0))
-    assert "Sessions" in button.group(1), (
-        "the control has no visible word, so it has no accessible name either")
-    assert 'aria-expanded' in button.group(0), (
-        "nothing says whether the column is open")
+    whole, inside = button.group(0), button.group(1)
+    visible = re.sub(r"<[^>]+>", "", inside).strip()
+    label = re.search(r'aria-label="([^"]*)"', whole)
+    tip = re.search(r'data-tip="([^"]*)"', whole)
+
+    if visible:
+        assert not label, (
+            "the control has the word %r on it AND an aria-label, and the label "
+            "is what a screen reader reads instead of the word" % visible)
+    else:
+        assert label, (
+            "the control draws an icon and carries no name at all, so it is "
+            "announced as `button` and cannot be reached by voice")
+        assert tip, (
+            "the name exists only for a screen reader: nothing puts the word on "
+            "screen for a pointer or the keyboard")
+        assert label.group(1) == tip.group(1), (
+            "the control is called %r and shows %r"
+            % (label.group(1), tip.group(1)))
+        assert "Sessions" in label.group(1), (
+            "the name is not the word the column is called: %r" % label.group(1))
+
+    assert "aria-expanded" in whole, "nothing says whether the column is open"
 
     script = PAGE[PAGE.index("<script"):]
     code = re.sub(r"/\*.*?\*/", "", script, flags=re.S)
@@ -541,8 +559,8 @@ def test_the_sessions_control_is_named_by_the_word_on_it():
     # walked straight through it.
     sets = re.findall(r"\$\('railtab'\)\s*\.setAttribute\(\s*'aria-label'", code)
     assert not sets, (
-        "the script puts an aria-label back on the control, which replaces the "
-        "word written on it every time the column opens or closes")
+        "the script writes an aria-label on every open and close, so the name "
+        "changes under the word that is meant to be fixed")
 
 
 def test_the_spine_is_part_of_the_frame_and_is_the_only_way_in():
@@ -556,8 +574,8 @@ def test_the_spine_is_part_of_the_frame_and_is_the_only_way_in():
     that for half an hour.
 
     Known-bad, three: move the button after `<div id="left"`; add a second
-    control with `aria-controls="rail"`; drop the vertical writing so the word
-    runs across a 34px column.
+    control with `aria-controls="rail"`; put a word back on the wall instead of
+    a drawn icon.
     """
     import re
 
@@ -569,12 +587,16 @@ def test_the_spine_is_part_of_the_frame_and_is_the_only_way_in():
     assert len(opens) == 1, (
         "%d controls open the sessions column; two of them can disagree about "
         "whether it is open" % len(opens))
-    style = PAGE[PAGE.index("#railtab{"):PAGE.index("/* Open: the spine lifts")]
-    assert "writing-mode:vertical-rl" in style, (
-        "the word runs across a column 34px wide, so it is not readable at all")
-    assert "rotate(180deg)" in style, (
-        "vertical-rl alone reads top to bottom; a spine in this alphabet reads "
-        "bottom to top, which is what the drawing showed")
+    # ⛔ IT DRAWS, IT DOES NOT SET TYPE SIDEWAYS. The word used to run bottom
+    # to top down the strip, and that rotation was the whole reason it went: the
+    # only thing on this page a reader had to tilt their head for. What replaces
+    # it has to be a drawn mark, not the same word turned some other way.
+    style = PAGE[PAGE.index("#railtab{"):PAGE.index("/* Open: the rail lifts")]
+    assert "writing-mode" not in style, (
+        "the rail sets type sideways again")
+    assert "<svg" in PAGE[PAGE.index('id="railtab"'):PAGE.index("</button>",
+                                                                PAGE.index('id="railtab"'))], (
+        "the rail carries no drawn mark, so there is nothing on it to press")
 
     # ⛔ AND IT IS NEVER HIDDEN. The panel and its only opener used to be
     # dropped by the same media query, and `#newchat` lives inside the panel: a


### PR DESCRIPTION
The rail draws an icon instead of the word SESSIONS set vertically. The word was the whole objection: the only thing on the page a person has to tilt their head for, naming a category where everything else names an action. It appears beside the icon the moment a pointer or the keyboard arrives, drawn rather than left to `title`, which waits a second and never appears for a keyboard at all. Chosen by drawing four variants side by side at real proportions, after two guesses had been wrong.

Dragging the separator now widens something. The measure cap sat on the whole transcript, so the pane could be dragged from 530px to 1440 and the conversation stopped growing at 534: the rest turned into margin. The cap is gone from the transcript AND from the prose - the measure is the width of the pane and the separator is the control that sets it. The default still opens inside 65 to 80 characters, and the gate computes that from the pane rather than from a number in a comment.

The drawer pushes the conversation instead of covering it, at the standard 256px. Covering was slicing every line down the middle.

And every dimension is a published figure rather than a judgement: 16px body, 12px labels, 20px headings on a 1.25 ratio, 13px monospace, 48px rail and icon buttons, 56px bars, 40px controls, 24px icons. The header had been 50, which is twelve and a half steps of the 4px base this file spends everywhere else.

Two defects found on the way: an icon drawn at 12px from a 16-unit viewBox scaled its stroke to 1.2 while declaring 1.6, so the one-stroke rule was true in the attribute and false on the screen; and taking the word off the rail left the column it opens with no title, because that title had been left empty on the reasoning that the rail carried it.

Nine known-bad mutations across the new gates, all killed. 535 tests pass.