### PR TITLE
The event stream wrote out its own framing seven times

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.37.0"
+version = "0.38.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/chat.py
+++ b/src/aihawk/chat.py
@@ -26,214 +26,214 @@ DEFAULT_CHAT_ID = "default"
 UNNAMED = "New chat"
 
 
-class ChatService:
-    """One conversation, its listeners, and the link it drives."""
-
-    def __init__(self, link: Link, brain: Brain,
-                 model_label: str = "no model", *,
-                 session_id: str = DEFAULT_CHAT_ID,
-                 name: str | None = None) -> None:
-        self._link = link
-        self._brain = brain
-        self._listeners: List[asyncio.Queue] = []
-        self.history: List[Dict[str, str]] = []
-        self.session_id = session_id
-        self.name = name or UNNAMED
-        self.model_label = model_label
-        self._busy = asyncio.Lock()
-        self._task: Optional[asyncio.Task] = None
-        #: Which conversation the history belongs to. A reconnecting page says
-        #: how far it got with `Last-Event-ID`, and that position only means
-        #: something inside one conversation: after a reset, or after the
-        #: process restarts, the same number points at a different transcript.
-        #: Counted from the clock so a restart cannot collide with the run
-        #: before it.
-        self._epoch = str(int(time.time() * 1000))
-
-    @property
-    def link(self):
-        """The connection this conversation drives, addressed to it.
-
-        Exposed because the LIVE routes need it: the picture and the tab strip
-        belong to this session's browser, and reaching for the shared connection
-        instead would draw whatever the default session happens to be looking
-        at. That is a wrong answer that looks exactly like a right one.
-        """
-        return self._link
-
-    def save(self) -> None:
-        """Write this conversation down as it stands.
-
-        Called when the conversation CHANGES - a turn ended, it was renamed, it
-        was reset - and not on a timer, for the reason the browsers are saved
-        the same way: a file written on a tick is a version of the session that
-        existed only between two ticks.
-
-        ⛔ BOTH TRANSCRIPTS, and saving only one would be a promise the other
-        half cannot keep. The page draws `history`; the model holds `messages`.
-        Reopening with only the first gives somebody a conversation they can
-        read and cannot continue, under a follow-up box that still says "and now
-        sort them by price" will work.
-
-        A write that fails costs the saved conversation and nothing else: the
-        turn is already finished and answered, and losing it to a full disk
-        would be a strange way to report a full disk.
-        """
-        try:
-            store.save_chat(self.session_id, self.name, self.history,
-                            list(getattr(self._brain, "messages", []) or []),
-                            self.usage)
-        except Exception:
-            pass
-
-    def restore(self) -> bool:
-        """Read this conversation back, if one was saved. Answers whether it was.
-
-        The epoch is NOT restored, and that is deliberate: it says which
-        transcript a page's positions belong to, and a page reconnecting from
-        before the restart holds positions into a transcript this process never
-        had. A new epoch makes it replay from the beginning instead of resuming
-        into the middle of something else.
-        """
-        saved = store.load_chat(self.session_id)
-        if not saved:
-            return False
-        self.history = list(saved.get("history") or [])
-        self.name = saved.get("name") or self.name
-        messages = saved.get("messages") or []
-        remember = getattr(self._brain, "remember", None)
-        if callable(remember) and messages:
-            remember(messages, saved.get("usage") or {})
-        return True
-
-    def subscribe(self) -> asyncio.Queue:
-        q: asyncio.Queue = asyncio.Queue()
-        self._listeners.append(q)
-        return q
-
-    def unsubscribe(self, q: asyncio.Queue) -> None:
-        if q in self._listeners:
-            self._listeners.remove(q)
-
-    async def emit(self, kind: str, text: str) -> None:
-        event = {"kind": kind, "text": text}
-        # `busy` is STATE, not conversation: replaying it to somebody who
-        # opens the page later would show a spinner for work that finished
-        # an hour ago.
-        if kind != "busy":
-            self.history.append(event)
-        for q in list(self._listeners):
-            q.put_nowait(event)
-
-    def reset(self) -> bool:
-        """Start a fresh conversation, keeping the browser where it is.
-
-        ⛔ THIS IS A COST AND LATENCY CONTROL, not a tidiness feature, and
-        until it existed there was no way to reach it short of killing the
-        process. Every turn resends the whole transcript, so the transcript is
-        the bill and it is also the wait: measured on this interface, a first
-        instruction on a fresh process carries 3,106 prompt tokens and the
-        agent moves 4.1 s after the click; by the third instruction of the same
-        session the first turn already carries 38,207 and the wait is 6.7 s.
-        Nothing trimmed it, so it only grew.
-
-        The browser is deliberately left alone. Someone who has logged in
-        somewhere and wants to drop the transcript should not lose the session
-        they built, and the two have no reason to be tied.
-
-        Refused while a run is in flight rather than cancelling it: throwing
-        away a transcript that something is still writing into is the kind of
-        surprise a person cannot undo.
-        """
-        if self.busy:
-            return False
-        forget = getattr(self._brain, "forget", None)
-        if callable(forget):
-            forget()
-        self.history.clear()
-        self._epoch = str(int(time.time() * 1000))
-        return True
-
-    @property
-    def epoch(self) -> str:
-        """Which transcript the history positions belong to."""
-        return self._epoch
-
-    @property
-    def usage(self) -> dict:
-        """What this conversation has cost, for the file it is saved into.
-
-        Read through the brain rather than kept here: the brain owns the
-        transcript, so it owns what the transcript has cost. It is no longer
-        sent anywhere - the meter that drew it is gone - but it is still counted
-        and still saved, so putting a number back on the screen is a question of
-        where to draw it and not of measuring it again.
-        """
-        got = getattr(self._brain, "usage", None)
-        return dict(got) if isinstance(got, dict) else {}
-
-    @property
-    def busy(self) -> bool:
-        """Whether an instruction is in flight, for a listener joining now.
-
-        The lock and not the task handle: the lock is held for exactly as long
-        as `send` runs, which is the span the page draws as busy, while the
-        handle survives its own task and would answer for a run that ended.
-        """
-        return self._busy.locked()
-
-    def start(self, text: str) -> None:
-        """Run an instruction detached, keeping the handle so it can be stopped.
-
-        The task is held for exactly that reason. Firing and forgetting is one
-        line shorter and makes the stop button a decoration.
-        """
-        self._task = asyncio.create_task(self.send(text))
-
-    def stop(self) -> bool:
-        t = self._task
-        if t is not None and not t.done():
-            t.cancel()
-            return True
-        return False
-
-    async def send(self, text: str) -> None:
-        async with self._busy:
-            # Emitted here and not added by the page, so the instruction is part
-            # of the transcript: somebody opening the page mid-run sees what was
-            # asked, and a reload does not lose it. The page adding it locally is
-            # one line shorter and leaves a conversation with no questions in it.
-            if self.name == UNNAMED:
-                # Named from what it was first asked, because a column of eight
-                # rows that all say "New chat" is a column nobody can use, and
-                # asking somebody to name a conversation before having it is
-                # asking them to describe work they have not done yet.
-                flat = " ".join(text.split())
-                self.name = flat[:48] + ("..." if len(flat) > 48 else "")
-            await self.emit("you", text)
-            await self.emit("busy", "1")
-            try:
-                await self._brain.handle(text, self._link, self.emit)
-            except asyncio.CancelledError:
-                # The cancellation lands at the next await, and since the model
-                # request runs in a thread that is either the request itself or
-                # the tool call after it - so stop is prompt rather than "after
-                # the step in flight", which is what this comment used to say
-                # and what the loop used to do.
-                #
-                # Prompt is not free: a model request already sent finishes in
-                # its thread and its answer is discarded, so a run stopped
-                # mid-turn is still billed for that reply. Stopping cuts what
-                # comes next, never what is already in the air.
-                await self.emit("err", "stopped")
-                raise
-            except Exception as exc:
-                await self.emit("err", f"{type(exc).__name__}: {exc}")
-            finally:
-                await self.emit("busy", "0")
-                # After the turn and not during it: a transcript written
-                # mid-run is a version of the conversation that existed for a
-                # moment, and this is the moment it is worth keeping. Stopped
-                # and failed runs are saved too - what was asked and how far it
-                # got is exactly what somebody reopens the session to see.
-                self.save()
+class ChatService:
+    """One conversation, its listeners, and the link it drives."""
+
+    def __init__(self, link: Link, brain: Brain,
+                 model_label: str = "no model", *,
+                 session_id: str = DEFAULT_CHAT_ID,
+                 name: str | None = None) -> None:
+        self._link = link
+        self._brain = brain
+        self._listeners: List[asyncio.Queue] = []
+        self.history: List[Dict[str, str]] = []
+        self.session_id = session_id
+        self.name = name or UNNAMED
+        self.model_label = model_label
+        self._busy = asyncio.Lock()
+        self._task: Optional[asyncio.Task] = None
+        #: Which conversation the history belongs to. A reconnecting page says
+        #: how far it got with `Last-Event-ID`, and that position only means
+        #: something inside one conversation: after a reset, or after the
+        #: process restarts, the same number points at a different transcript.
+        #: Counted from the clock so a restart cannot collide with the run
+        #: before it.
+        self._epoch = str(int(time.time() * 1000))
+
+    @property
+    def link(self):
+        """The connection this conversation drives, addressed to it.
+
+        Exposed because the LIVE routes need it: the picture and the tab strip
+        belong to this session's browser, and reaching for the shared connection
+        instead would draw whatever the default session happens to be looking
+        at. That is a wrong answer that looks exactly like a right one.
+        """
+        return self._link
+
+    def save(self) -> None:
+        """Write this conversation down as it stands.
+
+        Called when the conversation CHANGES - a turn ended, it was renamed, it
+        was reset - and not on a timer, for the reason the browsers are saved
+        the same way: a file written on a tick is a version of the session that
+        existed only between two ticks.
+
+        ⛔ BOTH TRANSCRIPTS, and saving only one would be a promise the other
+        half cannot keep. The page draws `history`; the model holds `messages`.
+        Reopening with only the first gives somebody a conversation they can
+        read and cannot continue, under a follow-up box that still says "and now
+        sort them by price" will work.
+
+        A write that fails costs the saved conversation and nothing else: the
+        turn is already finished and answered, and losing it to a full disk
+        would be a strange way to report a full disk.
+        """
+        try:
+            store.save_chat(self.session_id, self.name, self.history,
+                            list(getattr(self._brain, "messages", []) or []),
+                            self.usage)
+        except Exception:
+            pass
+
+    def restore(self) -> bool:
+        """Read this conversation back, if one was saved. Answers whether it was.
+
+        The epoch is NOT restored, and that is deliberate: it says which
+        transcript a page's positions belong to, and a page reconnecting from
+        before the restart holds positions into a transcript this process never
+        had. A new epoch makes it replay from the beginning instead of resuming
+        into the middle of something else.
+        """
+        saved = store.load_chat(self.session_id)
+        if not saved:
+            return False
+        self.history = list(saved.get("history") or [])
+        self.name = saved.get("name") or self.name
+        messages = saved.get("messages") or []
+        remember = getattr(self._brain, "remember", None)
+        if callable(remember) and messages:
+            remember(messages, saved.get("usage") or {})
+        return True
+
+    def subscribe(self) -> asyncio.Queue:
+        q: asyncio.Queue = asyncio.Queue()
+        self._listeners.append(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue) -> None:
+        if q in self._listeners:
+            self._listeners.remove(q)
+
+    async def emit(self, kind: str, text: str) -> None:
+        event = {"kind": kind, "text": text}
+        # `busy` is STATE, not conversation: replaying it to somebody who
+        # opens the page later would show a spinner for work that finished
+        # an hour ago.
+        if kind != "busy":
+            self.history.append(event)
+        for q in list(self._listeners):
+            q.put_nowait(event)
+
+    def reset(self) -> bool:
+        """Start a fresh conversation, keeping the browser where it is.
+
+        ⛔ THIS IS A COST AND LATENCY CONTROL, not a tidiness feature, and
+        until it existed there was no way to reach it short of killing the
+        process. Every turn resends the whole transcript, so the transcript is
+        the bill and it is also the wait: measured on this interface, a first
+        instruction on a fresh process carries 3,106 prompt tokens and the
+        agent moves 4.1 s after the click; by the third instruction of the same
+        session the first turn already carries 38,207 and the wait is 6.7 s.
+        Nothing trimmed it, so it only grew.
+
+        The browser is deliberately left alone. Someone who has logged in
+        somewhere and wants to drop the transcript should not lose the session
+        they built, and the two have no reason to be tied.
+
+        Refused while a run is in flight rather than cancelling it: throwing
+        away a transcript that something is still writing into is the kind of
+        surprise a person cannot undo.
+        """
+        if self.busy:
+            return False
+        forget = getattr(self._brain, "forget", None)
+        if callable(forget):
+            forget()
+        self.history.clear()
+        self._epoch = str(int(time.time() * 1000))
+        return True
+
+    @property
+    def epoch(self) -> str:
+        """Which transcript the history positions belong to."""
+        return self._epoch
+
+    @property
+    def usage(self) -> dict:
+        """What this conversation has cost, for the file it is saved into.
+
+        Read through the brain rather than kept here: the brain owns the
+        transcript, so it owns what the transcript has cost. It is no longer
+        sent anywhere - the meter that drew it is gone - but it is still counted
+        and still saved, so putting a number back on the screen is a question of
+        where to draw it and not of measuring it again.
+        """
+        got = getattr(self._brain, "usage", None)
+        return dict(got) if isinstance(got, dict) else {}
+
+    @property
+    def busy(self) -> bool:
+        """Whether an instruction is in flight, for a listener joining now.
+
+        The lock and not the task handle: the lock is held for exactly as long
+        as `send` runs, which is the span the page draws as busy, while the
+        handle survives its own task and would answer for a run that ended.
+        """
+        return self._busy.locked()
+
+    def start(self, text: str) -> None:
+        """Run an instruction detached, keeping the handle so it can be stopped.
+
+        The task is held for exactly that reason. Firing and forgetting is one
+        line shorter and makes the stop button a decoration.
+        """
+        self._task = asyncio.create_task(self.send(text))
+
+    def stop(self) -> bool:
+        t = self._task
+        if t is not None and not t.done():
+            t.cancel()
+            return True
+        return False
+
+    async def send(self, text: str) -> None:
+        async with self._busy:
+            # Emitted here and not added by the page, so the instruction is part
+            # of the transcript: somebody opening the page mid-run sees what was
+            # asked, and a reload does not lose it. The page adding it locally is
+            # one line shorter and leaves a conversation with no questions in it.
+            if self.name == UNNAMED:
+                # Named from what it was first asked, because a column of eight
+                # rows that all say "New chat" is a column nobody can use, and
+                # asking somebody to name a conversation before having it is
+                # asking them to describe work they have not done yet.
+                flat = " ".join(text.split())
+                self.name = flat[:48] + ("..." if len(flat) > 48 else "")
+            await self.emit("you", text)
+            await self.emit("busy", "1")
+            try:
+                await self._brain.handle(text, self._link, self.emit)
+            except asyncio.CancelledError:
+                # The cancellation lands at the next await, and since the model
+                # request runs in a thread that is either the request itself or
+                # the tool call after it - so stop is prompt rather than "after
+                # the step in flight", which is what this comment used to say
+                # and what the loop used to do.
+                #
+                # Prompt is not free: a model request already sent finishes in
+                # its thread and its answer is discarded, so a run stopped
+                # mid-turn is still billed for that reply. Stopping cuts what
+                # comes next, never what is already in the air.
+                await self.emit("err", "stopped")
+                raise
+            except Exception as exc:
+                await self.emit("err", f"{type(exc).__name__}: {exc}")
+            finally:
+                await self.emit("busy", "0")
+                # After the turn and not during it: a transcript written
+                # mid-run is a version of the conversation that existed for a
+                # moment, and this is the moment it is worth keeping. Stopped
+                # and failed runs are saved too - what was asked and how far it
+                # got is exactly what somebody reopens the session to see.
+                self.save()

