### PR TITLE
The two controls on the bar are declared once (0.35.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.34.0"
+version = "0.35.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/web.py
+++ b/src/aihawk/web.py
@@ -462,15 +462,22 @@ code,pre,.g,.meta,.badge,#url{
    things being pushed, and this rule only describes the size it is announced
    at rather than drawn at. */
 #head h1{ margin:0; font-size:var(--t-ui); font-weight:600 }
-.badge{ font-size:var(--t-label); color:var(--fg-2);
-        background:var(--raised); border:1px solid var(--line-2);
-        padding:3px 9px; border-radius:var(--r-pill) }
+/* ⛔ ONE RULE FOR BOTH, BECAUSE TWO RULES THAT MUST AGREE DO NOT. The badge and
+   the Clear button sit side by side on the same bar and were declared
+   separately: putting the control height on one of them and not the other left
+   a 40px pill beside a 20px one, same radius, visibly different shapes. Written
+   once, they cannot drift again.
+
+   Height from the control token, text at the body size - 12px on a bar control
+   is a caption size, and these are things you read and press. */
+.badge, #fresh{ height:var(--h-ctl); display:inline-flex; align-items:center;
+                font-size:var(--t-ui); color:var(--fg-2);
+                background:var(--raised); border:1px solid var(--line-2);
+                padding:0 var(--s3); border-radius:var(--r-pill) }
+
 /* 24px is the floor WCAG 2.2 sets for a target, and these three sat at 21,
    22 and 23 - close enough to look fine and short enough to fail. */
-#fresh{ min-height:var(--h-ctl); font-size:var(--t-label); font-family:var(--sans);
-        color:var(--fg-2);
-        background:var(--raised); border:1px solid var(--line-2); cursor:pointer;
-        padding:3px 9px; border-radius:var(--r-pill);
+#fresh{ font-family:var(--sans); cursor:pointer;
         transition:background-color 120ms ease-out, color 120ms ease-out }
 #fresh:hover:not(:disabled){ background:var(--hover); color:var(--fg) }
 #fresh:disabled{ opacity:.3; cursor:default }

--- a/tests/test_the_page_meets_the_craft_floor.py
+++ b/tests/test_the_page_meets_the_craft_floor.py
@@ -64,6 +64,41 @@ def test_the_drawn_icons_share_one_stroke():
         % (len(widths), ", ".join(sorted(widths))))
 
 
+def test_the_controls_on_a_bar_are_declared_once():
+    """⛔ TWO RULES THAT MUST AGREE DO NOT AGREE. The model badge and the Clear
+    button sit side by side on the same bar and were declared separately, so a
+    pass that put the control height on one of them and not the other left a
+    40px pill beside a 20px one - same radius, visibly different shapes, and
+    nothing went red because each rule was internally fine.
+
+    This page already learned it once for the browser bar, where the address was
+    24 tall, the Live and Frozen pair 30 and the layout picker 30: three
+    controls on one line sitting on three different rhythms. The fix there was
+    the same as the fix here - say it once.
+
+    Known-bad, two: split them back into two rules; give one of them a size of
+    its own after the shared rule.
+    """
+    shared = re.search(r"\.badge, ?#fresh\{([^}]*)\}", CODE)
+    assert shared, (
+        "the badge and the button are declared apart again, so the next pass "
+        "that touches one of them can leave the other behind")
+    for needed in ("height", "font-size", "border-radius", "padding"):
+        assert needed in shared.group(1), (
+            "the shared rule does not state %r, so each control decides it "
+            "for itself" % needed)
+
+    # The rule whose selector IS `#fresh`, not the shared one that contains
+    # the string: `#fresh{` appears inside `.badge, #fresh{` too, and the first
+    # version of this gate accused the very rule it exists to require.
+    own = [body for sel, body in re.findall(r"([^{}]+)\{([^}]*)\}", CODE)
+           if sel.strip().endswith("#fresh") and "," not in sel]
+    for body in own:
+        for forbidden in ("height", "font-size", "border-radius", "padding"):
+            assert forbidden not in body, (
+                "`#fresh` sets its own %r after the shared rule, which is how "
+                "the two drifted apart the first time" % forbidden)
+
 def test_an_icon_draws_the_stroke_it_declares():
     """⛔ THE ONE-STROKE RULE WAS TRUE IN THE ATTRIBUTE AND FALSE ON THE SCREEN.
     An `svg` drawn at 12px from a 16-unit viewBox scales everything inside it by


### PR DESCRIPTION
The model badge and the Clear button sit side by side on the same bar and were declared apart. The pass that put the control height on everything reached one of them and not the other, so a 40px pill stood beside a 20px one - same radius, visibly different shapes - and nothing went red, because each rule was internally fine.

They are one rule now: one height from the control token, one border, one radius, one padding, and the text at the body size. 12px on a bar control is a caption size, and these are things you read and press.

This page had already learned it once, on the browser bar, where the address was 24 tall, the Live and Frozen pair 30 and the layout picker 30. The lesson was written down and applied there and nowhere else, which is the shape this file keeps producing: a rule that stops being enforced one bar over. There is a gate for it now.

Three known-bad mutations, all killed. The gate's first version accused the very rule it exists to require, because the string  appears inside .