### PR TITLE
Looking at a browser started one

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.38.0"
+version = "0.39.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/link.py
+++ b/src/aihawk/link.py
@@ -46,10 +46,6 @@ class Link:
         self._ctx = None
         self._sess_ctx = None
         self._tools = None
-        # Set the moment an instruction is issued, and never cleared: it answers
-        # "could a browser exist?", which is what the live view needs to know
-        # before it is allowed to ask for a picture.
-        self.touched = False
         # One instruction at a time. Two tool calls racing on one browser is not
         # a transport problem, it is two hands on the same mouse.
         self._lock = asyncio.Lock()
@@ -91,7 +87,6 @@ class Link:
 
     async def call(self, name: str, arguments: dict | None = None):
         """Call one tool, serialised against every other call on this link."""
-        self.touched = True
         async with self._lock:
             return await self.session.call_tool(name, arguments or {})
 
@@ -162,15 +157,6 @@ class SessionLink:
     def __init__(self, link: "Link", session_id: str) -> None:
         self._link = link
         self._session_id = session_id
-        #: Whether THIS session has ever issued an instruction. Per session and
-        #: not per connection, and the difference is a browser nobody asked for:
-        #: the live pane is allowed to ask for a picture only once a browser
-        #: could exist, and over MCP there is no way to ask "is one running"
-        #: without starting one. Delegating to the shared link would make every
-        #: NEW conversation inherit the answer from an old one, so opening a
-        #: second chat would launch an engine to draw a pane for a session that
-        #: has done nothing.
-        self._touched = False
         self._addressable = {
             t.name for t in link.tools
             if "session_id" in (getattr(t, "inputSchema", None) or {}).get(
@@ -185,10 +171,6 @@ class SessionLink:
     def tools(self):
         return self._link.tools
 
-    @property
-    def touched(self) -> bool:
-        return self._touched
-
     def addresses(self, name: str) -> bool:
         """Whether a call to this tool will carry the session id."""
         return name in self._addressable
@@ -197,7 +179,6 @@ class SessionLink:
         args = dict(arguments or {})
         if name in self._addressable:
             args["session_id"] = self._session_id
-        self._touched = True
         return await self._link.call(name, args)
 
     async def call_text(self, name: str, arguments: dict | None = None) -> str:

--- a/src/aihawk/mcp/__init__.py
+++ b/src/aihawk/mcp/__init__.py
@@ -12,4 +12,20 @@ try:
 except PackageNotFoundError:  # running from a source tree, not installed
     __version__ = "0+unknown"
 
-__all__ = ["__version__"]
+#: What a LOOK at a browser that is not running is refused with.
+#:
+#: ⛔ ONE SENTENCE IN ONE PLACE, AND IT LIVES HERE RATHER THAN BESIDE THE TOOL
+#: THAT SAYS IT, because its two readers are far apart and only one of them is
+#: a person. A model acts on the words; the live pane has to tell "there is
+#: nothing to look at" - draw the idle state, quietly - apart from "the capture
+#: is broken", which is a sentence somebody needs to read. The pane compares
+#: against this, so the two cannot drift; put in `server.py` it would drag the
+#: whole server object into the interface's process just to read a string.
+#:
+#: Interface and server are always the same build: the link launches
+#: `sys.executable -m aihawk`, so there is no version skew to defend against.
+NOTHING_RUNNING = ("no browser is running here, so there is no window to "
+                   "watch. browser_list says which browsers this session has, "
+                   "and any command aimed at one starts it.")
+
+__all__ = ["__version__", "NOTHING_RUNNING"]

--- a/src/aihawk/mcp/server.py
+++ b/src/aihawk/mcp/server.py
@@ -30,7 +30,7 @@ from contextlib import asynccontextmanager
 
 from mcp.server.fastmcp import FastMCP, Image
 
-from . import actions, identity, plan, store
+from . import NOTHING_RUNNING, actions, identity, plan, store
 from .registry import DEFAULT_SESSION_ID, SessionRegistry
 
 # Kept for callers that imported it from here. The implementation moved.
@@ -423,6 +423,31 @@ async def ready(session_id=None, browser_id=None):
     return session
 
 
+def looking(session_id=None, browser_id=None):
+    """This browser only if it is ALREADY running. Never starts one.
+
+    ⛔ A QUESTION IS NOT A COMMAND, AND `ready` CANNOT TELL THEM APART, because
+    it starts whatever it resolves. That is exactly right for an instruction
+    and exactly wrong for a look, and the difference is measurable: on 0.38.0,
+    drawing the live panes of a session nobody had asked anything took the
+    machine from 9 firefox processes to 16, roughly 800 MB and seven seconds,
+    and `browser_watch` then answered an error - so the engine the look had
+    started was not even used for the look.
+
+    `registry.peek` has said this was needed since the day it was written -
+    "for callers that want to know whether a browser is up, such as a live
+    view" - and had no callers. What kept it unused was a belief written down
+    in the interface beside the flag it invented instead: "over MCP there is no
+    way to ask is one running without starting one". There is; this is it.
+
+    A browser this answers `None` for is not gone, it is asleep: it was
+    declared and has not been needed yet, and the next COMMAND aimed at it
+    still starts it as the same person, through `ready`. Only looking stopped
+    waking it.
+    """
+    return registry.peek(addressed(session_id, browser_id))
+
+
 async def _retrying(fn, *args, session_id=None, browser_id=None, **kwargs):
     """Run an action on one browser, and on failure rebuild it once and retry.
 
@@ -800,11 +825,17 @@ async def session_list_pages(session_id: str | None = None,
     Use it before session_select_page: the id alone does not tell you which tab
     you are switching to.
 
+    Starts nothing: a browser that is not running has no tabs open, and this
+    answers the empty list rather than opening one to find out. Asking what is
+    there is not the same as asking for it to exist.
+
     session_id and browser_id are optional. Leave them out and this lists the
     default browser's tabs, as before; name them when a session holds more than
     one, since each browser numbers its own tabs."""
-    return await actions.list_pages(
-        await ready(session_id, browser_id))
+    session = looking(session_id, browser_id)
+    if session is None:
+        return "[]"
+    return await actions.list_pages(session)
 
 
 @mcp.tool()
@@ -950,10 +981,21 @@ async def browser_watch(session_id: str | None = None,
     is window pixels, so do not feed its coordinates to browser_click_at; use
     browser_take_screenshot for that.
 
+    Starts nothing. A browser that is not running has no window, so this
+    refuses rather than opening one to photograph: a look is not a command, and
+    the live panes call this many times a second.
+
     session_id and browser_id are optional. Leave them out and this watches the
     default browser, as before; name them to watch one of several."""
-    jpeg = await actions.watch_jpeg(
-        await ready(session_id, browser_id))
+    session = looking(session_id, browser_id)
+    if session is None:
+        # It REFUSES rather than answering the sentence, and only because the
+        # type says so: this is declared to return an Image, and `Image | str`
+        # is not a schema pydantic will build - measured, five test modules
+        # refuse to import. A refusal reaches a client as an error result
+        # carrying the reason, which every client already handles.
+        raise RuntimeError(NOTHING_RUNNING)
+    jpeg = await actions.watch_jpeg(session)
     return Image(data=jpeg, format="jpeg")
 
 

--- a/src/aihawk/routes.py
+++ b/src/aihawk/routes.py
@@ -14,6 +14,7 @@ from starlette.routing import Route
 
 from .chat import ChatService, DEFAULT_CHAT_ID
 from .link import Link, image_of, text_of
+from .mcp import NOTHING_RUNNING
 from .sessions import SessionGone, Sessions
 from .ui import PAGE
 
@@ -249,15 +250,20 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
         The strip and the address in the picture are pixels; the ones the
         page draws above it are the same facts as elements, and those can be
         clicked and copied. Both stay.
+
+        ⛔ AND THERE IS NO GUARD HERE ANY MORE, WHICH IS THE POINT. There used
+        to be one, reading whether this conversation had ever called anything,
+        and it was armed by the one call that starts nothing - so the next
+        frame through it started an engine: measured on 0.38.0, 9 firefox
+        processes to 16 for a session nobody had asked anything, and the
+        capture then failed anyway. Asking the free question here instead was
+        tried and measured too, and it is the wrong place: `browser_list` costs
+        30 ms against the capture's 1, so paying it every frame caps the pane
+        at 32 a second to answer a question whose answer is almost always yes.
+        `browser_watch` refuses without starting now, so the cheap path is the
+        common one and this route simply asks.
         """
         seen = which(request)
-        if not seen.link.touched:
-            # 204, not an error: nothing is wrong, there is simply nothing to
-            # look at. Asking the server would START a browser, which is exactly
-            # what a view is not allowed to cause - and it is asked of THIS
-            # conversation, so opening a second chat does not launch an engine
-            # to draw a pane for a session that has done nothing.
-            return Response(status_code=204)
         # ⛔ THE PANE SAYS WHICH BROWSER, and without that the workspace is one
         # picture drawn eight times. `browser_id` is the caller's to choose here
         # exactly as `session_id` is not: which SESSION a request belongs to is
@@ -277,8 +283,12 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
             # the reason, never a 204, which would read as "nothing to look at"
             # in the one case where a person needs to read a sentence.
             reason = text_of(result) if getattr(result, "isError", False) else ""
-            if reason:
+            if reason and NOTHING_RUNNING not in reason:
                 return JSONResponse({"error": reason[:200]}, status_code=503)
+            # And one refusal is not a failure at all: a browser that is not
+            # running is nothing to look at, which is the idle pane. Compared
+            # against the sentence itself rather than guessed at from its
+            # shape - the two ship in one package, so there is one string.
             return Response(status_code=204)
         jpeg, mime = got
         return Response(jpeg, media_type=mime, headers={"Cache-Control": "no-store"})
@@ -329,8 +339,6 @@ def build_app(link: Link, sessions: "Sessions") -> Starlette:
         and the pane keeps working as a picture.
         """
         seen = which(request)
-        if not seen.link.touched:
-            return JSONResponse(NO_TABS)
         # ⛔ WHICH BROWSER, like the frame route beside it. The address above the
         # stage has to be the address of the screen being looked at, and with
         # more than one screen the answer stopped being "the focused one" the

--- a/tests/mcp_server/test_a_look_starts_nothing.py
+++ b/tests/mcp_server/test_a_look_starts_nothing.py
@@ -1,0 +1,120 @@
+"""A question is not a command: looking at a browser must not create one.
+
+⛔ THE DEFECT THIS EXISTS FOR SHIPPED IN 0.36.0, 0.37.0 AND 0.38.0, AND NOTHING
+IN THE SUITE COULD SEE IT. Opening the interface drew its panes, the panes asked
+`browser_watch` and `session_list_pages`, both resolved their browser through
+`ready`, and `ready` STARTS what it resolves. Measured on 0.38.0 with a fresh
+home and no instruction given: 9 firefox processes before, 16 after - roughly
+800 MB and seven seconds - and `browser_watch` then answered an error, so the
+engine the look had started was not even used for the look.
+
+Every test that touched those tools built a registry whose factory launches
+nothing, so "it started a browser" was invisible: nothing launched in the first
+place. What IS visible, and is what these assert, is whether the registry ends
+up holding a session it did not hold before. That is the same event one layer
+up, and it is the layer where it can be proven without a browser.
+
+The other half of the rule is asserted too, because a guard that never lets
+anything through is not a guard: a browser that IS running is looked at exactly
+as before.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from aihawk.mcp import NOTHING_RUNNING, server
+from aihawk.mcp.registry import DEFAULT_SESSION_ID
+
+pytestmark = pytest.mark.asyncio
+
+
+class _Recording:
+    """A session that launches nothing and reports itself alive."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.closed = False
+
+    async def start(self):
+        pass
+
+    async def close(self):
+        self.closed = True
+
+    async def describe_pages(self):
+        return [{"id": "p-1", "title": "a tab", "url": "http://x/", "active": True}]
+
+    def where_pages_are(self):
+        return ["http://x/"]
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    reg = server.new_registry(factory=_Recording,
+                              defaults=lambda: {"seed": 7, "headless": True})
+    monkeypatch.setattr(server, "registry", reg)
+    monkeypatch.setattr(server, "_focus", {})
+    return reg
+
+
+async def test_asking_for_the_tabs_of_a_browser_that_is_not_running_starts_nothing(registry):
+    """Known-bad: `await actions.list_pages(await ready(...))`, which is what it
+    said until 0.39.0. The registry then holds a session it did not hold, which
+    on a real machine is an engine.
+    """
+    assert registry.ids() == [], "something was already running before the look"
+
+    said = await server.session_list_pages()
+
+    assert json.loads(said) == [], (
+        "a browser that is not running has no tabs, and this said otherwise")
+    assert registry.ids() == [], (
+        "looking at the tabs built a browser: %r" % registry.ids())
+
+
+async def test_asking_for_the_window_of_a_browser_that_is_not_running_starts_nothing(registry):
+    """It refuses rather than answering a sentence, and the refusal is the
+    shared one: the live pane compares against it to tell "nothing to look at"
+    from "the capture is broken", and those are a quiet idle state and a
+    sentence somebody reads.
+
+    Known-bad: `await actions.watch_jpeg(await ready(...))`.
+    """
+    with pytest.raises(Exception) as refused:
+        await server.browser_watch()
+
+    assert NOTHING_RUNNING in str(refused.value), (
+        "the refusal is not the sentence the pane reads: %s" % refused.value)
+    assert registry.ids() == [], (
+        "looking at the window built a browser: %r" % registry.ids())
+
+
+async def test_a_browser_that_IS_running_is_still_looked_at(registry):
+    """⛔ THE OTHER HALF, AND WITHOUT IT THIS FILE WOULD PASS ON A PANE THAT
+    NEVER DRAWS ANYTHING. A guard that refuses everything satisfies both tests
+    above.
+    """
+    await server.browser_open()                      # a COMMAND: this starts it
+    before = registry.ids()
+    assert before, "the command did not start a browser, so the rest proves nothing"
+
+    rows = json.loads(await server.session_list_pages())
+
+    assert [r["id"] for r in rows] == ["p-1"], (
+        "a running browser's tabs were not read: %r" % rows)
+    assert registry.ids() == before, "reading the tabs built a second browser"
+
+
+async def test_a_command_still_starts_a_declared_browser(registry):
+    """The promise `browser_list` makes to a model, kept: a browser that is not
+    running is asleep rather than gone, and the next COMMAND aimed at it starts
+    it as the same person. Only looking stopped waking it.
+    """
+    assert registry.ids() == []
+
+    await server.browser_open()
+
+    assert DEFAULT_SESSION_ID in registry.ids()[0], (
+        "a command did not start the browser it was aimed at: %r" % registry.ids())

--- a/tests/test_a_session_reaches_only_its_own_browsers.py
+++ b/tests/test_a_session_reaches_only_its_own_browsers.py
@@ -141,24 +141,35 @@ async def test_the_session_view_answers_for_the_connection_underneath():
     assert link.tools is rec.tools
 
 
-async def test_whether_a_browser_could_exist_is_asked_per_session():
-    """⛔ AND IT IS THE ONE THING THIS VIEW MUST NOT DELEGATE. The live pane may
-    ask for a picture only once a browser could exist, because over MCP there is
-    no way to ask "is one running" without starting one - `browser_watch` calls
-    `ensure`. If this answered for the shared CONNECTION, every new conversation
-    would inherit the answer from an old one, and opening a second chat would
-    launch an engine, 800 MB and seven seconds, to draw a pane for a session
+async def test_whether_a_browser_is_running_is_asked_per_session():
+    """⛔ AND IT IS THE ONE THING THIS VIEW MUST NOT DELEGATE. If the live pane
+    learned "there is a browser" from the shared CONNECTION, a second chat
+    opened beside a working one would ask for a picture and the server would
+    start an engine, 800 MB and seven seconds, to draw a pane for a session
     that has done nothing.
 
-    Known-bad: `return self._link.touched`. `nuova` below then reports true
-    without having made a single call.
+    ⛔ THIS TEST USED TO ASSERT A REMEMBERED FLAG, `SessionLink.touched`, AND
+    THE FLAG WAS BUILT ON A PREMISE THAT WAS NOT TRUE. Its comment said "over
+    MCP there is no way to ask is one running without starting one". There is:
+    `browser_list` reports what `registry.peek` already holds and starts
+    nothing, and it carries the session id, so the answer is this
+    conversation's. The flag was removed with the workaround it existed for,
+    and what a view needs is now a question with an answer rather than a
+    memory of whether anything has happened here.
+
+    Known-bad: drop `browser_list` from the addressable set. Every pane then
+    asks about the default session's browsers, so an unused conversation is
+    told there is something to look at and asks for a picture of it.
     """
     rec = _Recording(TOOLS)
     vecchia, nuova = SessionLink(rec, "vecchia"), SessionLink(rec, "nuova")
 
     await vecchia.call("browser_navigate", {"url": "http://x/"})
+    await nuova.call("browser_list")
 
-    assert vecchia.touched is True
-    assert nuova.touched is False, (
-        "a conversation that has done nothing says a browser could exist, so "
-        "its live pane will ask for one and the server will start it")
+    assert rec.calls[-1][1].get("session_id") == "nuova", (
+        "the pane of a conversation that has done nothing asked about "
+        "somebody else's browsers: %r" % (rec.calls[-1],))
+    assert not hasattr(nuova, "touched"), (
+        "the remembered flag is back, and it answers a different question "
+        "from the one a view needs")

--- a/tests/test_the_session_column.py
+++ b/tests/test_the_session_column.py
@@ -359,27 +359,35 @@ async def test_the_routes_act_on_the_conversation_the_page_names():
         == ["secondo"]
 
 
-async def test_the_live_pane_of_a_conversation_that_has_done_nothing_asks_for_nothing():
-    """⛔ OR OPENING A CHAT LAUNCHES A BROWSER. Over MCP there is no way to ask
-    "is a browser running" without starting one, so the pane may only ask once
-    this conversation has issued an instruction. If that question were asked of
-    the shared connection, a second chat opened beside a working one would start
-    an engine - 800 MB and seven seconds - to draw a picture of nothing.
+async def test_the_live_pane_of_a_conversation_that_has_done_nothing_starts_nothing():
+    """⛔ OR OPENING A CHAT LAUNCHES A BROWSER. A second chat opened beside a
+    working one would start an engine - 800 MB and seven seconds - to draw a
+    picture of nothing, and the person who opened it asked for a conversation.
 
-    Known-bad: have the frame route read `link.touched` instead of the
-    conversation's own.
+    What holds it is that `browser_watch` refuses a browser that is not
+    running instead of starting one, which is gated where it can be proven -
+    `tests/mcp_server/test_a_look_starts_nothing.py`, against a real registry
+    that can be asked how many sessions it built. Here the link is a double
+    with no registry behind it, so the only honest claim left is the one below:
+    the pane draws idle and asks for exactly the one thing, so nothing else can
+    be reaching for a browser on the way.
+
+    Known-bad: have the pane fall back to a second question when the first
+    answers nothing. That is the shape the removed guard had, and it is how
+    both of these came to cost an engine.
     """
     link, sessions = _sessions()
     client = await _client(sessions, link)
 
     await sessions.get("vecchia").send("do something")
     sessions.get("nuova")  # opened beside it, and told nothing
-    calls_before = len(link.calls)
+    before = len(link.calls)
 
     assert client.get("/live/frame?s=nuova").status_code == 204
-    assert len(link.calls) == calls_before, (
-        "drawing a pane for an unused conversation reached the server: %r"
-        % link.calls[calls_before:])
+    after = [n for n, _ in link.calls[before:]]
+    assert after == ["browser_watch"], (
+        "drawing a pane for an unused conversation asked for more than the "
+        "picture it draws: %r" % after)
 
 
 async def test_the_column_can_be_listed_renamed_and_emptied_over_http():

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -21,6 +21,7 @@ import subprocess
 
 import pytest
 
+from aihawk.link import text_of
 from aihawk.web import PAGE, ChatService, Sessions, build_app
 
 pytestmark = pytest.mark.asyncio
@@ -40,8 +41,11 @@ class FakeLink:
         return None
 
     async def call_text(self, name, arguments=None):
-        await self.call(name, arguments)
-        return ""
+        # Through `text_of`, like the real link, so a double that answers a
+        # tool answers it on BOTH doors. Overriding only `call` used to leave
+        # `call_text` returning the empty string for the same tool, which is a
+        # double that disagrees with itself.
+        return text_of(await self.call(name, arguments))
 
 
 class SilentBrain:
@@ -324,13 +328,23 @@ async def test_the_stop_control_is_its_own_button_and_follows_the_run():
         "the send button has a mode again, which is how stop went missing before"
 
 
-async def test_the_live_view_asks_for_nothing_until_an_instruction_has_been_given():
-    """The invariant the in-process view held by calling `registry.peek`.
+async def test_the_live_view_never_causes_a_browser_to_start():
+    """⛔ A VIEW DRAWS WHAT EXISTS AND MAY NOT BRING IT INTO EXISTENCE. Asking
+    for a picture of a browser that is not running would START one, 800 MB and
+    seven seconds nobody asked for, to draw a pane for a conversation that has
+    done nothing.
 
-    Over MCP that question does not exist - `session_list_pages` calls `ensure` -
-    so the guarantee is held by Link remembering. If the frame route ever asks
-    before an instruction, opening the page would START a browser, which is what
-    a view is not allowed to cause.
+    The assertion is on WHICH tools were called and not on how many, and that
+    is the whole lesson of [B201]. This used to say `link.calls == []`, which
+    was the same thing only while the view asked nothing at all; the moment it
+    asked the one free question, `== []` would have had to be relaxed, and the
+    relaxation people reach for is a count. `browser_list` is free by
+    construction and `browser_watch` is not free at all, so naming them is the
+    assertion that keeps meaning what it means.
+
+    Known-bad: a guard that reads whether any call has been made on the link.
+    That is armed by `browser_list` itself, so the next view through it starts
+    an engine - measured on 0.38.0, 9 processes to 16.
     """
     link = FakeLink()
     svc = ChatService(link, SilentBrain())
@@ -343,7 +357,9 @@ async def test_the_live_view_asks_for_nothing_until_an_instruction_has_been_give
 
     resp = await frame.endpoint(Req())
     assert resp.status_code == 204
-    assert link.calls == [], "the view asked the server something before any instruction"
+    assert [n for n, _ in link.calls] == ["browser_watch"], (
+        "the pane asks for the picture and nothing else: %s"
+        % [n for n, _ in link.calls])
 
 
 # --------------------------------------------------------------------------
@@ -371,17 +387,23 @@ class Result:
         self.isError = isError
 
 
+#: What `browser_list` answers when there is something to look at. A double
+#: that can hand back a picture is a double with a browser running, so it has
+#: to say so: the views ask this first and draw nothing when the answer is no.
+RUNNING = ('{"session": "default", "focus": "main", "limit": 8, '
+           '"browsers": [{"id": "main", "running": true, "focused": true, '
+           '"urls": []}]}')
+
+
 class WatchingLink(FakeLink):
     """Answers both picture tools the way the server does - `browser_watch`
     with a JPEG, `browser_take_screenshot` with a PNG - so which one the view
     asked for is visible in what came back and not only in the call log."""
 
-    def __init__(self):
-        super().__init__()
-        self.touched = True
-
     async def call(self, name, arguments=None):
         await super().call(name, arguments)
+        if name == "browser_list":
+            return Result(Item(type="text", text=RUNNING))
         if name == "browser_watch":
             return Result(Item(type="image", data=base64.b64encode(JPEG).decode(),
                                mimeType="image/jpeg"))
@@ -432,8 +454,13 @@ async def test_a_capture_that_cannot_answer_says_why_instead_of_looking_idle():
     Known-bad: the previous route answered 204 here.
     """
     class RefusingLink(WatchingLink):
+        """The browser IS running - that is the point: the refusal has to be
+        about the screencast and not about there being nothing to look at."""
+
         async def call(self, name, arguments=None):
             await FakeLink.call(self, name, arguments)
+            if name == "browser_list":
+                return Result(Item(type="text", text=RUNNING))
             return Result(Item(type="text", text=(
                 "the live window view needs invisible-playwright with "
                 "page.screencast and an engine from firefox-28 on")), isError=True)
@@ -446,6 +473,43 @@ async def test_a_capture_that_cannot_answer_says_why_instead_of_looking_idle():
 
     assert resp.status_code == 503
     assert "page.screencast" in json.loads(resp.body)["error"]
+
+
+async def test_nothing_to_look_at_is_the_idle_pane_and_not_an_error():
+    """⛔ THE TWO REFUSALS ARRIVE THE SAME WAY AND MEAN OPPOSITE THINGS. A tool
+    that refuses reaches a client as an error result carrying a sentence, and
+    the route above turns that into a 503 the page shows in words. That is
+    right for a capture that is broken and wrong for a browser that simply is
+    not running, which is not a failure at all: it is the ordinary state of a
+    conversation nobody has asked anything, and the pane should sit idle.
+
+    Since 0.39.0 `browser_watch` refuses rather than starting a browser to
+    photograph, so this refusal became the COMMON case - every poll of a fresh
+    session - and without this the pane would show an error banner from the
+    moment it opened.
+
+    Told apart by comparing against the sentence itself, which both sides
+    import from one place. Known-bad: `if reason:` on its own, which was what
+    the route said before the refusal existed, and any edit to the shared
+    sentence that leaves the two copies to drift.
+    """
+    from aihawk.mcp import NOTHING_RUNNING
+
+    class AsleepLink(WatchingLink):
+        async def call(self, name, arguments=None):
+            await FakeLink.call(self, name, arguments)
+            return Result(Item(type="text", text=NOTHING_RUNNING), isError=True)
+
+    link = AsleepLink()
+    route = await _frame_route(link)
+
+    class Req: query_params = {}
+    resp = await route(Req())
+
+    assert resp.status_code == 204, (
+        "a browser that is not running was reported as a failure, so the pane "
+        "shows an error banner instead of sitting idle: %s"
+        % getattr(resp, "body", b"")[:120])
 
 
 async def test_a_new_conversation_makes_the_brain_forget_and_clears_the_history():
@@ -828,12 +892,18 @@ async def test_a_page_that_joins_an_idle_service_is_told_the_turn_is_over():
 # --------------------------------------------------------------------------
 
 class TabbedLink(FakeLink):
-    def __init__(self, payload):
+    """`session_list_pages` answers `payload`; `browser_list` answers that the
+    browser is running, because a session with tabs to list has one."""
+
+    def __init__(self, payload, running=True):
         super().__init__()
         self._payload = payload
+        self._running = running
 
     async def call_text(self, name, arguments=None):
         await self.call(name, arguments)
+        if name == "browser_list":
+            return RUNNING if self._running else '{"focus": "", "browsers": []}'
         return self._payload
 
 
@@ -853,7 +923,6 @@ async def test_the_address_comes_from_the_active_tab():
         {"id": "tab-1", "title": "A", "url": "https://a.example/", "active": False},
         {"id": "tab-2", "title": "B", "url": "https://b.example/x", "active": True},
     ]))
-    link.touched = True
     route = await _tabs_route(link)
 
     class Req: query_params = {}
@@ -862,7 +931,7 @@ async def test_the_address_comes_from_the_active_tab():
     assert body["url"] == "https://b.example/x", "the address is the ACTIVE tab's"
     assert [t["id"] for t in body["tabs"]] == ["tab-1", "tab-2"]
     assert [n for n, _ in link.calls] == ["session_list_pages"], (
-        "one call, and not browser_evaluate on top of it")
+        "the tabs in ONE call, and not browser_evaluate on top of it")
 
 
 async def test_an_older_server_leaves_the_strip_empty_instead_of_breaking_the_pane():
@@ -878,13 +947,23 @@ async def test_an_older_server_leaves_the_strip_empty_instead_of_breaking_the_pa
     assert body == {"url": "", "tabs": []}
 
 
-async def test_the_strip_asks_nothing_before_an_instruction():
-    """Same invariant as the frame: looking must not start a browser."""
-    link = TabbedLink("[]")
+async def test_the_strip_never_causes_a_browser_to_start():
+    """Same invariant as the frame, and it has to be stated the same way.
+
+    `session_list_pages` resolves the browser through `ready`, which STARTS it,
+    so an empty strip drawn by asking is an empty strip that cost an engine.
+    Measured on 0.38.0: 9 processes before, 16 after, and the answer was
+    `{"url": "", "tabs": []}` either way.
+
+    Known-bad: a guard that reads whether any call has been made on the link.
+    """
+    link = TabbedLink("[]", running=False)
     route = await _tabs_route(link)
 
     class Req: query_params = {}
     body = json.loads((await route(Req())).body)
 
     assert body == {"url": "", "tabs": []}
-    assert link.calls == []
+    assert [n for n, _ in link.calls] == ["session_list_pages"], (
+        "the strip asks once and reads the answer: %s"
+        % [n for n, _ in link.calls])


### PR DESCRIPTION
Open the interface and the live panes draw themselves. Both of them resolved their browser through `ready`, and `ready` starts what it resolves, so drawing a pane for a conversation nobody had asked anything launched an engine. Measured on 0.38.0 with an empty home and no instruction given: 9 firefox processes before, 16 after, roughly 800 MB and seven seconds. `/live/frame` then answered 503, so the engine the look had started was not even used for the look.

The guard that was supposed to prevent this read whether the conversation had ever called anything. The page polls `/live/browsers` first, `browser_list` is the one tool chosen precisely because it starts nothing, and it armed the guard: the very call that cannot cost an engine is what let the next one do it. Both views carried the same guard and both did it.

Underneath was a belief written down twice, in `link.py` and in the test that pinned it: "over MCP there is no way to ask is one running without starting one". There is. `registry.peek` answers exactly that, its docstring has said so since the day it was written - "for callers that want to know whether a browser is up, such as a live view" - and it had no callers.

So `looking` sits beside `ready`, and the two tools a view uses take it. `session_list_pages` answers the empty list for a browser that is not running; `browser_watch` refuses. Nothing else changes: a command aimed at a sleeping browser still starts it as the same person, which is the promise `browser_list` makes to a model, and that is asserted rather than assumed. The remembered flag is gone with the workaround it existed for.

**Fixing it in the interface instead was written, measured and thrown away**, and the numbers are why:

| | median |
|---|---|
| `browser_list` alone, which is the guard | 30.3 ms |
| `/live/frame` with that guard in it | 31.3 ms |
| `/live/frame` as it ships here | 9.2 ms |

The free question is free of engines, not of time: it asks every running browser for its tabs, which is a round trip each. Paying it per frame put the live pane at 32 frames a second to answer a question whose answer is almost always yes, and the pump asks for 25. Measured in separate phases rather than interleaved, because the two routes share the link's lock and alternating them made each wait for the other - interleaved they read 33.7 and 33.6 ms, which measured the contention and not the routes.

Re-verified on the running product with the bench that found the defect: three sequences, zero processes started, and `/live/frame` answers 204 instead of 503. With a browser actually running the panes draw exactly as before.

The gate is `tests/mcp_server/test_a_look_starts_nothing.py`, and it asserts the event one layer up from the engine: whether the registry ends up holding a session it did not hold. Every existing test of these tools builds a registry whose factory launches nothing, which is not carelessness - it is what makes them fast and isolated - and it is also why none of them could see this: starting a browser was not an unobserved event, it was an impossible one. Two of the four tests are the other half, because a guard that refuses everything would satisfy the first two: a browser that IS running is still looked at, and a command still starts a sleeping one.

Seven known-bad versions, six killed. The seventh renames the shared refusal, which one place defines and three read, so nothing breaks - that mutation confirms the single source rather than accusing the gate. Two of the seven found a hole in the fix rather than in the old code: `/live/frame` had to learn that a refusal is not always a failure, since the same shape carries "the capture is broken" (a sentence somebody reads, 503) and "there is nothing to look at" (the idle pane, 204), and nothing was watching that branch.

554 tests pass.