--- a/src/aihawk/routes.py
+++ b/src/aihawk/routes.py
@@ -18,6 +18,59 @@ from .sessions import SessionGone, Sessions
 from .ui import PAGE
 
 
+def sse(payload: dict, at: str | None = None) -> bytes:
+    """One event, framed the way `EventSource` reads them.
+
+    ⛔ ONE PLACE KNOWS THE FRAMING, where seven wrote it out by hand. The
+    framing is three details a reader skims past - the `id:` line before the
+    `data:` line, the single newline between them, the blank line that ends the
+    event - and every one of them is load-bearing: a missing blank line makes
+    two events arrive as one and neither is delivered. Written seven times it
+    was seven chances to get one of them wrong in a way no test looked at.
+
+    `at` is the resume point, and leaving it out is meaningful rather than
+    lazy: an id MOVES that point, so state which is not a place to resume from
+    is sent without one, and the spec then keeps the last id standing.
+    """
+    head = (b"id: " + at.encode() + b"\n") if at else b""
+    return head + b"data: " + json.dumps(payload).encode() + b"\n\n"
+
+
+def marker_at(epoch: str, position: int) -> str:
+    """The resume point for this position of this transcript."""
+    return "%s:%d" % (epoch, position)
+
+
+def resume_point(marker: str, epoch: str) -> tuple[int, bool]:
+    """Where a reconnecting listener got to, and whether it is even the same
+    conversation. Answers `(the first event it still needs, same transcript)`.
+
+    ⛔ THE EPOCH IS HALF THE ANSWER. A position only means something inside one
+    transcript: after a reset, or after the process restarts, the same number
+    points at something else entirely, so a mismatch is not a resume at all -
+    it replays from the beginning and the page is told to drop what it holds
+    rather than grow a chimera.
+
+    Written beside `marker_at`, which is the only thing that produces what this
+    reads, so the two cannot drift apart.
+    """
+    if ":" not in marker:
+        return 0, False
+    said, _, position = marker.partition(":")
+    if said != epoch or not position.isdigit():
+        return 0, False
+    return int(position) + 1, True
+
+
+#: The answer when there is nothing to say, in the shape of the answer when
+#: there is. The page reads the same fields either way, so an empty reply that
+#: omits a field is a reply the page cannot read - and both of these are given
+#: on paths that exist precisely because something went wrong or is missing,
+#: which is where a shape written out a second time drifts unnoticed.
+NO_BROWSERS = {"browsers": [], "focus": "", "limit": 0}
+NO_TABS = {"url": "", "tabs": []}
+
+
 def build_app(link: Link, sessions: "Sessions") -> Starlette:
     def named(session_id: str | None) -> ChatService:
         """The conversation with this id, refusing one nobody declared.
@@ -114,37 +167,27 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
         # copy of everything. Measured: three consecutive subscriptions each
         # received all 21 events of the same conversation.
         #
-        # The epoch is the other half. A position only means something inside
-        # one transcript: after a reset, or after the process restarts, the
-        # same number points at something else entirely, so a mismatch replays
-        # from the beginning - and says `fresh` first, so a page holding the
-        # previous conversation drops it instead of growing a chimera.
-        resume_from, same_conversation = 0, False
+        # What the header means, and why a position alone is not enough, is in
+        # `resume_point`. It is not repeated here: written in both places it
+        # would be two accounts of one rule, free to disagree.
         marker = request.headers.get("last-event-id") or ""
-        if ":" in marker:
-            epoch, _, index = marker.partition(":")
-            if epoch == service.epoch and index.isdigit():
-                resume_from = int(index) + 1
-                same_conversation = True
+        resume_from, same_conversation = resume_point(marker, service.epoch)
         replay = history[resume_from:] if same_conversation else history
 
         async def stream() -> AsyncIterator[bytes]:
             try:
-                yield b"data: " + json.dumps(
-                    {"kind": "model", "text": service.model_label}).encode() + b"\n\n"
+                yield sse({"kind": "model", "text": service.model_label})
                 if not same_conversation and marker:
                     # It reconnected carrying a position from another
                     # transcript, so what it is still showing is not this one.
-                    yield b"data: " + json.dumps(
-                        {"kind": "fresh", "text": "1"}).encode() + b"\n\n"
+                    yield sse({"kind": "fresh", "text": "1"})
                 # Flagged as replay so the page does not animate forty rows at
                 # once and does not start a stopwatch on work that finished
                 # before this listener existed. Numbered so the next
                 # reconnection can say where it got to instead of starting over.
                 for offset, past in enumerate(replay):
-                    yield (b"id: " + ("%s:%d" % (service.epoch, resume_from + offset)).encode()
-                           + b"\ndata: " + json.dumps({**past, "replay": True}).encode()
-                           + b"\n\n")
+                    yield sse({**past, "replay": True},
+                              marker_at(service.epoch, resume_from + offset))
                 # And then the CURRENT state, which the replay above cannot
                 # carry: `emit` keeps `busy` out of the history on purpose, so a
                 # page opened long after a run would not show a spinner for work
@@ -173,11 +216,9 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
                 # it should call `waiting()`, and a run in progress would lose
                 # its clock.
                 if joining_a_run:
-                    yield b"data: " + json.dumps(
-                        {"kind": "busy", "text": "1"}).encode() + b"\n\n"
+                    yield sse({"kind": "busy", "text": "1"})
                 else:
-                    yield b"data: " + json.dumps(
-                        {"kind": "busy", "text": "0", "replay": True}).encode() + b"\n\n"
+                    yield sse({"kind": "busy", "text": "0", "replay": True})
                 while True:
                     event = await q.get()
                     # Only what the history keeps is numbered: an id moves the
@@ -185,11 +226,10 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
                     # Leaving the field out keeps the last one,
                     # which is what the spec says and what is wanted here.
                     if event["kind"] in ("busy", "fresh"):
-                        yield b"data: " + json.dumps(event).encode() + b"\n\n"
+                        yield sse(event)
                     else:
-                        yield (b"id: " + ("%s:%d" % (service.epoch,
-                                                     len(service.history) - 1)).encode()
-                               + b"\ndata: " + json.dumps(event).encode() + b"\n\n")
+                        yield sse(event, marker_at(service.epoch,
+                                                   len(service.history) - 1))
             finally:
                 service.unsubscribe(q)
 
@@ -267,9 +307,9 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
             # An older server answered this in prose. The workspace then draws
             # nothing rather than half of something, and the single live pane -
             # which does not need this - keeps working.
-            return JSONResponse({"browsers": [], "focus": "", "limit": 0})
+            return JSONResponse(NO_BROWSERS)
         if not isinstance(got, dict):
-            return JSONResponse({"browsers": [], "focus": "", "limit": 0})
+            return JSONResponse(NO_BROWSERS)
         return JSONResponse({"browsers": got.get("browsers") or [],
                              "focus": got.get("focus") or "",
                              "limit": got.get("limit") or 0})
@@ -290,7 +330,7 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
         """
         seen = which(request)
         if not seen.link.touched:
-            return JSONResponse({"url": "", "tabs": []})
+            return JSONResponse(NO_TABS)
         # ⛔ WHICH BROWSER, like the frame route beside it. The address above the
         # stage has to be the address of the screen being looked at, and with
         # more than one screen the answer stopped being "the focused one" the
@@ -302,9 +342,9 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
                 {"browser_id": watching} if watching else None)
             rows = json.loads(raw)
         except Exception:
-            return JSONResponse({"url": "", "tabs": []})
+            return JSONResponse(NO_TABS)
         if not isinstance(rows, list) or not all(isinstance(r, dict) for r in rows):
-            return JSONResponse({"url": "", "tabs": []})
+            return JSONResponse(NO_TABS)
         here = next((r for r in rows if r.get("active")), rows[0] if rows else {})
         return JSONResponse({"url": here.get("url") or "", "tabs": rows})
 

--- a/src/aihawk/routes.py
+++ b/src/aihawk/routes.py
@@ -18,329 +18,329 @@ from .sessions import SessionGone, Sessions
 from .ui import PAGE
 
 
-def build_app(link: Link, sessions: "Sessions") -> Starlette:
-    def named(session_id: str | None) -> ChatService:
-        """The conversation with this id, refusing one nobody declared.
-
-        ⛔ ONE PLACE TURNS AN ID OFF THE WIRE INTO A CONVERSATION, because the
-        id does not always arrive the same way: eight routes carry it in the
-        query string and the rename carries it in the body. Written twice, the
-        rename is where it would have gone on resurrecting deleted sessions
-        after the eight beside it had stopped.
-        """
-        if not sessions.knows(session_id):
-            raise SessionGone(session_id or "")
-        return sessions.get(session_id)
-
-    def which(request: Request) -> ChatService:
-        """The conversation this request is about.
-
-        ⛔ EVERY ROUTE GOES THROUGH HERE, the live ones included. A route that
-        read the session id and a route that did not would act on two different
-        conversations while the page showed one, and the way that fails is the
-        picture on the right belonging to somebody else's browser. A caller that
-        names nothing gets the default conversation, which is what every page
-        written before this existed does.
-
-        ⛔ AND IT REFUSES AN ID NOBODY DECLARED, instead of declaring it. A
-        request is a way to look at a conversation, never a way to start one -
-        `/sessions/new` is. See `Sessions.knows` for what a page left open on a
-        deleted session did to it.
-        """
-        return named(request.query_params.get("s"))
-
-    async def root(_request: Request) -> HTMLResponse:
-        return HTMLResponse(PAGE)
-
-    async def listing(_request: Request) -> JSONResponse:
-        return JSONResponse({"sessions": sessions.listing(),
-                             "default": DEFAULT_CHAT_ID})
-
-    async def new_session(_request: Request) -> JSONResponse:
-        service = sessions.new()
-        return JSONResponse({"id": service.session_id, "name": service.name})
-
-    async def rename_session(request: Request) -> JSONResponse:
-        body = await request.json()
-        at = (body or {}).get("id") or DEFAULT_CHAT_ID
-        service = named(at)
-        done = sessions.rename(at, (body or {}).get("name", ""))
-        return JSONResponse({"renamed": done, "name": service.name})
-
-    async def forget_session(request: Request) -> JSONResponse:
-        body = await request.json()
-        at = (body or {}).get("id")
-        if not at:
-            return JSONResponse({"error": "no id"}, status_code=400)
-        return JSONResponse({"forgotten": await sessions.forget(at)})
-
-    async def send(request: Request) -> JSONResponse:
-        body = await request.json()
-        text = (body or {}).get("text", "")
-        if not text:
-            return JSONResponse({"error": "empty"}, status_code=400)
-        which(request).start(text)
-        return JSONResponse({"accepted": True})
-
-    async def stop(request: Request) -> JSONResponse:
-        return JSONResponse({"stopped": which(request).stop()})
-
-    async def fresh(request: Request) -> JSONResponse:
-        service = which(request)
-        done = service.reset()
-        if done:
-            # Told to every listener, not just the tab that asked: two tabs on
-            # one session must not disagree about what the conversation is.
-            await service.emit("fresh", "1")
-            service.save()
-        return JSONResponse({"fresh": done})
-
-    async def events(request: Request) -> StreamingResponse:
-        service = which(request)
-        q = service.subscribe()
-        # Freeze the replay/live boundary while subscribing. StreamingResponse
-        # starts `stream` later, so taking this snapshot inside it would let an
-        # intervening event appear in both history and the listener's queue.
-        history = list(service.history)
-        # Taken with the snapshot, for the same reason: whether a run is in
-        # flight is part of the state this listener is joining.
-        joining_a_run = service.busy
-
-        # ⛔ WHERE THIS LISTENER GOT TO, AND WHETHER IT IS EVEN THE SAME
-        # CONVERSATION. `EventSource` reconnects by itself after any drop, and
-        # until this was read the server answered every reconnection with the
-        # whole transcript again, while the page - which has no de-duplication
-        # and had never been given an id to resume from - appended a second
-        # copy of everything. Measured: three consecutive subscriptions each
-        # received all 21 events of the same conversation.
-        #
-        # The epoch is the other half. A position only means something inside
-        # one transcript: after a reset, or after the process restarts, the
-        # same number points at something else entirely, so a mismatch replays
-        # from the beginning - and says `fresh` first, so a page holding the
-        # previous conversation drops it instead of growing a chimera.
-        resume_from, same_conversation = 0, False
-        marker = request.headers.get("last-event-id") or ""
-        if ":" in marker:
-            epoch, _, index = marker.partition(":")
-            if epoch == service.epoch and index.isdigit():
-                resume_from = int(index) + 1
-                same_conversation = True
-        replay = history[resume_from:] if same_conversation else history
-
-        async def stream() -> AsyncIterator[bytes]:
-            try:
-                yield b"data: " + json.dumps(
-                    {"kind": "model", "text": service.model_label}).encode() + b"\n\n"
-                if not same_conversation and marker:
-                    # It reconnected carrying a position from another
-                    # transcript, so what it is still showing is not this one.
-                    yield b"data: " + json.dumps(
-                        {"kind": "fresh", "text": "1"}).encode() + b"\n\n"
-                # Flagged as replay so the page does not animate forty rows at
-                # once and does not start a stopwatch on work that finished
-                # before this listener existed. Numbered so the next
-                # reconnection can say where it got to instead of starting over.
-                for offset, past in enumerate(replay):
-                    yield (b"id: " + ("%s:%d" % (service.epoch, resume_from + offset)).encode()
-                           + b"\ndata: " + json.dumps({**past, "replay": True}).encode()
-                           + b"\n\n")
-                # And then the CURRENT state, which the replay above cannot
-                # carry: `emit` keeps `busy` out of the history on purpose, so a
-                # page opened long after a run would not show a spinner for work
-                # that ended an hour ago. That is right for a finished run and
-                # wrong for one still going - the page would show a transcript
-                # growing under a composer that says nothing is happening, and
-                # with no turn ceiling the stop button is the only thing that
-                # ends such a run. So it is sent as what it is, the present, and
-                # only when true: a page starts out believing it is idle.
-                # ⛔ AND IT IS SENT WHEN FALSE TOO, WHICH IS NOT SYMMETRY FOR
-                # ITS OWN SAKE: without it the last thing the model said was
-                # never drawn. The page holds one narration line back so that a
-                # sentence with tool calls after it reads as their lead-in and
-                # one with nothing after it reads as the answer, and the event
-                # that resolves that lookahead is the end of the turn - which
-                # is a `busy` going false. A replay carries no `busy` at all, so
-                # a page reopening a FINISHED conversation sat holding its last
-                # sentence forever. Measured on the developer's own saved
-                # session: 257 events ending in `said`, and the answer to the
-                # last thing they asked was not on the screen.
-                # Marked as replay so it flushes without animating one row and
-                # without redrawing the session list, exactly like the events
-                # above it.
-                # The two are NOT one line with a conditional inside: the live
-                # one must arrive unflagged or the page calls `waited()` where
-                # it should call `waiting()`, and a run in progress would lose
-                # its clock.
-                if joining_a_run:
-                    yield b"data: " + json.dumps(
-                        {"kind": "busy", "text": "1"}).encode() + b"\n\n"
-                else:
-                    yield b"data: " + json.dumps(
-                        {"kind": "busy", "text": "0", "replay": True}).encode() + b"\n\n"
-                while True:
-                    event = await q.get()
-                    # Only what the history keeps is numbered: an id moves the
-                    # resume point, and `busy` is not a place to resume from.
-                    # Leaving the field out keeps the last one,
-                    # which is what the spec says and what is wanted here.
-                    if event["kind"] in ("busy", "fresh"):
-                        yield b"data: " + json.dumps(event).encode() + b"\n\n"
-                    else:
-                        yield (b"id: " + ("%s:%d" % (service.epoch,
-                                                     len(service.history) - 1)).encode()
-                               + b"\ndata: " + json.dumps(event).encode() + b"\n\n")
-            finally:
-                service.unsubscribe(q)
-
-        return StreamingResponse(stream(), media_type="text/event-stream",
-                                 headers={"Cache-Control": "no-store"})
-
-    async def frame(request: Request) -> Response:
-        """The window the active tab lives in, as `browser_watch` captures it.
-
-        Not `browser_take_screenshot`: that is the page alone, and the engine
-        draws the pointer outside the page on purpose, so no screenshot can
-        show it. The window capture shows the pointer, the tab strip and the
-        address bar, keeps answering while a page loads, and costs one frame
-        the server already holds rather than a paint. The tool exists from
-        0.15.0 of the server, which is the floor pyproject declares.
-
-        The strip and the address in the picture are pixels; the ones the
-        page draws above it are the same facts as elements, and those can be
-        clicked and copied. Both stay.
-        """
-        seen = which(request)
-        if not seen.link.touched:
-            # 204, not an error: nothing is wrong, there is simply nothing to
-            # look at. Asking the server would START a browser, which is exactly
-            # what a view is not allowed to cause - and it is asked of THIS
-            # conversation, so opening a second chat does not launch an engine
-            # to draw a pane for a session that has done nothing.
-            return Response(status_code=204)
-        # ⛔ THE PANE SAYS WHICH BROWSER, and without that the workspace is one
-        # picture drawn eight times. `browser_id` is the caller's to choose here
-        # exactly as `session_id` is not: which SESSION a request belongs to is
-        # decided by the page's own url and imposed, while which BROWSER inside
-        # it a pane is watching is what the pane is for.
-        watching = request.query_params.get("b") or None
-        try:
-            result = await seen.link.call("browser_watch",
-                                          {"browser_id": watching} if watching else {})
-        except Exception as exc:
-            return JSONResponse({"error": str(exc)[:200]}, status_code=503)
-        got = image_of(result)
-        if got is None:
-            # A tool that raised reaches a client as an error RESULT with the
-            # reason as text, not as an exception: an engine without the
-            # screencast, or a window captured as nothing. That is a 503 with
-            # the reason, never a 204, which would read as "nothing to look at"
-            # in the one case where a person needs to read a sentence.
-            reason = text_of(result) if getattr(result, "isError", False) else ""
-            if reason:
-                return JSONResponse({"error": reason[:200]}, status_code=503)
-            return Response(status_code=204)
-        jpeg, mime = got
-        return Response(jpeg, media_type=mime, headers={"Cache-Control": "no-store"})
-
-    async def browsers(request: Request) -> JSONResponse:
-        """The panes to draw: which browsers this session holds, and where.
-
-        Asked of the server through the same tool an agent would call, because
-        the interface has no privileged path to the browsers - and it starts
-        nothing, so drawing the workspace can never cost an engine.
-
-        ⛔ AND IT ASKS EVEN WHEN THIS CONVERSATION HAS DONE NOTHING, which is
-        the opposite of what the picture and the tab strip do. Those may not ask
-        before an instruction because asking STARTS a browser; `browser_list` is
-        the one question that starts nothing, by construction and by its own
-        test. Copying the guard here looked prudent and was a bug: a session
-        reopened after a restart has browsers it declared and no instruction
-        yet, so the workspace would have been empty in exactly the case the
-        declarations exist for - and the panes offering to wake them would
-        never have been drawn.
-        """
-        seen = which(request)
-        try:
-            got = json.loads(await seen.link.call_text("browser_list"))
-        except Exception:
-            # An older server answered this in prose. The workspace then draws
-            # nothing rather than half of something, and the single live pane -
-            # which does not need this - keeps working.
-            return JSONResponse({"browsers": [], "focus": "", "limit": 0})
-        if not isinstance(got, dict):
-            return JSONResponse({"browsers": [], "focus": "", "limit": 0})
-        return JSONResponse({"browsers": got.get("browsers") or [],
-                             "focus": got.get("focus") or "",
-                             "limit": got.get("limit") or 0})
-
-    async def tabs(request: Request) -> JSONResponse:
-        """Every tab, and which one is current.
-
-        ONE call where there were two. It asks `session_list_pages`, which since
-        0.9.0 of the server answers with id, title, url and active - the four
-        fields its description had always promised and had never returned. While
-        it returned ids only this had to ask `browser_evaluate` for
-        `location.href` instead, which is script in the page to learn something
-        the server already knew.
-
-        A stale or older server is not an error here: anything that does not
-        parse into those fields leaves the strip empty and the address blank,
-        and the pane keeps working as a picture.
-        """
-        seen = which(request)
-        if not seen.link.touched:
-            return JSONResponse({"url": "", "tabs": []})
-        # ⛔ WHICH BROWSER, like the frame route beside it. The address above the
-        # stage has to be the address of the screen being looked at, and with
-        # more than one screen the answer stopped being "the focused one" the
-        # moment clicking a screen became a way to look somewhere else.
-        watching = request.query_params.get("b") or None
-        try:
-            raw = await seen.link.call_text(
-                "session_list_pages",
-                {"browser_id": watching} if watching else None)
-            rows = json.loads(raw)
-        except Exception:
-            return JSONResponse({"url": "", "tabs": []})
-        if not isinstance(rows, list) or not all(isinstance(r, dict) for r in rows):
-            return JSONResponse({"url": "", "tabs": []})
-        here = next((r for r in rows if r.get("active")), rows[0] if rows else {})
-        return JSONResponse({"url": here.get("url") or "", "tabs": rows})
-
-    async def select(request: Request) -> JSONResponse:
-        body = await request.json()
-        page_id = (body or {}).get("id", "")
-        if not page_id:
-            return JSONResponse({"error": "no id"}, status_code=400)
-        await which(request).link.call("session_select_page", {"page_id": page_id})
-        return JSONResponse({"ok": True})
-
-    async def vanished(_request: Request, exc: Exception) -> JSONResponse:
-        """410, because the conversation existed and does not any more.
-
-        Not 404: the page asking is a page that HAD this conversation open, and
-        the difference between "there is no such thing" and "this is over" is
-        the difference between a page that says something wrong happened and a
-        page that says what happened. It is also the only status the page reads
-        as a reason to stop asking - anything else is a failure worth retrying.
-        """
-        return JSONResponse({"error": "this conversation was deleted",
-                             "id": getattr(exc, "session_id", "")},
-                            status_code=410)
-
-    return Starlette(exception_handlers={SessionGone: vanished}, routes=[
-        Route("/", root),
-        Route("/sessions", listing),
-        Route("/sessions/new", new_session, methods=["POST"]),
-        Route("/sessions/rename", rename_session, methods=["POST"]),
-        Route("/sessions/forget", forget_session, methods=["POST"]),
-        Route("/chat/send", send, methods=["POST"]),
-        Route("/chat/stop", stop, methods=["POST"]),
-        Route("/chat/fresh", fresh, methods=["POST"]),
-        Route("/chat/events", events),
-        Route("/live/frame", frame),
-        Route("/live/browsers", browsers),
-        Route("/live/tabs", tabs),
-        Route("/live/select", select, methods=["POST"]),
-    ])
+def build_app(link: Link, sessions: "Sessions") -> Starlette:
+    def named(session_id: str | None) -> ChatService:
+        """The conversation with this id, refusing one nobody declared.
+
+        ⛔ ONE PLACE TURNS AN ID OFF THE WIRE INTO A CONVERSATION, because the
+        id does not always arrive the same way: eight routes carry it in the
+        query string and the rename carries it in the body. Written twice, the
+        rename is where it would have gone on resurrecting deleted sessions
+        after the eight beside it had stopped.
+        """
+        if not sessions.knows(session_id):
+            raise SessionGone(session_id or "")
+        return sessions.get(session_id)
+
+    def which(request: Request) -> ChatService:
+        """The conversation this request is about.
+
+        ⛔ EVERY ROUTE GOES THROUGH HERE, the live ones included. A route that
+        read the session id and a route that did not would act on two different
+        conversations while the page showed one, and the way that fails is the
+        picture on the right belonging to somebody else's browser. A caller that
+        names nothing gets the default conversation, which is what every page
+        written before this existed does.
+
+        ⛔ AND IT REFUSES AN ID NOBODY DECLARED, instead of declaring it. A
+        request is a way to look at a conversation, never a way to start one -
+        `/sessions/new` is. See `Sessions.knows` for what a page left open on a
+        deleted session did to it.
+        """
+        return named(request.query_params.get("s"))
+
+    async def root(_request: Request) -> HTMLResponse:
+        return HTMLResponse(PAGE)
+
+    async def listing(_request: Request) -> JSONResponse:
+        return JSONResponse({"sessions": sessions.listing(),
+                             "default": DEFAULT_CHAT_ID})
+
+    async def new_session(_request: Request) -> JSONResponse:
+        service = sessions.new()
+        return JSONResponse({"id": service.session_id, "name": service.name})
+
+    async def rename_session(request: Request) -> JSONResponse:
+        body = await request.json()
+        at = (body or {}).get("id") or DEFAULT_CHAT_ID
+        service = named(at)
+        done = sessions.rename(at, (body or {}).get("name", ""))
+        return JSONResponse({"renamed": done, "name": service.name})
+
+    async def forget_session(request: Request) -> JSONResponse:
+        body = await request.json()
+        at = (body or {}).get("id")
+        if not at:
+            return JSONResponse({"error": "no id"}, status_code=400)
+        return JSONResponse({"forgotten": await sessions.forget(at)})
+
+    async def send(request: Request) -> JSONResponse:
+        body = await request.json()
+        text = (body or {}).get("text", "")
+        if not text:
+            return JSONResponse({"error": "empty"}, status_code=400)
+        which(request).start(text)
+        return JSONResponse({"accepted": True})
+
+    async def stop(request: Request) -> JSONResponse:
+        return JSONResponse({"stopped": which(request).stop()})
+
+    async def fresh(request: Request) -> JSONResponse:
+        service = which(request)
+        done = service.reset()
+        if done:
+            # Told to every listener, not just the tab that asked: two tabs on
+            # one session must not disagree about what the conversation is.
+            await service.emit("fresh", "1")
+            service.save()
+        return JSONResponse({"fresh": done})
+
+    async def events(request: Request) -> StreamingResponse:
+        service = which(request)
+        q = service.subscribe()
+        # Freeze the replay/live boundary while subscribing. StreamingResponse
+        # starts `stream` later, so taking this snapshot inside it would let an
+        # intervening event appear in both history and the listener's queue.
+        history = list(service.history)
+        # Taken with the snapshot, for the same reason: whether a run is in
+        # flight is part of the state this listener is joining.
+        joining_a_run = service.busy
+
+        # ⛔ WHERE THIS LISTENER GOT TO, AND WHETHER IT IS EVEN THE SAME
+        # CONVERSATION. `EventSource` reconnects by itself after any drop, and
+        # until this was read the server answered every reconnection with the
+        # whole transcript again, while the page - which has no de-duplication
+        # and had never been given an id to resume from - appended a second
+        # copy of everything. Measured: three consecutive subscriptions each
+        # received all 21 events of the same conversation.
+        #
+        # The epoch is the other half. A position only means something inside
+        # one transcript: after a reset, or after the process restarts, the
+        # same number points at something else entirely, so a mismatch replays
+        # from the beginning - and says `fresh` first, so a page holding the
+        # previous conversation drops it instead of growing a chimera.
+        resume_from, same_conversation = 0, False
+        marker = request.headers.get("last-event-id") or ""
+        if ":" in marker:
+            epoch, _, index = marker.partition(":")
+            if epoch == service.epoch and index.isdigit():
+                resume_from = int(index) + 1
+                same_conversation = True
+        replay = history[resume_from:] if same_conversation else history
+
+        async def stream() -> AsyncIterator[bytes]:
+            try:
+                yield b"data: " + json.dumps(
+                    {"kind": "model", "text": service.model_label}).encode() + b"\n\n"
+                if not same_conversation and marker:
+                    # It reconnected carrying a position from another
+                    # transcript, so what it is still showing is not this one.
+                    yield b"data: " + json.dumps(
+                        {"kind": "fresh", "text": "1"}).encode() + b"\n\n"
+                # Flagged as replay so the page does not animate forty rows at
+                # once and does not start a stopwatch on work that finished
+                # before this listener existed. Numbered so the next
+                # reconnection can say where it got to instead of starting over.
+                for offset, past in enumerate(replay):
+                    yield (b"id: " + ("%s:%d" % (service.epoch, resume_from + offset)).encode()
+                           + b"\ndata: " + json.dumps({**past, "replay": True}).encode()
+                           + b"\n\n")
+                # And then the CURRENT state, which the replay above cannot
+                # carry: `emit` keeps `busy` out of the history on purpose, so a
+                # page opened long after a run would not show a spinner for work
+                # that ended an hour ago. That is right for a finished run and
+                # wrong for one still going - the page would show a transcript
+                # growing under a composer that says nothing is happening, and
+                # with no turn ceiling the stop button is the only thing that
+                # ends such a run. So it is sent as what it is, the present, and
+                # only when true: a page starts out believing it is idle.
+                # ⛔ AND IT IS SENT WHEN FALSE TOO, WHICH IS NOT SYMMETRY FOR
+                # ITS OWN SAKE: without it the last thing the model said was
+                # never drawn. The page holds one narration line back so that a
+                # sentence with tool calls after it reads as their lead-in and
+                # one with nothing after it reads as the answer, and the event
+                # that resolves that lookahead is the end of the turn - which
+                # is a `busy` going false. A replay carries no `busy` at all, so
+                # a page reopening a FINISHED conversation sat holding its last
+                # sentence forever. Measured on the developer's own saved
+                # session: 257 events ending in `said`, and the answer to the
+                # last thing they asked was not on the screen.
+                # Marked as replay so it flushes without animating one row and
+                # without redrawing the session list, exactly like the events
+                # above it.
+                # The two are NOT one line with a conditional inside: the live
+                # one must arrive unflagged or the page calls `waited()` where
+                # it should call `waiting()`, and a run in progress would lose
+                # its clock.
+                if joining_a_run:
+                    yield b"data: " + json.dumps(
+                        {"kind": "busy", "text": "1"}).encode() + b"\n\n"
+                else:
+                    yield b"data: " + json.dumps(
+                        {"kind": "busy", "text": "0", "replay": True}).encode() + b"\n\n"
+                while True:
+                    event = await q.get()
+                    # Only what the history keeps is numbered: an id moves the
+                    # resume point, and `busy` is not a place to resume from.
+                    # Leaving the field out keeps the last one,
+                    # which is what the spec says and what is wanted here.
+                    if event["kind"] in ("busy", "fresh"):
+                        yield b"data: " + json.dumps(event).encode() + b"\n\n"
+                    else:
+                        yield (b"id: " + ("%s:%d" % (service.epoch,
+                                                     len(service.history) - 1)).encode()
+                               + b"\ndata: " + json.dumps(event).encode() + b"\n\n")
+            finally:
+                service.unsubscribe(q)
+
+        return StreamingResponse(stream(), media_type="text/event-stream",
+                                 headers={"Cache-Control": "no-store"})
+
+    async def frame(request: Request) -> Response:
+        """The window the active tab lives in, as `browser_watch` captures it.
+
+        Not `browser_take_screenshot`: that is the page alone, and the engine
+        draws the pointer outside the page on purpose, so no screenshot can
+        show it. The window capture shows the pointer, the tab strip and the
+        address bar, keeps answering while a page loads, and costs one frame
+        the server already holds rather than a paint. The tool exists from
+        0.15.0 of the server, which is the floor pyproject declares.
+
+        The strip and the address in the picture are pixels; the ones the
+        page draws above it are the same facts as elements, and those can be
+        clicked and copied. Both stay.
+        """
+        seen = which(request)
+        if not seen.link.touched:
+            # 204, not an error: nothing is wrong, there is simply nothing to
+            # look at. Asking the server would START a browser, which is exactly
+            # what a view is not allowed to cause - and it is asked of THIS
+            # conversation, so opening a second chat does not launch an engine
+            # to draw a pane for a session that has done nothing.
+            return Response(status_code=204)
+        # ⛔ THE PANE SAYS WHICH BROWSER, and without that the workspace is one
+        # picture drawn eight times. `browser_id` is the caller's to choose here
+        # exactly as `session_id` is not: which SESSION a request belongs to is
+        # decided by the page's own url and imposed, while which BROWSER inside
+        # it a pane is watching is what the pane is for.
+        watching = request.query_params.get("b") or None
+        try:
+            result = await seen.link.call("browser_watch",
+                                          {"browser_id": watching} if watching else {})
+        except Exception as exc:
+            return JSONResponse({"error": str(exc)[:200]}, status_code=503)
+        got = image_of(result)
+        if got is None:
+            # A tool that raised reaches a client as an error RESULT with the
+            # reason as text, not as an exception: an engine without the
+            # screencast, or a window captured as nothing. That is a 503 with
+            # the reason, never a 204, which would read as "nothing to look at"
+            # in the one case where a person needs to read a sentence.
+            reason = text_of(result) if getattr(result, "isError", False) else ""
+            if reason:
+                return JSONResponse({"error": reason[:200]}, status_code=503)
+            return Response(status_code=204)
+        jpeg, mime = got
+        return Response(jpeg, media_type=mime, headers={"Cache-Control": "no-store"})
+
+    async def browsers(request: Request) -> JSONResponse:
+        """The panes to draw: which browsers this session holds, and where.
+
+        Asked of the server through the same tool an agent would call, because
+        the interface has no privileged path to the browsers - and it starts
+        nothing, so drawing the workspace can never cost an engine.
+
+        ⛔ AND IT ASKS EVEN WHEN THIS CONVERSATION HAS DONE NOTHING, which is
+        the opposite of what the picture and the tab strip do. Those may not ask
+        before an instruction because asking STARTS a browser; `browser_list` is
+        the one question that starts nothing, by construction and by its own
+        test. Copying the guard here looked prudent and was a bug: a session
+        reopened after a restart has browsers it declared and no instruction
+        yet, so the workspace would have been empty in exactly the case the
+        declarations exist for - and the panes offering to wake them would
+        never have been drawn.
+        """
+        seen = which(request)
+        try:
+            got = json.loads(await seen.link.call_text("browser_list"))
+        except Exception:
+            # An older server answered this in prose. The workspace then draws
+            # nothing rather than half of something, and the single live pane -
+            # which does not need this - keeps working.
+            return JSONResponse({"browsers": [], "focus": "", "limit": 0})
+        if not isinstance(got, dict):
+            return JSONResponse({"browsers": [], "focus": "", "limit": 0})
+        return JSONResponse({"browsers": got.get("browsers") or [],
+                             "focus": got.get("focus") or "",
+                             "limit": got.get("limit") or 0})
+
+    async def tabs(request: Request) -> JSONResponse:
+        """Every tab, and which one is current.
+
+        ONE call where there were two. It asks `session_list_pages`, which since
+        0.9.0 of the server answers with id, title, url and active - the four
+        fields its description had always promised and had never returned. While
+        it returned ids only this had to ask `browser_evaluate` for
+        `location.href` instead, which is script in the page to learn something
+        the server already knew.
+
+        A stale or older server is not an error here: anything that does not
+        parse into those fields leaves the strip empty and the address blank,
+        and the pane keeps working as a picture.
+        """
+        seen = which(request)
+        if not seen.link.touched:
+            return JSONResponse({"url": "", "tabs": []})
+        # ⛔ WHICH BROWSER, like the frame route beside it. The address above the
+        # stage has to be the address of the screen being looked at, and with
+        # more than one screen the answer stopped being "the focused one" the
+        # moment clicking a screen became a way to look somewhere else.
+        watching = request.query_params.get("b") or None
+        try:
+            raw = await seen.link.call_text(
+                "session_list_pages",
+                {"browser_id": watching} if watching else None)
+            rows = json.loads(raw)
+        except Exception:
+            return JSONResponse({"url": "", "tabs": []})
+        if not isinstance(rows, list) or not all(isinstance(r, dict) for r in rows):
+            return JSONResponse({"url": "", "tabs": []})
+        here = next((r for r in rows if r.get("active")), rows[0] if rows else {})
+        return JSONResponse({"url": here.get("url") or "", "tabs": rows})
+
+    async def select(request: Request) -> JSONResponse:
+        body = await request.json()
+        page_id = (body or {}).get("id", "")
+        if not page_id:
+            return JSONResponse({"error": "no id"}, status_code=400)
+        await which(request).link.call("session_select_page", {"page_id": page_id})
+        return JSONResponse({"ok": True})
+
+    async def vanished(_request: Request, exc: Exception) -> JSONResponse:
+        """410, because the conversation existed and does not any more.
+
+        Not 404: the page asking is a page that HAD this conversation open, and
+        the difference between "there is no such thing" and "this is over" is
+        the difference between a page that says something wrong happened and a
+        page that says what happened. It is also the only status the page reads
+        as a reason to stop asking - anything else is a failure worth retrying.
+        """
+        return JSONResponse({"error": "this conversation was deleted",
+                             "id": getattr(exc, "session_id", "")},
+                            status_code=410)
+
+    return Starlette(exception_handlers={SessionGone: vanished}, routes=[
+        Route("/", root),
+        Route("/sessions", listing),
+        Route("/sessions/new", new_session, methods=["POST"]),
+        Route("/sessions/rename", rename_session, methods=["POST"]),
+        Route("/sessions/forget", forget_session, methods=["POST"]),
+        Route("/chat/send", send, methods=["POST"]),
+        Route("/chat/stop", stop, methods=["POST"]),
+        Route("/chat/fresh", fresh, methods=["POST"]),
+        Route("/chat/events", events),
+        Route("/live/frame", frame),
+        Route("/live/browsers", browsers),
+        Route("/live/tabs", tabs),
+        Route("/live/select", select, methods=["POST"]),
+    ])

--- a/src/aihawk/sessions.py
+++ b/src/aihawk/sessions.py
@@ -12,168 +12,168 @@ from .link import Link, SessionLink
 from .mcp import store
 
 
-class SessionGone(Exception):
-    """A request named a conversation that does not exist.
-
-    Its own class rather than an HTTPException so the one handler that answers
-    it lives beside the routes instead of inside each of them: eight routes
-    resolve a session and every one of them would otherwise carry the same
-    three lines, which is how a rule stops being enforced one route later.
-    """
-
-    def __init__(self, session_id: str) -> None:
-        super().__init__(session_id)
-        self.session_id = session_id
-
-class Sessions:
-    """Every conversation this interface holds, by id, saved as it goes.
-
-    ⛔ A CONVERSATION AND ITS BROWSERS ARE ONE SESSION, and this class is where
-    that is true rather than nearly true. The id it keys on is the SAME id the
-    server keys browsers on, so the chat called `lavoro` drives the browsers of
-    session `lavoro` and nothing else - which is why `forget` below closes them
-    as well. Two ids would have been easier and would have meant that deleting a
-    conversation left up to eight engines running with nothing naming them.
-
-    The MCP connection underneath is shared on purpose: one server, one process,
-    one place the browsers live. What keeps two conversations from driving each
-    other's browser is `SessionLink`, which puts the id on every call.
-
-    Conversations are built on demand and read from disk the first time they are
-    asked for. They are not all loaded at startup: a transcript is thousands of
-    lines and somebody with twenty sessions wants a column of names, not twenty
-    transcripts in memory to draw it.
-    """
-
-    def __init__(self, link: Link, make_brain, model_label: str = "no model") -> None:
-        self._link = link
-        self._make_brain = make_brain
-        self.model_label = model_label
-        self._live: Dict[str, ChatService] = {}
-
-    @classmethod
-    def around(cls, service: "ChatService") -> "Sessions":
-        """A registry holding one conversation somebody else built.
-
-        For callers that make the conversation themselves - the tests do, and so
-        would anything embedding this - so that having one conversation does not
-        require a second code path through the routes. One path means the single
-        case is exercised by the same code the many-session case uses.
-        """
-        got = cls(service._link, lambda: service._brain, service.model_label)
-        got._live[service.session_id] = service
-        return got
-
-    def get(self, session_id: str | None = None) -> ChatService:
-        """The conversation with this id, loaded from disk the first time."""
-        at = session_id or DEFAULT_CHAT_ID
-        found = self._live.get(at)
-        if found is not None:
-            return found
-        service = ChatService(SessionLink(self._link, at), self._make_brain(),
-                              model_label=self.model_label, session_id=at)
-        service.restore()
-        self._live[at] = service
-        return service
-
-    def new(self) -> ChatService:
-        """A conversation nobody has used yet, with an id of its own.
-
-        The id is the clock, not a counter: a counter has to be stored somewhere
-        to survive a restart, and the place it would be stored is the thing that
-        breaks. It is never shown - the name is - so it only has to be unique.
-        """
-        at = "s%d" % int(time.time() * 1000)
-        while at in self._live or store.load_chat(at) is not None:
-            at += "x"
-        return self.get(at)
-
-    def listing(self) -> List[dict]:
-        """Every conversation, saved or only live, newest first.
-
-        A conversation opened a moment ago has nothing on disk yet, and leaving
-        it out would make the column disagree with the page it is drawn beside.
-        """
-        rows = {r["id"]: dict(r) for r in store.known_chats()}
-        for at, service in self._live.items():
-            row = rows.setdefault(at, {"id": at, "saved": "", "turns": 0})
-            row["name"] = service.name
-            row["turns"] = sum(1 for e in service.history if e.get("kind") == "you")
-            row["live"] = True
-        out = list(rows.values())
-        out.sort(key=lambda r: (r.get("saved") or "", r["id"]), reverse=True)
-        return out
-
-    def knows(self, session_id: str | None) -> bool:
-        """Whether this conversation exists, WITHOUT bringing it into being.
-
-        ⛔ THE QUESTION EVERY REQUEST HAS TO ASK BEFORE `get`. Building what it
-        does not find is right for a caller that MEANS to start a conversation -
-        `new`, an embedder, a test - and wrong for a request that only means to
-        look at one. Measured: a page left open on a session somebody deleted
-        went on asking `/live/browsers` every three seconds, and one of those
-        questions was enough to declare the session again. The delete worked,
-        answered `forgotten:true`, closed the browsers, erased the file - and the
-        row came back on its own, empty and unnamed, for as long as that tab
-        stayed open. Every visible signal said the delete had failed.
-
-        ⛔ AND IT ASKS ABOUT BOTH HALVES OF A SESSION, because a session is a
-        conversation AND its browsers and either half can be the only one on
-        disk. An agent client that opens a browser in session `work` and never
-        touches this interface writes the browsers and no transcript; opening
-        `?s=work` here has to work, and asking only about transcripts would have
-        refused it. That is the same defect this method exists to fix, made one
-        step further along - which is why it is written into the one question
-        rather than into the routes that ask it.
-
-        Each half is asked of whoever owns it: what is in memory of this
-        registry, what is on disk of the store. The default is always known
-        because it is the conversation a page with no id gets, and on a fresh
-        install nothing has written it down yet.
-        """
-        at = session_id or DEFAULT_CHAT_ID
-        return (at == DEFAULT_CHAT_ID or at in self._live
-                or store.load_chat(at) is not None
-                or store.load(at) is not None)
-
-    def rename(self, session_id: str, name: str) -> bool:
-        clean = " ".join((name or "").split())[:80]
-        if not clean:
-            return False
-        service = self.get(session_id)
-        service.name = clean
-        service.save()
-        return True
-
-    async def forget(self, session_id: str) -> bool:
-        """Delete a conversation AND the browsers that belonged to it.
-
-        ⛔ Both halves, because they are one session. Erasing only the chat file
-        would leave up to eight engines running with nothing left that names
-        them - 6.5 GB, measured, unreachable and unkillable short of the task
-        manager. `session_forget` on the server is the tool that does the other
-        half, and it exists for exactly this.
-
-        Refused while that conversation is mid-run: the same reason `reset` is.
-
-        ⛔ AND `False` MEANS THAT AND NOTHING ELSE. It used to mean "there was
-        nothing to erase" as well, and the two are opposite news: the page reads
-        it and says "that session is still working, so it was not deleted", which
-        for a session somebody else had already deleted is the wrong sentence in
-        both halves. The caller asked for it to be gone; if it is gone, the
-        answer is yes.
-        """
-        service = self._live.get(session_id)
-        if service is not None and service.busy:
-            return False
-        try:
-            await self._link.call("session_forget", {"session_id": session_id})
-        except Exception:
-            # The browsers could not be closed - the server is gone, or it
-            # refused. The conversation is still deleted: leaving it listed
-            # because something else failed would tell somebody the delete did
-            # not work, when the half they were looking at did.
-            pass
-        self._live.pop(session_id, None)
-        store.erase_chat(session_id)
-        return True
+class SessionGone(Exception):
+    """A request named a conversation that does not exist.
+
+    Its own class rather than an HTTPException so the one handler that answers
+    it lives beside the routes instead of inside each of them: eight routes
+    resolve a session and every one of them would otherwise carry the same
+    three lines, which is how a rule stops being enforced one route later.
+    """
+
+    def __init__(self, session_id: str) -> None:
+        super().__init__(session_id)
+        self.session_id = session_id
+
+class Sessions:
+    """Every conversation this interface holds, by id, saved as it goes.
+
+    ⛔ A CONVERSATION AND ITS BROWSERS ARE ONE SESSION, and this class is where
+    that is true rather than nearly true. The id it keys on is the SAME id the
+    server keys browsers on, so the chat called `lavoro` drives the browsers of
+    session `lavoro` and nothing else - which is why `forget` below closes them
+    as well. Two ids would have been easier and would have meant that deleting a
+    conversation left up to eight engines running with nothing naming them.
+
+    The MCP connection underneath is shared on purpose: one server, one process,
+    one place the browsers live. What keeps two conversations from driving each
+    other's browser is `SessionLink`, which puts the id on every call.
+
+    Conversations are built on demand and read from disk the first time they are
+    asked for. They are not all loaded at startup: a transcript is thousands of
+    lines and somebody with twenty sessions wants a column of names, not twenty
+    transcripts in memory to draw it.
+    """
+
+    def __init__(self, link: Link, make_brain, model_label: str = "no model") -> None:
+        self._link = link
+        self._make_brain = make_brain
+        self.model_label = model_label
+        self._live: Dict[str, ChatService] = {}
+
+    @classmethod
+    def around(cls, service: "ChatService") -> "Sessions":
+        """A registry holding one conversation somebody else built.
+
+        For callers that make the conversation themselves - the tests do, and so
+        would anything embedding this - so that having one conversation does not
+        require a second code path through the routes. One path means the single
+        case is exercised by the same code the many-session case uses.
+        """
+        got = cls(service._link, lambda: service._brain, service.model_label)
+        got._live[service.session_id] = service
+        return got
+
+    def get(self, session_id: str | None = None) -> ChatService:
+        """The conversation with this id, loaded from disk the first time."""
+        at = session_id or DEFAULT_CHAT_ID
+        found = self._live.get(at)
+        if found is not None:
+            return found
+        service = ChatService(SessionLink(self._link, at), self._make_brain(),
+                              model_label=self.model_label, session_id=at)
+        service.restore()
+        self._live[at] = service
+        return service
+
+    def new(self) -> ChatService:
+        """A conversation nobody has used yet, with an id of its own.
+
+        The id is the clock, not a counter: a counter has to be stored somewhere
+        to survive a restart, and the place it would be stored is the thing that
+        breaks. It is never shown - the name is - so it only has to be unique.
+        """
+        at = "s%d" % int(time.time() * 1000)
+        while at in self._live or store.load_chat(at) is not None:
+            at += "x"
+        return self.get(at)
+
+    def listing(self) -> List[dict]:
+        """Every conversation, saved or only live, newest first.
+
+        A conversation opened a moment ago has nothing on disk yet, and leaving
+        it out would make the column disagree with the page it is drawn beside.
+        """
+        rows = {r["id"]: dict(r) for r in store.known_chats()}
+        for at, service in self._live.items():
+            row = rows.setdefault(at, {"id": at, "saved": "", "turns": 0})
+            row["name"] = service.name
+            row["turns"] = sum(1 for e in service.history if e.get("kind") == "you")
+            row["live"] = True
+        out = list(rows.values())
+        out.sort(key=lambda r: (r.get("saved") or "", r["id"]), reverse=True)
+        return out
+
+    def knows(self, session_id: str | None) -> bool:
+        """Whether this conversation exists, WITHOUT bringing it into being.
+
+        ⛔ THE QUESTION EVERY REQUEST HAS TO ASK BEFORE `get`. Building what it
+        does not find is right for a caller that MEANS to start a conversation -
+        `new`, an embedder, a test - and wrong for a request that only means to
+        look at one. Measured: a page left open on a session somebody deleted
+        went on asking `/live/browsers` every three seconds, and one of those
+        questions was enough to declare the session again. The delete worked,
+        answered `forgotten:true`, closed the browsers, erased the file - and the
+        row came back on its own, empty and unnamed, for as long as that tab
+        stayed open. Every visible signal said the delete had failed.
+
+        ⛔ AND IT ASKS ABOUT BOTH HALVES OF A SESSION, because a session is a
+        conversation AND its browsers and either half can be the only one on
+        disk. An agent client that opens a browser in session `work` and never
+        touches this interface writes the browsers and no transcript; opening
+        `?s=work` here has to work, and asking only about transcripts would have
+        refused it. That is the same defect this method exists to fix, made one
+        step further along - which is why it is written into the one question
+        rather than into the routes that ask it.
+
+        Each half is asked of whoever owns it: what is in memory of this
+        registry, what is on disk of the store. The default is always known
+        because it is the conversation a page with no id gets, and on a fresh
+        install nothing has written it down yet.
+        """
+        at = session_id or DEFAULT_CHAT_ID
+        return (at == DEFAULT_CHAT_ID or at in self._live
+                or store.load_chat(at) is not None
+                or store.load(at) is not None)
+
+    def rename(self, session_id: str, name: str) -> bool:
+        clean = " ".join((name or "").split())[:80]
+        if not clean:
+            return False
+        service = self.get(session_id)
+        service.name = clean
+        service.save()
+        return True
+
+    async def forget(self, session_id: str) -> bool:
+        """Delete a conversation AND the browsers that belonged to it.
+
+        ⛔ Both halves, because they are one session. Erasing only the chat file
+        would leave up to eight engines running with nothing left that names
+        them - 6.5 GB, measured, unreachable and unkillable short of the task
+        manager. `session_forget` on the server is the tool that does the other
+        half, and it exists for exactly this.
+
+        Refused while that conversation is mid-run: the same reason `reset` is.
+
+        ⛔ AND `False` MEANS THAT AND NOTHING ELSE. It used to mean "there was
+        nothing to erase" as well, and the two are opposite news: the page reads
+        it and says "that session is still working, so it was not deleted", which
+        for a session somebody else had already deleted is the wrong sentence in
+        both halves. The caller asked for it to be gone; if it is gone, the
+        answer is yes.
+        """
+        service = self._live.get(session_id)
+        if service is not None and service.busy:
+            return False
+        try:
+            await self._link.call("session_forget", {"session_id": session_id})
+        except Exception:
+            # The browsers could not be closed - the server is gone, or it
+            # refused. The conversation is still deleted: leaving it listed
+            # because something else failed would tell somebody the delete did
+            # not work, when the half they were looking at did.
+            pass
+        self._live.pop(session_id, None)
+        store.erase_chat(session_id)
+        return True

--- a/tests/test_the_event_stream_wire_format.py
+++ b/tests/test_the_event_stream_wire_format.py
@@ -1,0 +1,296 @@
+"""The exact bytes on the wire, which nothing else in this suite looks at.
+
+⛔ EVERY OTHER TEST OF THE STREAM SPLITS ON `data: ` AND DECODES THE JSON, so it
+sees the CONTENT and never the FRAMING: not the `id:` line that lets a dropped
+connection resume where it was, not the blank line that ends an event, not the
+order of the two, not which events are numbered and which are deliberately not.
+A page that reconnects reads the framing and nothing else, so until this file
+existed a change to it would have shipped green.
+
+⛔ AND IT DRIVES THE APPLICATION DIRECTLY INSTEAD OF THROUGH A CLIENT. A test
+client reassembles the response and hands back a decoded body, which is the
+projection this file exists to stop looking at; it also runs the application in
+another thread's event loop, where the conversation built here does not live.
+`send` is called with the literal messages the framework emits, so what is
+asserted below is what goes out.
+
+Written as a characterisation test BEFORE the framing was moved into one
+function, so that the move could be shown to change nothing rather than argued
+to.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+
+import pytest
+
+from aihawk.chat import ChatService
+from aihawk.routes import build_app
+from aihawk.sessions import Sessions
+
+from test_web_service import FakeLink, HangingBrain, TalkingBrain
+
+pytestmark = pytest.mark.asyncio
+
+
+class Wire:
+    """What the application sent, kept as the bytes it sent them in."""
+
+    def __init__(self) -> None:
+        self.status: int | None = None
+        self.headers: dict[str, str] = {}
+        self.chunks: list[bytes] = []
+        self._bell = asyncio.Event()
+
+    @property
+    def raw(self) -> bytes:
+        return b"".join(self.chunks)
+
+    def events(self) -> list[bytes]:
+        """The stream cut into its events, framing and all."""
+        return [block for block in self.raw.split(b"\n\n") if block.strip()]
+
+    async def send(self, message) -> None:
+        if message["type"] == "http.response.start":
+            self.status = message["status"]
+            self.headers = {k.decode().lower(): v.decode()
+                            for k, v in message["headers"]}
+        elif message["type"] == "http.response.body":
+            self.chunks.append(message.get("body", b""))
+        self._bell.set()
+
+    async def until(self, needle: bytes, timeout: float = 2.0) -> None:
+        async def wait() -> None:
+            while needle not in self.raw:
+                self._bell.clear()
+                if needle in self.raw:
+                    return
+                await self._bell.wait()
+        try:
+            await asyncio.wait_for(wait(), timeout)
+        except asyncio.TimeoutError:  # pragma: no cover - a failure message
+            raise AssertionError(
+                "%r never went out; the stream held %r" % (needle, self.raw))
+
+
+@contextlib.asynccontextmanager
+async def listening(svc, headers=()):
+    """One subscription to `/chat/events`, open for the body of the block."""
+    app = build_app(svc.link, Sessions.around(svc))
+    scope = {
+        "type": "http", "asgi": {"version": "3.0", "spec_version": "2.1"},
+        "http_version": "1.1", "method": "GET", "scheme": "http",
+        "path": "/chat/events", "raw_path": b"/chat/events",
+        "query_string": b"", "root_path": "",
+        "headers": [(b"host", b"testserver")] + list(headers),
+        "client": ("test", 1), "server": ("testserver", 80),
+    }
+
+    async def receive():
+        # The connection stays open: this listener is never the one that hangs
+        # up, so nothing here may answer `http.disconnect`.
+        await asyncio.sleep(3600)
+        return {"type": "http.disconnect"}
+
+    wire = Wire()
+    task = asyncio.create_task(app(scope, receive, wire.send))
+    try:
+        yield wire
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+#: What the server sends last before it settles into waiting for live events,
+#: in both directions of the branch that ends the opening burst.
+SETTLED = b'"kind": "busy"'
+
+
+async def talking(model_label="a model"):
+    svc = ChatService(FakeLink(), TalkingBrain(), model_label=model_label)
+    await svc.send("go")
+    return svc
+
+
+async def test_the_opening_burst_is_model_then_replay_then_the_present():
+    """The order is the contract: which model is answering, then everything
+    that was said, then whether a run is in flight right now.
+    """
+    svc = await talking()
+    async with listening(svc) as wire:
+        await wire.until(SETTLED)
+
+        assert wire.status == 200
+        assert wire.headers["content-type"] == "text/event-stream; charset=utf-8"
+        assert wire.headers["cache-control"] == "no-store"
+
+        events = wire.events()
+        assert events[0] == b'data: {"kind": "model", "text": "a model"}', (
+            "the first event is not the model, or it carries an id it has no "
+            "business carrying: %r" % events[0])
+        assert events[-1] == b'data: {"kind": "busy", "text": "0", "replay": true}', (
+            "a finished conversation does not end with the flush that draws "
+            "its last answer: %r" % events[-1])
+        assert len(events) == len(svc.history) + 2, (
+            "the burst is not model + the whole transcript + the present: %r"
+            % [e[:40] for e in events])
+
+
+async def test_every_replayed_event_is_numbered_inside_this_transcript():
+    """⛔ THE NUMBER IS THE WHOLE RESUME MECHANISM. Without the `id:` line a
+    dropped connection has nothing to say when it comes back, and the page -
+    which has no de-duplication - appends a second copy of the transcript.
+    """
+    svc = await talking()
+    async with listening(svc) as wire:
+        await wire.until(SETTLED)
+
+        numbered = [e for e in wire.events() if e.startswith(b"id: ")]
+        assert len(numbered) == len(svc.history), (
+            "%d of %d replayed events are numbered"
+            % (len(numbered), len(svc.history)))
+        for position, block in enumerate(numbered):
+            head, newline, body = block.partition(b"\n")
+            assert head == b"id: %s:%d" % (svc.epoch.encode(), position), (
+                "the resume point is not this transcript at this position: %r"
+                % head)
+            assert newline == b"\n" and body.startswith(b"data: "), (
+                "the id and the data are not one event: %r" % block)
+            assert json.loads(body.removeprefix(b"data: ")) == {
+                **svc.history[position], "replay": True}
+
+
+async def test_a_listener_that_says_where_it_got_to_is_not_sent_it_again():
+    """`EventSource` reconnects by itself after any drop, and until the header
+    was read the server answered every reconnection with the whole transcript.
+    """
+    svc = await talking()
+    marker = ("%s:0" % svc.epoch).encode()
+    async with listening(svc, [(b"last-event-id", marker)]) as wire:
+        await wire.until(SETTLED)
+
+        events = wire.events()
+        replayed = [e for e in events if e.startswith(b"id: ")]
+        assert len(replayed) == len(svc.history) - 1, (
+            "resuming from position 0 replayed %d of %d events"
+            % (len(replayed), len(svc.history)))
+        assert replayed[0].startswith(b"id: %s:1" % svc.epoch.encode()), (
+            "the replay did not carry on from where the page said it was: %r"
+            % replayed[0])
+        assert not any(b'"kind": "fresh"' in e for e in events), (
+            "a page resuming its own transcript was told to drop it")
+
+
+async def test_a_position_from_another_transcript_starts_over_and_says_so():
+    """A position only means something inside one transcript. After a reset, or
+    after the process restarts, the same number points at something else, so
+    the page is told to drop what it holds rather than grow a chimera.
+    """
+    svc = await talking()
+    async with listening(svc, [(b"last-event-id", b"an-older-epoch:3")]) as wire:
+        await wire.until(SETTLED)
+
+        events = wire.events()
+        assert events[1] == b'data: {"kind": "fresh", "text": "1"}', (
+            "the page was not told to drop the transcript it is showing: %r"
+            % events[1])
+        replayed = [e for e in events if e.startswith(b"id: ")]
+        assert len(replayed) == len(svc.history), "the replay did not start over"
+        assert replayed[0].startswith(b"id: %s:0" % svc.epoch.encode())
+
+
+async def test_a_marker_that_is_not_a_position_is_not_a_resume_either():
+    """⛔ AND A MARKER WITH NO POSITION IN IT AT ALL IS THE CASE THAT LOOKS
+    HARMLESS. Before the epoch existed the marker was a bare index, so a page
+    held open across that upgrade reconnects carrying something this format
+    cannot read. Treating it as "this transcript, from the beginning" replays
+    everything without telling the page to drop what it is already showing,
+    which is the doubled transcript the epoch exists to prevent - and it says
+    so only in the one branch nobody writes a test for.
+
+    Found by a mutation that survived: with no header at all the two answers
+    are indistinguishable, so the gate had to reach for the malformed one.
+    """
+    svc = await talking()
+    async with listening(svc, [(b"last-event-id", b"an-older-format")]) as wire:
+        await wire.until(SETTLED)
+
+        events = wire.events()
+        assert events[1] == b'data: {"kind": "fresh", "text": "1"}', (
+            "a marker this format cannot read was taken for a position in this "
+            "transcript: %r" % events[1])
+
+
+async def test_a_listener_joining_a_run_is_told_the_present_unflagged():
+    """⛔ THE TWO ARE NOT ONE LINE WITH A CONDITIONAL INSIDE. The live one must
+    arrive unflagged or the page calls `waited()` where it should call
+    `waiting()`, and a run in progress loses its clock.
+    """
+    brain = HangingBrain()
+    svc = ChatService(FakeLink(), brain, model_label="a model")
+    svc.start("something slow")
+    await asyncio.wait_for(brain.started.wait(), 2.0)
+    try:
+        async with listening(svc) as wire:
+            await wire.until(SETTLED)
+            assert wire.events()[-1] == b'data: {"kind": "busy", "text": "1"}', (
+                "a listener joining a run in flight was told the wrong thing: "
+                "%r" % wire.events()[-1])
+    finally:
+        svc.stop()
+        await asyncio.sleep(0)
+
+
+async def test_a_live_event_is_numbered_and_live_state_is_not():
+    """⛔ AN ID MOVES THE RESUME POINT, AND `busy` IS NOT A PLACE TO RESUME
+    FROM. Numbering it would make a reconnection resume past a real event, and
+    leaving the field out is what the spec says keeps the last id standing.
+    """
+    svc = await talking()
+    async with listening(svc) as wire:
+        await wire.until(SETTLED)
+        opening = len(wire.raw)
+
+        # Where the transcript is BEFORE the event, because `fresh` below joins
+        # the history too and would move this number under the assertion.
+        position = len(svc.history)
+
+        await svc.emit("said", "and then this")
+        await wire.until(b"and then this")
+        await svc.emit("busy", "0")
+        await svc.emit("fresh", "1")
+        await wire.until(b'"kind": "fresh"')
+
+        live = [b for b in wire.raw[opening:].split(b"\n\n") if b.strip()]
+        assert live[0] == (b'id: %s:%d\ndata: {"kind": "said", "text": '
+                           b'"and then this"}'
+                           % (svc.epoch.encode(), position)), (
+            "a live event is not numbered at its place in the transcript: %r"
+            % live[0])
+        assert live[1] == b'data: {"kind": "busy", "text": "0"}', (
+            "live state came with an id, which moves the resume point past a "
+            "real event: %r" % live[1])
+        assert live[2] == b'data: {"kind": "fresh", "text": "1"}', (
+            "a reset came with an id: %r" % live[2])
+
+
+async def test_every_event_ends_with_a_blank_line():
+    """The blank line is what ends an event for `EventSource`. Without it two
+    events are read as one and the page sees neither.
+    """
+    svc = await talking()
+    async with listening(svc) as wire:
+        await wire.until(SETTLED)
+        raw = wire.raw
+
+    assert raw.endswith(b"\n\n"), "the last event was never terminated"
+    for block in raw.split(b"\n\n")[:-1]:
+        assert block.strip(), "an empty frame went out on the wire"
+        assert block.endswith(b"}"), (
+            "an event does not end where its JSON ends: %r" % block[-40:])
+        assert block.count(b"\n") == (1 if block.startswith(b"id: ") else 0), (
+            "an event carries a line that is neither its id nor its data: %r"
+            % block)


### PR DESCRIPTION
Every event on `/chat/events` was assembled by hand: the optional `id:` line, the newline between it and the `data:` line, the json, the blank line that ends the event. Seven copies, five of them differing only in which dict goes in. Those three details are what a reader skims past and every one of them is load-bearing, so seven copies were seven chances to get one wrong somewhere nothing looked.

Now `sse()` knows the framing and nothing else does. `marker_at()` writes a resume point and `resume_point()` reads one, side by side so they cannot drift. The two empty replies that `/live/browsers` and `/live/tabs` give when there is nothing to say are named once instead of written out five times: they have to carry the same fields as the full replies, because the page reads the same fields either way, and they are returned exactly on the paths where something is missing, which is where a shape copied a second time goes stale unwatched.

`events()` drops from 42 lines of code to 31 and `stream()` from 27 to 21. `json.dumps` goes from seven calls to one.

**Nothing observable changes, and that is a measurement rather than a claim.** Every other test of the stream splits on `data: ` and decodes the json, so it sees the content and never the framing. `test_the_event_stream_wire_format.py` pins the bytes instead, and it was written and made green before any of this moved. It drives the application directly rather than through a test client, for two reasons: a client reassembles the response, which is the very thing under test, and it runs the app in another thread's event loop where the conversation the test built does not live.

It is a gate and not a green light: ten known-bad versions of the code, ten killed. Eight of those were tried against the old code first, and four went unnoticed by every other test in the suite, which is the measure of what the file adds. The tenth found a hole in the test rather than the code: a reconnection carrying a marker with no position in it, which is what a page held open across the upgrade that introduced the epoch sends, is correctly told to start over, and nothing had ever checked it.

The first commit is separate and is only line endings. The split that created `routes.py`, `chat.py` and `sessions.py` wrote them with an extra carriage return before each line ending, on 326, 211 and 165 lines. Python treats a lone CR as a line break too, so each of those lines counted twice and the modules parsed and ran exactly as intended, which is why nothing caught it. What it cost is stack traces: `Sessions.forget` sits on line 168 of a 180-line file and Python reported it at 281, past the end, so a traceback through these modules named a line that does not exist and printed no source at all. Counting CRLF does not reveal it, since the wrong sequence contains a correct one.

Measured while looking, and deliberately not changed here: `/live/tabs` starts a browser nobody asked for. On a fresh home with no instruction given, the process count goes 9, then 9 after `/live/browsers`, then 16 after `/live/tabs`, and the reply is `{"url": "", "tabs": []}`. The guard is `link.touched`, which is armed by the first call of any kind, and `browser_list` is precisely the question chosen because it starts nothing. The page already carries that rule and applies it only when a browser is named. Fixing it is a decision about what resolving an address may cause, not a mechanical change, so it is reported rather than folded into a refactor.

549 tests pass. Verified on the running interface as well: a real turn and three kinds of reconnection.
