### PR TITLE
The interface after a UX pass: a modal panel, a truthful transcript, controls that say what they do

### DIFF
--- a/src/aihawk/agent.py
+++ b/src/aihawk/agent.py
@@ -93,6 +93,38 @@ def _result_text(result) -> tuple[str, bool]:
     return (getattr(first, "text", None) or "[non-text result]"), failed
 
 
+#: How much of a tool result the WATCHER is shown, and how much the MODEL is
+#: sent. Two different jobs - the page is a window on the work, the message list
+#: is what every later turn pays for - so the two numbers differ on purpose.
+SHOWN, SENT = 1200, 8000
+
+
+def shorten(text: str, limit: int, where: str) -> str:
+    """`text` cut to `limit`, saying so whenever it cuts.
+
+    ⛔ IT CUT IN SILENCE, AND THE PERSON WATCHING GOT THE SMALLER COPY. A read
+    of a real page is tens of kilobytes; the page showed the first 1200
+    characters, stopping mid-word with no ellipsis, no count and no hint that
+    anything had been removed, while the line below handed the model nearly
+    seven times as much. Somebody expanding a step to audit what the agent saw
+    read a partial page as the whole one. The product's whole claim is that you
+    can watch what it does, and the watcher was the one being given less.
+
+    Both callers say it now, because the model reading a truncated page without
+    being told is the same defect one level up: it can ask for the rest, but
+    only if it knows there is a rest.
+
+    The marker starts on a new line so the page files the result into an
+    expandable block rather than onto the step row, and it is ASCII: a
+    non-ASCII character on a line this server may print is a known way to kill
+    the process on Windows.
+    """
+    if len(text) <= limit:
+        return text
+    return "%s\n[... %d more characters, not %s]" % (
+        text[:limit], len(text) - limit, where)
+
+
 class Conversation:
     """One transcript, and the loop that grows it.
 
@@ -216,9 +248,10 @@ class Conversation:
                     text = f"{type(exc).__name__}: {exc}"
                     await say("err", text)
                 else:
-                    await say("err" if failed else "result", text[:1200])
+                    await say("err" if failed else "result",
+                              shorten(text, SHOWN, "shown"))
                 self.messages.append({"role": "tool", "tool_call_id": call.id,
-                                      "content": text[:8000]})
+                                      "content": shorten(text, SENT, "sent")})
 
 
 async def run_task(mcp, task: str, *, client, model: str,

--- a/src/aihawk/chat.py
+++ b/src/aihawk/chat.py
@@ -234,10 +234,28 @@ class ChatService:
                 # its thread and its answer is discarded, so a run stopped
                 # mid-turn is still billed for that reply. Stopping cuts what
                 # comes next, never what is already in the air.
-                await self.emit("err", "stopped")
+                # ⛔ NOT AN ERROR. THE PERSON PRESSED THE BUTTON. This emitted
+                # `err` with the single word `stopped`, so a deliberate and
+                # correct action was answered with a red box, announced to a
+                # screen reader as "error stopped", and any step in flight was
+                # flipped to the failed state. The page treated the user's own
+                # instruction as a fault.
+                await self.emit("note", "Stopped.")
                 raise
             except Exception as exc:
-                await self.emit("err", f"{type(exc).__name__}: {exc}")
+                # ⛔ AND THIS PRINTED A PYTHON CLASS NAME AND THE PROVIDER'S
+                # RAW JSON INTO THE CONVERSATION. It is the one line in the
+                # product a person reads at the exact moment something has gone
+                # wrong, and it said nothing about what to do next or about the
+                # instruction they had just lost sight of. The detail stays -
+                # it is the only clue when the cause is real - behind a sentence
+                # that says what happened and what is still true.
+                detail = " ".join(str(exc).split())
+                await self.emit("err", "The turn ended early. What you asked is "
+                                "still in the transcript, so you can send it "
+                                "again once this is dealt with. (%s%s)"
+                                % (type(exc).__name__,
+                                   ": " + detail[:200] if detail else ""))
             finally:
                 await self.emit("busy", "0")
                 # After the turn and not during it: a transcript written

--- a/src/aihawk/ui/css/01-tokens.css
+++ b/src/aihawk/ui/css/01-tokens.css
@@ -152,7 +152,7 @@ code,pre,.g,.meta,.badge,#url{
    the meter at 2.71, the placeholder inside a screen at 2.51, the layout icons
    at 2.51. WCAG AA wants 4.5:1 for text and 3:1 for a graphic that carries
    meaning, and the token's own comment in this file says what it is for. A
-   label is a small word, not a faint one: `--fg-3` is 4.8:1 and still reads as
+   label is a small word, not a faint one: `--fg-3` is 6.3:1 on the ground and 5.9:1 on --raised and still reads as
    quieter than the thing it labels. */
 /* ⛔ AND THE TWO DEEPEST HEADINGS JOIN IT RATHER THAN RETYPING IT. `h5` had
    the body's size, the body's face and less contrast than the paragraph

--- a/src/aihawk/ui/css/01-tokens.css
+++ b/src/aihawk/ui/css/01-tokens.css
@@ -109,6 +109,9 @@
      and the kind of number nobody questions because it looks round in decimal. */
   --spine:48px;                               /* the sessions rail */
   --drawer:256px;                             /* the standard drawer's width */
+  --split:9px;                                /* the separator, and its own width */
+  --pane-min:420px;                           /* the conversation, at its narrowest */
+  --stage-min:480px;                          /* the picture, below which it is a strip */
   --topbar:56px;                              /* every header, one height */
   --h-ctl:40px;                               /* every control on a bar */
   --gutter:1.75rem;                            /* three digits of 11px mono */

--- a/src/aihawk/ui/css/01-tokens.css
+++ b/src/aihawk/ui/css/01-tokens.css
@@ -56,6 +56,23 @@
   --on-accent: #151005;
   --ok:  #79bf94;         /* 8.6:1 */
   --err: #e88b76;         /* 7.4:1 */
+  /* The error SURFACE, written twice with two different percentages - 9 and 8
+     for the fill, 32 and 30 for the edge - on two things that are the same
+     thing to the eye. The mechanisms stay different on purpose (a border on a
+     free-standing box, an inset shadow on a grid row, where a border would
+     shift all four tracks by two pixels); only the colour is shared. */
+  --err-fill: color-mix(in srgb, var(--err) 9%, transparent);
+  --err-edge: color-mix(in srgb, var(--err) 32%, transparent);
+
+  /* ⛔ THE INK OF A SHADOW, NOT THE SHADOW. Seven shadows were written by hand
+     with six geometries and five alphas, and the temptation is a `--e-2` that
+     carries the whole value - which cannot work here, because the offsets are
+     genuinely different jobs: the drawer throws sideways, the composer throws
+     UPWARD because it separates an input from a transcript scrolling under it.
+     So the depth is shared and the direction stays with the component. */
+  --shade-1: rgba(0,0,0,.35);   /* a chip lifted off the thing behind it */
+  --shade-2: rgba(0,0,0,.5);    /* a bar, a tooltip */
+  --shade-3: rgba(0,0,0,.85);   /* a panel over the page */
 
   --sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --mono: ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas,
@@ -137,7 +154,16 @@ code,pre,.g,.meta,.badge,#url{
    meaning, and the token's own comment in this file says what it is for. A
    label is a small word, not a faint one: `--fg-3` is 4.8:1 and still reads as
    quieter than the thing it labels. */
-.label{ font-size:var(--t-label); font-weight:600; letter-spacing:.07em;
+/* ⛔ AND THE TWO DEEPEST HEADINGS JOIN IT RATHER THAN RETYPING IT. `h5` had
+   the body's size, the body's face and less contrast than the paragraph
+   under it - 8.4:1 against 14.5 - so it read as a dimmer sentence rather
+   than as a heading. The file already says that levels sharing a size are
+   separated by weight and colour, and `h4` has taken that slot, so what is
+   left for `h5` is a different KIND: the label treatment this page already
+   uses for a small word that is not a faint one. Named here instead of
+   copied into the transcript, or the day this rule is retuned they drift. */
+.label, .say h5.md-h, .say h6.md-h, .answer h5.md-h, .answer h6.md-h{
+        font-size:var(--t-label); font-weight:600; letter-spacing:.07em;
         text-transform:uppercase; color:var(--fg-3); line-height:1 }
 .sr{ position:absolute; width:1px; height:1px; overflow:hidden; clip-path:inset(50%) }
 .skip{ position:absolute; left:var(--s2); top:var(--s2); z-index:20;

--- a/src/aihawk/ui/css/02-sessions.css
+++ b/src/aihawk/ui/css/02-sessions.css
@@ -1,8 +1,9 @@
-/* ---------------- panes ---------------- */
-/* The session column is FIXED width and the two panes beside it share what is
-   left, because the column holds names and a name does not get more readable
-   with more room, while the transcript and the picture both do. It collapses
-   below 900px rather than squeezing the two things that matter. */
+/* ---------------- the sessions panel ---------------- */
+/* A FIXED-width panel that lies OVER the conversation as a modal, closed until
+   asked for. Fixed because it holds names, and a name does not get more
+   readable with more room; over rather than beside, because a column that
+   took its width out of the room moved and rewrapped the conversation every
+   time it opened. Below 900px it narrows, and nothing about it collapses. */
 /* ⛔ CLOSED UNTIL SOMEBODY ASKS FOR IT. A column of sessions standing open
    beside a conversation somebody is reading is a list nobody needed yet taking
    a fifth of the width; open by default it reads as scaffolding rather than as
@@ -92,6 +93,7 @@
    this - when a panel goes up a rung, what sits on it goes up a rung. */
 #newchat:hover{ background:var(--hover); color:var(--fg);
                 border-color:var(--line-2) }
+#newchat:active{ background:var(--top) }
 
 /* ⛔ AN ICON, AND THE WORD WHEN IT IS WANTED. The rail carried SESSIONS set
    vertically, and the word was the whole objection: it is the only thing on
@@ -135,13 +137,25 @@
 /* The word, on screen, the moment a pointer or the keyboard arrives. Drawn
    rather than left to `title`: the native tooltip waits about a second, takes
    the operating system's colours, and never appears for a keyboard at all. */
-#railtab::after{ content:attr(data-tip); position:absolute; left:calc(100% + var(--s2));
-                 top:9px; white-space:nowrap; pointer-events:none; z-index:6;
-                 background:var(--top); color:var(--fg); font-size:var(--t-label);
-                 padding:4px 8px; border-radius:var(--r-sm);
-                 box-shadow:0 2px 8px var(--shade-1);
-                 opacity:0; transition:opacity 125ms ease-out }
+/* ⛔ ONE LOOK FOR A DRAWN WORD, WHEREVER IT HANGS. The rail's tip was the only
+   one and its look was written into its own rule; the second tip - F2 on a
+   session row, for the keyboard that the native tooltip never serves - would
+   have copied all nine declarations. The look is shared by the attribute, and
+   each element keeps only where it puts the word and when it shows it. */
+[data-tip]::after{ content:attr(data-tip); position:absolute; white-space:nowrap;
+                   pointer-events:none; z-index:6;
+                   background:var(--top); color:var(--fg); font-size:var(--t-label);
+                   padding:4px 8px; border-radius:var(--r-sm);
+                   box-shadow:0 2px 8px var(--shade-1);
+                   opacity:0; transition:opacity 125ms ease-out }
+#railtab::after{ left:calc(100% + var(--s2)); top:9px }
 #railtab:hover::after, #railtab:focus-visible::after{ opacity:1 }
+/* On the row, at the right, and only while the NAME has keyboard focus: a
+   pointer user has the double click and the native title, and a tip that
+   appeared on every hover would be a label on every row. */
+.chat::after{ right:var(--s2); top:calc(100% - 4px); text-transform:none;
+              letter-spacing:0; font-weight:400 }
+.chat:has(.nm:focus-visible)::after{ opacity:1 }
 /* Open: the rail lifts a rung and the icon goes to full ink. The state is drawn
    on the thing you press, where a hand already is - and the word goes quiet,
    because the column beside it is now saying its own name. */
@@ -153,18 +167,7 @@
    into the whole sessions feature. */
 #railtab:focus-visible{ outline-offset:-4px }
 #railtab:hover{ background:var(--raised); color:var(--fg) }
-/* ⛔ OPEN, THE RAIL GIVES ITS WIDTH AWAY. A 48px strip beside an open column is
-   48px that says nothing: the column beside it already carries the name, the
-   state and the way out. So the button leaves the flow - the conversation gets
-   those pixels back and the panel starts at the edge of the window - and is
-   drawn over the panel's own header, in the same place on screen it was a
-   moment ago.
-
-   Moved, not duplicated. It is the same button, and it has to be: a second
-   control that opens the same column is a second thing to keep in step with the
-   first, which this page carried for half an hour once and a gate now forbids.
-   It is also the only thing that CLOSES the column, so it cannot simply be
-   hidden. */
+#railtab:active{ background:var(--hover) }
 /* ⛔ ABOVE THE PANEL, AND 5 IS THE PANEL. Both were 5, and the panel comes
    later in the document, so it painted over the button: the icon was exactly
    where it belonged, 48 by 56 at the top-left corner, and invisible. The
@@ -202,6 +205,10 @@
        color:var(--fg-2); font:inherit; font-size:var(--t-body);
        text-align:left }
 .chat:hover{ background:var(--hover); color:var(--fg) }
+/* Pressed is one rung above hovered, on every control that hovers to a rung:
+   not a global scale on `button:active`, which would shrink a full-width row,
+   the segmented pair and the delete cross alike - decoration by category. */
+.chat:active{ background:var(--top) }
 /* A mark on the edge rather than a filled row: the current session should be
    findable at a glance without the list turning into a row of blocks. */
 /* The attribute sits on the BUTTON now, where the name is, so the row is
@@ -254,6 +261,7 @@
           opacity:0; transition:opacity 120ms ease-out }
 .chat:hover .x, .chat:focus-within .x, .chat .x:focus-visible{ opacity:1 }
 .chat .x:hover{ background:var(--line-2); color:var(--fg) }
+.chat .x:active{ background:var(--line-3) }
 
 
 /* ⛔ A PERCENTAGE ALONE GIVES THE SURPLUS TO THE WRONG PANE. The conversation

--- a/src/aihawk/ui/css/02-sessions.css
+++ b/src/aihawk/ui/css/02-sessions.css
@@ -115,13 +115,21 @@
    the other way round for one commit - band across the whole width, rail
    hanging below - and the owner asked for this one back. It is also the older
    of the two: the strip belongs to the room, not to the pane beside it. */
-#railtab{ flex:none; width:var(--spine); padding:11px 0 0; cursor:pointer; border:0;
+/* ⛔ CENTRED IN A ROW ONE HEADER TALL, AND NOT BY A NUMBER. An 11px top
+   padding put the icon 4.5px above the line the drawer title, the model chip
+   and the address bar all share: the kind of miss nobody names and everybody
+   reads as unfinished, on the app's most visible seam. A margin computed from
+   the icon's size would work and would put that size in a second file, so a
+   redrawn icon would silently un-centre itself. A grid row exactly one header
+   tall centres whatever is drawn in it. */
+#railtab{ flex:none; width:var(--spine); padding:0; cursor:pointer; border:0;
+          display:grid; grid-template-rows:calc(var(--topbar) - 1px) 1fr;
+          justify-items:center; align-items:center;
           position:relative; background:var(--base); color:var(--fg-3);
 
           /* Half the weight it was: a hairline that says where the room ends
              rather than a rule that draws attention to itself. */
           box-shadow:inset -.5px 0 0 var(--accent);
-          display:flex; justify-content:center; align-items:flex-start;
           transition:background-color 120ms ease-out, color 120ms ease-out }
 #railtab svg{ flex:none; display:block }
 /* The word, on screen, the moment a pointer or the keyboard arrives. Drawn

--- a/src/aihawk/ui/css/02-sessions.css
+++ b/src/aihawk/ui/css/02-sessions.css
@@ -19,29 +19,42 @@
    Anchored to the spine's own width so the two are one object, and lifted with
    a shadow rather than a border, because what says "this is over that" is the
    shadow. */
-/* ⛔ IT STOPS ABOVE THE COMPOSER, AND THAT IS NOT DECORATION. Full height, it
-   covered 256px of the 530px input - measured 2026-09-11, and `elementFromPoint`
-   on the corner of the textarea answered `chats`, so half of the only input on
-   the page was dead with nothing saying so. The rule that used to prevent it
-   padded the transcript out of the way, and that rewrapped every paragraph as
-   the panel appeared, which is what it was removed for.
+/* ⛔ IT IS A MODAL NOW, AND THAT IS WHAT ANSWERS THE THING THE OWNER SAW. It
+   floated over the near edge of the conversation and left what it covered
+   looking READABLE: measured 2026-09-12 in a real browser, 240px off the front
+   of every line at every desktop width - 48% of the measure at 1440px, 61% at
+   960px, 29 rows buried at once and one of them whole. Lines read
+   `.com/it/ navigated to` with the verb and the step number underneath the
+   panel. That is not a panel over a page, that is text that looks broken.
 
-   So the CHAT still knows nothing: the coupling runs the other way, and the
-   panel knows where the input begins.
+   Covering is not the defect. Covering while the page underneath still claims
+   to be usable is. So the two panes go `inert` behind it and dim to 2.36:1 by
+   the shell's one `[inert]` rule, Escape closes it, a click outside closes it,
+   and choosing a conversation closes it on the way out. What is covered is
+   visibly out of play, for as long as it takes to pick a name.
 
-   ⛔ AND IT IS THE DISTANCE TO THE INPUT, NOT THE HEIGHT OF IT. The first
-   version published the composer's height, which is the same number only
-   while the composer sits at the bottom of the window. Below 720px the panes
-   stack - the conversation becomes `60vh` with the browser under it - so the
-   input is in the MIDDLE of the window and the drawer ran straight over it
-   again: measured 34% at 719px and 43% at 600px, in a real browser, on the
-   build that was supposed to have fixed this. `I made it vertical so it holds
-   at every width` was the claim, and eight widths said otherwise. */
-#rail { position:absolute; top:0; bottom:var(--rail-bottom, 0px);
+   ⛔ AND THAT IS WHY `--rail-bottom` IS GONE, with the function that published
+   it, its observer and its listener. It existed so the drawer would stop short
+   of the composer: a second place that knew where the input is, re-measured on
+   every resize, because the input moves when the panes stack. With the composer
+   inert behind the panel there is nothing to keep clear of - it cannot be typed
+   into either way - so the drawer runs the full height and one mechanism does
+   what two had to agree on.
+
+   The surface is `--raised` and not `--well`: the recessed rung against the
+   ground is 1.04:1, so the edge that was supposed to say "this is on top of
+   that" was invisible, and the shadow was carrying the separation alone. */
+#rail { position:absolute; top:0; bottom:0;
         left:var(--spine); width:var(--drawer);
         z-index:5; display:flex; flex-direction:column;
-        background:var(--well); border-right:1px solid var(--line-1);
-        box-shadow:14px 0 34px -18px #000 }
+        background:var(--raised); border-right:1px solid var(--line-3);
+        box-shadow:18px 0 36px -14px rgba(0,0,0,.85) }
+/* An animation and not a transition: the panel is toggled with `hidden`, so it
+   goes from not being rendered to being rendered, and there is no `from` value
+   for a transition to start at. The global reduced-motion block in the stage
+   stylesheet reaches this, like every other animation on the page. */
+#rail:not([hidden]){ animation:railin 150ms ease-out }
+@keyframes railin{ from{ transform:translateX(-100%) } }
 /* The header of the column lines up with the header of the conversation beside
    it: same height, same padding, so the two read as one row across the app. */
 /* ⛔ NO LEFT PADDING FOR THE BUTTON ANY MORE, and this said the opposite until
@@ -53,12 +66,31 @@
            gap:8px; padding:0 var(--s3);
            border-bottom:1px solid var(--line-1) }
 #railhead .label{ flex:1 }
+/* ⛔ THE PANEL ANSWERS IN THE PANEL. A rename that the server refuses and a
+   delete it refuses because the agent is mid-run were both reported into the
+   transcript - which, with the panel open, is the thing the panel is covering
+   and the page has just put out of play. The sentence landed where nobody
+   could read it. Cleared by `drawChats`, which already runs on every path that
+   changes this list, so no caller has to remember to empty it. The colours are
+   the transcript's own `.orph` recipe rather than a second set picked by hand:
+   one description of what an error looks like. */
+#railsay{ flex:none; margin:0 var(--s2); padding:6px 8px;
+          font-size:var(--t-label); line-height:1.4; color:var(--err);
+          background:color-mix(in srgb, var(--err) 9%, transparent);
+          border:1px solid color-mix(in srgb, var(--err) 32%, transparent);
+          border-radius:var(--r-sm) }
+#railsay:empty{ display:none }
 #newchat{ flex:none; width:48px; height:48px; display:grid;
           place-items:center; padding:0; border-radius:var(--r);
           border:1px solid transparent; background:none;
           color:var(--fg-3); cursor:pointer;
           transition:background-color 120ms ease-out, color 120ms ease-out }
-#newchat:hover{ background:var(--raised); color:var(--fg);
+/* ⛔ `--hover` AND NOT `--raised`, AND THE WHOLE GROUP MOVED TOGETHER. The panel
+   itself is `--raised` now, so a row that lit up to `--raised` on hover lit up
+   to the colour it was already sitting on: the feedback would have been deleted
+   by a one-line change to the surface behind it. The ladder exists for exactly
+   this - when a panel goes up a rung, what sits on it goes up a rung. */
+#newchat:hover{ background:var(--hover); color:var(--fg);
                 border-color:var(--line-2) }
 
 /* ⛔ AN ICON, AND THE WORD WHEN IT IS WANTED. The rail carried SESSIONS set
@@ -154,11 +186,13 @@
           nobody reports. */
        color:var(--fg-2); font:inherit; font-size:var(--t-body);
        text-align:left }
-.chat:hover{ background:var(--raised); color:var(--fg) }
+.chat:hover{ background:var(--hover); color:var(--fg) }
 /* A mark on the edge rather than a filled row: the current session should be
    findable at a glance without the list turning into a row of blocks. */
-.chat[aria-current="true"]{ color:var(--fg) }
-.chat[aria-current="true"]::before{ content:""; position:absolute; left:0;
+/* The attribute sits on the BUTTON now, where the name is, so the row is
+   selected through it rather than carrying a second copy of the same fact. */
+.chat:has([aria-current="true"]){ color:var(--fg) }
+.chat:has([aria-current="true"])::before{ content:""; position:absolute; left:0;
        top:7px; bottom:7px; width:2px; border-radius:2px; background:var(--fg-3) }
 /* The name is a button so it can be reached by keyboard, and the whole of the
    user agent's button chrome has to come off or it draws as a raised box with
@@ -173,9 +207,18 @@
    The height comes from a min-height rather than padding: the row is a flex
    child and padding would move the text off the baseline it shares with the
    count beside it. */
+/* ⛔ NOT A FLEX CONTAINER, AND THE ELLIPSIS IS THE WHOLE REASON.
+   `text-overflow` does nothing on one: the text becomes an anonymous flex item
+   and there is no line box for the ellipsis to hang off. So this rule asked for
+   the ellipsis and the display mode switched it off - measured on the running
+   page 2026-09-12, a name overflowing its box by 10px and cut dead with no
+   mark, which reads as a broken row rather than as a long name. The row itself
+   is already `display:flex; align-items:center`, so nothing here has to centre
+   anything, and `font:inherit` brings the body's 1.55 leading, which puts the
+   line box at 24.8px and meets the 24px target floor without a second number
+   being declared. */
 .chat .nm{ cursor:pointer; flex:1; min-width:0; overflow:hidden;
-           text-overflow:ellipsis; min-height:24px; display:flex;
-           align-items:center;
+           text-overflow:ellipsis; min-height:24px;
            white-space:nowrap; border:0; background:none; color:inherit;
            font:inherit; text-align:left; padding:0 }
 #chats .none{ margin:0; padding:var(--s3) var(--s2); color:var(--fg-3);

--- a/src/aihawk/ui/css/02-sessions.css
+++ b/src/aihawk/ui/css/02-sessions.css
@@ -48,7 +48,7 @@
         left:var(--spine); width:var(--drawer);
         z-index:5; display:flex; flex-direction:column;
         background:var(--raised); border-right:1px solid var(--line-3);
-        box-shadow:18px 0 36px -14px rgba(0,0,0,.85) }
+        box-shadow:18px 0 36px -14px var(--shade-3) }
 /* An animation and not a transition: the panel is toggled with `hidden`, so it
    goes from not being rendered to being rendered, and there is no `from` value
    for a transition to start at. The global reduced-motion block in the stage
@@ -76,8 +76,8 @@
    one description of what an error looks like. */
 #railsay{ flex:none; margin:0 var(--s2); padding:6px 8px;
           font-size:var(--t-label); line-height:1.4; color:var(--err);
-          background:color-mix(in srgb, var(--err) 9%, transparent);
-          border:1px solid color-mix(in srgb, var(--err) 32%, transparent);
+          background:var(--err-fill);
+          border:1px solid var(--err-edge);
           border-radius:var(--r-sm) }
 #railsay:empty{ display:none }
 #newchat{ flex:none; width:48px; height:48px; display:grid;
@@ -139,7 +139,7 @@
                  top:9px; white-space:nowrap; pointer-events:none; z-index:6;
                  background:var(--top); color:var(--fg); font-size:var(--t-label);
                  padding:4px 8px; border-radius:var(--r-sm);
-                 box-shadow:0 2px 8px rgba(0,0,0,.4);
+                 box-shadow:0 2px 8px var(--shade-1);
                  opacity:0; transition:opacity 125ms ease-out }
 #railtab:hover::after, #railtab:focus-visible::after{ opacity:1 }
 /* Open: the rail lifts a rung and the icon goes to full ink. The state is drawn
@@ -194,7 +194,7 @@
            laid out until they are scrolled to, and Ctrl+F still finds them. */
         content-visibility:auto; contain-intrinsic-size:auto 600px }
 .chat{ position:relative; display:flex; align-items:center; gap:6px; width:100%;
-       padding:7px 8px 7px 10px; border:0; border-radius:8px; background:none;
+       padding:7px 8px 7px 10px; border:0; border-radius:var(--r); background:none;
        /* --t-body and not --t-small: the latter was referenced here, exactly
           once, and declared nowhere, so the size silently fell back to what
           it inherited. A dangling token that renders plausibly is the kind
@@ -249,7 +249,7 @@
    that row is neither hovered nor focused, so the control that deletes a
    conversation was reachable in one direction only. Transparent instead, and
    it shows itself the moment it takes focus. */
-.chat .x{ flex:none; width:24px; height:24px; border:0; border-radius:4px;
+.chat .x{ flex:none; width:24px; height:24px; border:0; border-radius:var(--r-sm);
           background:none; color:var(--fg-3); cursor:pointer; line-height:1;
           opacity:0; transition:opacity 120ms ease-out }
 .chat:hover .x, .chat:focus-within .x, .chat .x:focus-visible{ opacity:1 }

--- a/src/aihawk/ui/css/02-sessions.css
+++ b/src/aihawk/ui/css/02-sessions.css
@@ -137,6 +137,13 @@
 /* Open: the rail lifts a rung and the icon goes to full ink. The state is drawn
    on the thing you press, where a hand already is - and the word goes quiet,
    because the column beside it is now saying its own name. */
+/* ⛔ INSIDE, OR THE RING IS CLIPPED ON THREE SIDES. The strip is flush with
+   the window on the left, the top and the bottom, so the page-wide focus
+   outline drew outside the viewport and the only segment left was a 2px
+   amber line beside the permanent amber hairline this strip already
+   carries - two similar marks 2.5px apart, on the single keyboard route
+   into the whole sessions feature. */
+#railtab:focus-visible{ outline-offset:-4px }
 #railtab:hover{ background:var(--raised); color:var(--fg) }
 /* ⛔ OPEN, THE RAIL GIVES ITS WIDTH AWAY. A 48px strip beside an open column is
    48px that says nothing: the column beside it already carries the name, the

--- a/src/aihawk/ui/css/03-shell.css
+++ b/src/aihawk/ui/css/03-shell.css
@@ -189,6 +189,10 @@
 #log > *{ overflow-anchor:none }
 #anchor{ height:1px; overflow-anchor:auto }
 
+/* 46ch is 397px, which is about 57 characters at the 16px body: a `ch` is the
+   width of a zero, not of a letter, and this file carries the warning about
+   exactly that a few rules up. 57 is inside the measure every source here
+   quotes, so the number is right and it was the LABEL that was lying. */
 #hint{ color:var(--fg-3); max-width:46ch; margin:var(--s6) auto 0; text-align:center }
 #hint p{ margin:0 0 var(--s4) }
 #hint .eg{ font:var(--t-mono)/1.9 var(--mono); color:var(--fg-2);

--- a/src/aihawk/ui/css/03-shell.css
+++ b/src/aihawk/ui/css/03-shell.css
@@ -105,16 +105,19 @@
    whoever was reading them. The owner named the rule by looking at it: the
    bar lives on top and the chat must not know a thing.
 
-   What covering costs is the near edge of the conversation, and the words
-   stay where they are to come back to. What it must NOT cover is a control,
-   which is why the drawer stops above the composer - see `--composer-h` in
-   the sessions stylesheet. */
-/* ⛔ AND THE CHAT DOES NOT KNOW THE COLUMN EXISTS. The transcript and the
-   composer took a left padding here while the panel was open, to keep out
-   from under it - but a padding that changes changes the line width, so every
-   paragraph rewrapped as the panel appeared: the text moved under the eyes of
-   whoever was reading it. The panel is an overlay. It covers the near edge and
-   the rest of the words stay where they are, to come back to by closing it. */
+   What covering costs is the near edge of the conversation, and the words stay
+   where they are to come back to. What it must not do is cover them while they
+   still look readable, which is what it did until 2026-09-12: that is answered
+   in the sessions stylesheet, where the panel became a modal and the two panes
+   go inert behind it. Nothing about it is known here, and that is the point -
+   the coupling runs one way and it does not start in this file.
+
+   ⛔ AND THE `--composer-h` THIS PARAGRAPH USED TO SEND THE READER TO HAD BEEN
+   DEAD FOR A DAY BEFORE THE DRAWER STOPPED NEEDING ONE AT ALL. It was renamed
+   to `--rail-bottom` on the same afternoon it was written, and the variable is
+   now gone with the function, the observer and the listener that maintained it.
+   A pointer to a name that does not exist is worse than no pointer: it reads as
+   a fact somebody could go and check. */
 /* Capped in CHARACTERS and not in pixels, because the thing being limited is
    the measure and 680px is only one screen's worth of it: on a 1920 window the
    same column ran to about 92 characters, past the 80 the WCAG asks for and

--- a/src/aihawk/ui/css/03-shell.css
+++ b/src/aihawk/ui/css/03-shell.css
@@ -56,7 +56,7 @@
    conversation is costing and running, then the one thing you can do to it.
    The rule that separates the last is the same hairline the panes use. */
 #head { flex:none; height:var(--topbar); display:flex; align-items:center;
-        gap:var(--s2); padding:0 var(--s4);
+        justify-content:flex-end; gap:var(--s2); padding:0 var(--s4);
         border-bottom:1px solid var(--line-1) }
 #head .vr{ width:1px; height:18px; flex:none; background:var(--line-2);
            margin:0 var(--s1) }
@@ -65,7 +65,9 @@
    model and Clear against the left edge, under the transcript's own margin and
    nowhere near the edge they had always sat on. The push belongs to the first
    of whatever survives, not to whichever element happened to be there. */
-#head #model{ margin-left:auto }
+/* The push is the CONTAINER'S now (`justify-content:flex-end` above), so it
+   no longer depends on which child happens to exist: the badge is hidden until
+   the server names a model, and a hidden child cannot carry a margin. */
 /* The heading is out of flow (`.sr` is absolute), so it is not one of the
    things being pushed, and this rule only describes the size it is announced
    at rather than drawn at. */
@@ -87,8 +89,9 @@
    22 and 23 - close enough to look fine and short enough to fail. */
 #fresh{ font-family:var(--sans); cursor:pointer;
         transition:background-color 120ms ease-out, color 120ms ease-out }
-#fresh:hover:not(:disabled){ background:var(--hover); color:var(--fg) }
-#fresh:disabled{ opacity:.3; cursor:default }
+#fresh:hover:not([aria-disabled="true"]){ background:var(--hover); color:var(--fg) }
+#fresh:active:not([aria-disabled="true"]){ background:var(--top) }
+#fresh[aria-disabled="true"]{ cursor:default }
 
 /* ⛔ `inert` HAS NO LOOK, AND A CONTROL THAT CANNOT BE USED MUST NOT LOOK
    USABLE. This page already spells that `opacity:.3` on a disabled button, and
@@ -98,7 +101,11 @@
    to see, and stayed fully lit the whole time. Seen on the running page, a
    deleted conversation left a composer inviting a sentence it could not send.
    One rule, so the look follows the mechanism rather than whoever remembers. */
-[inert]{ opacity:.3 }
+/* ⛔ AND ONE VALUE FOR THE WHOLE CLASS. Four rules said "this control cannot
+   be used" with two different numbers - .3 on two disabled buttons and on
+   inert subtrees, .4 on the empty room's picker - and the newest control was
+   left out altogether. Whatever the mechanism, the look is this one. */
+:disabled, [inert], [aria-disabled="true"]{ opacity:.3 }
 
 #log{ flex:1; overflow:auto; scrollbar-gutter:stable;
       padding:var(--s5) var(--s4) }
@@ -147,11 +154,15 @@
    characters per line, past every source that has a number: 65-72 in the chat
    design guidance, 75 as Baymard's upper bound, 80 as the WCAG 2.1 AAA cap.
 
-   66ch is 498px here; minus the 37px indent that is 461px of text, and at
-   6.11px a character that is 75 characters. The unit stays `ch` because it
-   tracks the font's own metrics if the font ever changes; the number comes
-   from the measurement, and the conversion is written down here so the next
-   person does not redo it in the wrong unit for the third time.
+   ⛔ MEASURED AT 14px, AND THE BODY IS 16px NOW. The ratio is what survives
+   a size change: at the size this page ships `0` is 8.63px and the average
+   character 6.98px, and one `ch` is still 1.24 characters. The cap itself
+   is gone - the pane is the measure, see the block below - so the number
+   that matters is the DEFAULT: a 530px pane minus its padding holds about
+   71 characters at 16px, inside every range quoted above, and the gate that
+   computes it reads the pane's own ceiling rather than a number written
+   here. The conversion stays written down so the next person does not redo
+   it in the wrong unit for the third time.
 
    Left aligned rather than centred: centring splits the slack in two and puts
    half on the LEFT, which reads as the column having been pushed away from the
@@ -204,14 +215,22 @@
    quotes, so the number is right and it was the LABEL that was lying. */
 #hint{ color:var(--fg-3); max-width:46ch; margin:var(--s6) auto 0; text-align:center }
 #hint p{ margin:0 0 var(--s4) }
-#hint .eg{ font:var(--t-mono)/1.9 var(--mono); color:var(--fg-2);
+#hint .eg{ display:block; width:100%; cursor:pointer;
+           font:var(--t-mono)/1.9 var(--mono); color:var(--fg-2);
            background:var(--raised); border:1px solid var(--line-1);
-           border-radius:var(--r); padding:var(--s3) var(--s4); text-align:left }
+           border-radius:var(--r); padding:var(--s3) var(--s4); text-align:left;
+           transition:background-color 120ms ease-out }
+#hint .eg:hover{ background:var(--hover); color:var(--fg) }
+#hint .eg:active{ background:var(--top) }
 #hint .sm{ font-size:var(--t-label); color:var(--fg-3) }
 
 #jump{ position:absolute; bottom:100%; margin-bottom:var(--s2);
        left:50%; transform:translateX(-50%); z-index:2;
        background:var(--top); border:1px solid var(--line-2); color:var(--fg);
        font:var(--t-ui)/1 var(--sans); padding:7px 13px;
-       border-radius:var(--r-pill); cursor:pointer }
+       border-radius:var(--r-pill); cursor:pointer;
+       transition:border-color 120ms ease-out }
+/* It sits on `--top`, the last rung, so there is no background above it: the
+   edge answers the pointer instead. */
+#jump:hover{ border-color:var(--line-3) }
 

--- a/src/aihawk/ui/css/03-shell.css
+++ b/src/aihawk/ui/css/03-shell.css
@@ -1,10 +1,19 @@
-#left { width:clamp(420px, 44%, 530px); display:flex; flex-direction:column;
+/* ⛔ 44% OF THE ROOM THE TWO PANES ACTUALLY SHARE, not of the window. The
+   percentage was measured against the whole window while the spine and the
+   separator are outside the split, so the conversation was quietly 25px
+   narrower than the number said at every width where the clamp was not
+   already binding. The floor and the separator are tokens now, read here and
+   by the separator's own rule and by the code that drags it: one number, three
+   readers, instead of the same 420 and 9 written out in four places. */
+#left { width:clamp(var(--pane-min),
+                    calc((100% - var(--spine) - var(--split)) * .44), 530px);
+        display:flex; flex-direction:column;
         position:relative }
 /* The separator carries the line that used to be `#left`'s right border, so
    the thing you drag and the thing you see are the same thing. Wider than the
    line it draws: a 1px target is a 1px target, and this one is grabbed by
    hand. */
-#split{ flex:0 0 9px; cursor:col-resize; position:relative; background:none;
+#split{ flex:0 0 var(--split); cursor:col-resize; position:relative; background:none;
         border:0; padding:0; touch-action:none }
 /* ⛔ NINE PIXELS OF LINE, TWENTY-FIVE OF TARGET. WCAG 2.2 puts the floor at
    24px and none of its exceptions cover a separator: the arrow keys are a

--- a/src/aihawk/ui/css/04-transcript.css
+++ b/src/aihawk/ui/css/04-transcript.css
@@ -85,7 +85,10 @@ h5.md-h, h6.md-h{ font-size:var(--t-h3); font-weight:600; color:var(--fg-2) }
    whatever page the agent last read, and the browser it drives is right there.
    The address is printed next to them so an injected one is legible. */
 .lk  { color:var(--fg) }
-.href{ color:var(--fg-3); font:.75rem/1.5 var(--mono); overflow-wrap:anywhere }
+/* ⛔ `--t-mono`, THE SIZE THIS FILE'S OWN TOKEN NAMES FOR AN ADDRESS. It was hand-written at .75rem,
+   which made the printed address the SMALLEST type on the page - the one string that exists
+   so that an injected link can be read before it is trusted. */
+.href{ color:var(--fg-3); font:var(--t-mono)/1.5 var(--mono); overflow-wrap:anywhere }
 .href::before{ content:" " }
 /* ⛔ NO COLOURED BAR DOWN THE LEFT EDGE. A 2px stripe on a callout is the
    house style of every framework and belongs to none of them; a tint plus a
@@ -176,7 +179,9 @@ h5.md-h, h6.md-h{ font-size:var(--t-h3); font-weight:600; color:var(--fg-2) }
 .out{ margin:2px 0 var(--s2) var(--indent);
       max-height:290px; max-height:15lh; overflow:auto; overscroll-behavior:contain;
       white-space:pre-wrap; overflow-wrap:anywhere;
-      font:.75rem/1.5 var(--mono); color:var(--fg-3);
+      /* And the opened detail is not SMALLER than the row that introduced
+         it: clicking to read something made the something harder to read. */
+      font:var(--t-mono)/1.5 var(--mono); color:var(--fg-3);
       background:var(--raised); border-left:2px solid var(--line-2);
       border-radius:0 var(--r-sm) var(--r-sm) 0; padding:8px 10px }
 

--- a/src/aihawk/ui/css/04-transcript.css
+++ b/src/aihawk/ui/css/04-transcript.css
@@ -61,7 +61,9 @@ h3.md-h, h4.md-h, h5.md-h, h6.md-h{
    under it, which is a hierarchy only the weight was carrying. */
 h3.md-h{ font-size:var(--t-h1) }
 h4.md-h{ font-size:var(--t-h2); font-weight:600 }
-h5.md-h, h6.md-h{ font-size:var(--t-h3); font-weight:600; color:var(--fg-2) }
+/* h5 and h6 are dressed by the label rule in the token file: at the body's
+   size and face they were a dimmer paragraph, and the ladder had no slot
+   left for them that size and weight could carry. */
 /* A fenced block inside an answer is already inside the answer's indent, and
    `.out` carries its own for the tool output it was written for: the two
    stacked, so code sat a step to the right of the prose describing it. */
@@ -102,9 +104,9 @@ h5.md-h, h6.md-h{ font-size:var(--t-h3); font-weight:600; color:var(--fg-2) }
    house style of every framework and belongs to none of them; a tint plus a
    hairline in the same hue says the same thing without the costume. */
 .orph  { display:flex; gap:8px; font-size:var(--t-mono); color:var(--err);
-         background:color-mix(in srgb, var(--err) 9%, transparent);
+         background:var(--err-fill);
          border-radius:var(--r-sm);
-         border:1px solid color-mix(in srgb, var(--err) 32%, transparent);
+         border:1px solid var(--err-edge);
          padding:6px 10px }
 
 /* ONE grid: every row on the same rails, so nothing shifts as text changes. */
@@ -121,8 +123,14 @@ h5.md-h, h6.md-h{ font-size:var(--t-h3); font-weight:600; color:var(--fg-2) }
    reading. */
 .lab { user-select:text; grid-column:2; min-width:0; overflow:hidden;
        text-overflow:ellipsis; white-space:nowrap; font-size:var(--t-mono) }
-.lab b   { font-family:var(--sans); font-weight:600; color:var(--fg) }  /* the verb */
-.lab code{ color:var(--accent) }                                        /* the object */
+/* ⛔ THE INK MOVED BETWEEN THESE TWO, AND THEY HAVE TO MOVE TOGETHER. The
+   accent is the page's ACTION colour - it is on the send button - and its most
+   frequent appearance on screen was the address in a step row, which is not an
+   action and is not a thing to press. The address is the object of the line and
+   now carries full ink; the verb steps back to the quieter one, because two
+   full-ink things in one row is no hierarchy at all. */
+.lab b   { font-family:var(--sans); font-weight:600; color:var(--fg-2) } /* the verb */
+.lab code{ color:var(--fg) }                                            /* the object */
 .lab .inline{ color:var(--fg-3) }                    /* a short result, on the row */
 /* ⛔ SIX CHARACTERS OF ROOM, RESERVED, BECAUSE THE CLOCK GROWS WHILE IT RUNS.
    The timing is written ten times a second and the column was sized to its
@@ -181,11 +189,11 @@ h5.md-h, h6.md-h{ font-size:var(--t-h3); font-weight:600; color:var(--fg-2) }
    places had `--err` and `--well` re-expanded as rgba by hand, which is seven
    surfaces that would keep the old hue the day either token moves. */
 .ev[data-state="err"] > .row{
-     background:color-mix(in srgb, var(--err) 8%, transparent);
-     box-shadow:inset 0 0 0 1px color-mix(in srgb, var(--err) 30%, transparent) }
+     background:var(--err-fill);
+     box-shadow:inset 0 0 0 1px var(--err-edge) }
 
 .out{ margin:2px 0 var(--s2) var(--indent);
-      max-height:290px; max-height:15lh; overflow:auto; overscroll-behavior:contain;
+      max-height:15lh; overflow:auto; overscroll-behavior:contain;
       white-space:pre-wrap; overflow-wrap:anywhere;
       /* And the opened detail is not SMALLER than the row that introduced
          it: clicking to read something made the something harder to read. */

--- a/src/aihawk/ui/css/04-transcript.css
+++ b/src/aihawk/ui/css/04-transcript.css
@@ -130,6 +130,21 @@ h5.md-h, h6.md-h{ font-size:var(--t-h3); font-weight:600; color:var(--fg-2) }
   width:6px; height:6px; border-radius:50%; background:var(--accent);
   animation:breathe 1.4s ease-in-out infinite }
 .ev[data-state="err"] .g{ color:var(--err) }
+/* ⛔ THE OUTCOME IN WORDS, because the tint that carried it alone measures
+   1.12:1 against the row and says nothing in greyscale. `failed` on a step the
+   server refused, `stopped` on one the end of the turn had to close because no
+   result ever came. The face is the prose one on purpose: it is a word being
+   read, not part of the address beside it. */
+.lab .mark{ font-family:var(--sans); font-size:var(--t-label) }
+.ev[data-state="err"] .lab .mark{ color:var(--err) }
+.ev[data-state="off"] .lab .mark{ color:var(--fg-3) }
+/* And the inline result of a failed step is the reason it failed: it read in
+   the same quiet grey as an ordinary answer. */
+.ev[data-state="err"] .lab .inline{ color:var(--err) }
+/* A step nobody landed. Not an error - Stop is a correct thing to press - so
+   it takes no red, only the end of the running state, which is what stops the
+   dot that was asserting work nobody was doing. */
+.ev[data-state="off"] .g{ color:var(--fg-3) }
 /* The wait between steps, wearing the same row as a step so the sequence does
    not change shape when the agent is thinking rather than acting. Its verb is
    muted, because nothing has happened yet and a bold one would claim it had. */

--- a/src/aihawk/ui/css/04-transcript.css
+++ b/src/aihawk/ui/css/04-transcript.css
@@ -113,7 +113,16 @@ h5.md-h, h6.md-h{ font-size:var(--t-h3); font-weight:600; color:var(--fg-2) }
 .lab b   { font-family:var(--sans); font-weight:600; color:var(--fg) }  /* the verb */
 .lab code{ color:var(--accent) }                                        /* the object */
 .lab .inline{ color:var(--fg-3) }                    /* a short result, on the row */
-.meta{ grid-column:3; white-space:nowrap; font-size:var(--t-label); color:var(--fg-3) }
+/* ⛔ SIX CHARACTERS OF ROOM, RESERVED, BECAUSE THE CLOCK GROWS WHILE IT RUNS.
+   The timing is written ten times a second and the column was sized to its
+   contents, so every time the number gained a digit - `5ms` to `58ms` to
+   `412ms` to `1.0s` - the label beside it lost about 6.6px and re-truncated
+   under the reader's eye, three times in the first second of every step. A
+   `ch` really is one character here: this is the mono face and it is tabular,
+   which is the one place in this file where that unit means what it looks
+   like. */
+.meta{ grid-column:3; white-space:nowrap; font-size:var(--t-label);
+       min-width:6ch; text-align:right; color:var(--fg-3) }
 
 /* The chevron is the row's own pseudo-element in its own track: no svg, no icon
    font, and it cannot shift the label when it turns. */

--- a/src/aihawk/ui/css/04-transcript.css
+++ b/src/aihawk/ui/css/04-transcript.css
@@ -1,6 +1,14 @@
 /* ---------------- one turn ---------------- */
 .turn + .turn{ margin-top:var(--s6) }   /* between turns */
-.turn > * + *{ margin-top:var(--s3) }   /* inside a turn */
+/* ⛔ 20 AND NOT 12, BECAUSE THE SPACING SAID THE WRONG THING ABOUT WHAT
+   BELONGS TOGETHER. Two paragraphs of one answer are 16px apart, and the
+   answer sat 12px from the step row under it: a two-paragraph answer read as
+   two separate things and the step below read as part of the second one.
+   Raised here rather than lowering the paragraph gap - at the 1.6 leading
+   this file declares, 12px is under half a line and paragraphs stop
+   separating at all. The ladder is 4 / 8 / 16 / 20 / 24 / 32 and never goes
+   down as the things it separates get further apart. */
+.turn > * + *{ margin-top:var(--s5) }   /* inside a turn */
 /* A turn that has scrolled out of sight costs no layout and no paint. Chosen
    over hiding or removing old turns because it is the only one of the three
    that leaves the text findable with Ctrl+F and readable by a screen reader:

--- a/src/aihawk/ui/css/05-composer.css
+++ b/src/aihawk/ui/css/05-composer.css
@@ -2,7 +2,7 @@
 form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
       border-top:1px solid var(--line-1);
       background:var(--raised);
-      box-shadow:0 -1px 0 rgba(0,0,0,.5), 0 -12px 28px -12px rgba(0,0,0,.65) }
+      box-shadow:0 -1px 0 var(--shade-2), 0 -12px 28px -12px var(--shade-2) }
 .composer{ display:flex; align-items:flex-end; gap:var(--s2);
            background:var(--base); border:1px solid var(--line-2);
            border-radius:var(--r-lg); padding:10px 10px 10px var(--s3);

--- a/src/aihawk/ui/css/05-composer.css
+++ b/src/aihawk/ui/css/05-composer.css
@@ -39,7 +39,13 @@ form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
    thing that ends a run that will not converge. It follows the RUN. */
 #halt{ background:var(--stop) }
 #chip{ display:inline-flex; align-items:center; gap:6px; margin-bottom:var(--s2);
+       max-width:100%;
        background:var(--hover); border:1px solid var(--line-2); color:var(--fg-2);
        font-size:var(--t-label); padding:3px 9px; border-radius:var(--r-pill);
        cursor:pointer }
+/* The queued sentence can be a paragraph. It gives way to the width there is
+   rather than to a character count guessed in advance - a `ch` is the width of
+   a zero, not of a letter, and this file is not the place to relearn that. */
+#chip .what{ min-width:0; overflow:hidden; text-overflow:ellipsis;
+             white-space:nowrap }
 

--- a/src/aihawk/ui/css/05-composer.css
+++ b/src/aihawk/ui/css/05-composer.css
@@ -7,8 +7,19 @@ form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
            background:var(--base); border:1px solid var(--line-2);
            border-radius:var(--r-lg); padding:10px 10px 10px var(--s3);
            box-shadow:var(--lip); transition:border-color 120ms ease-out }
-.composer:focus-within{ border-color:var(--line-3) }
-#i{ flex:1; background:transparent; border:0; outline:none; resize:none; color:var(--fg);
+/* --fg-4 and not --line-3: this is the only signal a pointer user gets that the
+   box has the keyboard, and a border at 1.2:1 against the surface is not a
+   signal. #6b747d reads at 3.92:1 against the ground, over the 3:1 floor for a
+   non-text indicator, without inventing a token. */
+.composer:focus-within{ border-color:var(--fg-4) }
+/* ⛔ NO BLANKET `outline:none`, WHICH IS WHAT THIS RULE USED TO CARRY. It beats
+   the page-wide `:focus-visible` outline on specificity, so the one input on
+   the page - the only way to talk to the agent - had no focus ring at all for
+   anybody arriving by keyboard: the caret was the whole indication, and a caret
+   is invisible in a screenshot, at a distance, and to most people scanning a
+   window. Scoped to the case the declaration was actually written for. */
+#i:focus:not(:focus-visible){ outline:none }
+#i{ flex:1; background:transparent; border:0; resize:none; color:var(--fg);
     font:var(--t-body)/1.55 var(--sans); min-height:24px; max-height:200px;
     overflow-y:hidden; padding:0; caret-color:var(--accent) }
 /* --fg-3 and not --fg-4: the placeholder is the only hint the composer gives,

--- a/src/aihawk/ui/css/05-composer.css
+++ b/src/aihawk/ui/css/05-composer.css
@@ -11,15 +11,21 @@ form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
    box has the keyboard, and a border at 1.2:1 against the surface is not a
    signal. #6b747d reads at 3.92:1 against the ground, over the 3:1 floor for a
    non-text indicator, without inventing a token. */
-.composer:focus-within{ border-color:var(--fg-4) }
-/* ⛔ NO BLANKET `outline:none`, WHICH IS WHAT THIS RULE USED TO CARRY. It beats
-   the page-wide `:focus-visible` outline on specificity, so the one input on
-   the page - the only way to talk to the agent - had no focus ring at all for
-   anybody arriving by keyboard: the caret was the whole indication, and a caret
-   is invisible in a screenshot, at a distance, and to most people scanning a
-   window. Scoped to the case the declaration was actually written for. */
-#i:focus:not(:focus-visible){ outline:none }
-#i{ flex:1; background:transparent; border:0; resize:none; color:var(--fg);
+/* ⛔ ONE INDICATOR, ON THE CONTAINER, TWO PIXELS WIDE. The keyboard ring was
+   drawn on the textarea INSIDE this bordered box, and on a textarea
+   `:focus-visible` matches on every focus - a click included, because the
+   element takes keyboard input - so the page opened on two nested rectangles
+   and drew them again on every click into the box. The box is the control a
+   person sees, so the box says it has the keyboard: the border goes to
+   `--fg-4` and a 1px shadow doubles it to a 2px ring at 3.92:1 against the
+   ground, over the 3:1 floor for a focus indicator, with nothing moving. */
+.composer:focus-within{ border-color:var(--fg-4);
+                        box-shadow:var(--lip), 0 0 0 1px var(--fg-4) }
+/* `outline:none` on the field itself, because the ring belongs to the box
+   around it - see `.composer:focus-within` above. Not a blanket removal of the
+   focus signal: it is the one place on the page where the visible control and
+   the focusable element are two different boxes. */
+#i{ flex:1; background:transparent; border:0; outline:none; resize:none; color:var(--fg);
     font:var(--t-body)/1.55 var(--sans); min-height:24px; max-height:200px;
     overflow-y:hidden; padding:0; caret-color:var(--accent) }
 /* --fg-3 and not --fg-4: the placeholder is the only hint the composer gives,

--- a/src/aihawk/ui/css/05-composer.css
+++ b/src/aihawk/ui/css/05-composer.css
@@ -43,7 +43,20 @@ form{ position:relative; padding:var(--s3) var(--s4) var(--s4);
 #go:hover:not(:disabled){ background:var(--accent-hi) }
 #halt:hover{ background:var(--stop-hi) }
 #go:active, #halt:active{ transform:scale(.92); box-shadow:none }
-#go:disabled{ opacity:.3; cursor:default }
+#go:disabled{ cursor:default }
+/* ⛔ QUEUE LOOKS DIFFERENT FROM SEND, on the button itself. While the agent
+   works, Enter queues the sentence for the next turn, and the only thing that
+   said so was a placeholder that vanished at the first keystroke: the button
+   looked exactly like Send. Outlined rather than filled - the same shape, held
+   back - and the hover rule below has to be this specific or the ordinary
+   hover fills it in again and undoes the signal. */
+#go[data-mode="queue"]:not(:disabled), #go[data-mode="replace"]:not(:disabled){
+     background:transparent; color:var(--accent);
+     box-shadow:inset 0 0 0 1.5px var(--accent) }
+#go[data-mode="queue"]:hover:not(:disabled), #go[data-mode="replace"]:hover:not(:disabled){
+     background:color-mix(in srgb, var(--accent) 14%, transparent) }
+/* #chip sits on `--hover`; the next rung up is `--top`. */
+#chip:hover{ background:var(--top) }
 /* Its own button, not a mode of the send button. As a mode it disappeared the
    moment somebody typed, because the same control then meant "queue this for
    the next turn" - and the loop has no turn ceiling, so this button is the only

--- a/src/aihawk/ui/css/06-browser.css
+++ b/src/aihawk/ui/css/06-browser.css
@@ -66,8 +66,13 @@
    open, Live/Frozen, the layout picker and the address are three armed controls
    over an empty room: the bar looked identical whether the product was working
    or waiting to be told what to do. */
-#right[data-empty="1"] #url,
-#right[data-empty="1"] #mode{ opacity:.4 }
+/* ⛔ NEITHER LINE IS HERE ANY MORE, FOR TWO DIFFERENT REASONS. The picker
+   goes inert when the room is empty, and inert has one look, declared once in
+   the shell - a second opacity here was the second of the two numbers the
+   page used for "cannot be used". And the address is TEXT, not a control:
+   `opacity:.4` put `no page yet` at 2.13:1 on every first run, where the
+   `.dim` class the script already sets on an empty address reads at 6.6:1. Ink
+   for words, the shared rule for controls. */
 /* ⛔ AND `pointer-events` IS NOT A DISABLED STATE. It only stops the
    mouse: the five buttons kept their place in the tab order, kept the focus
    ring, and Enter still fired the handler - so a keyboard could operate five

--- a/src/aihawk/ui/css/06-browser.css
+++ b/src/aihawk/ui/css/06-browser.css
@@ -61,7 +61,7 @@
               transition:color 120ms ease-out }
 #mode button:hover:not([aria-pressed="true"]){ color:var(--fg-2) }
 #mode button[aria-pressed="true"]{ background:var(--top); color:var(--fg);
-                                    box-shadow:0 1px 2px rgba(0,0,0,.35) }
+                                    box-shadow:0 1px 2px var(--shade-1) }
 /* ⛔ A CONTROL THAT CANNOT DO ANYTHING DOES NOT LOOK READY. With no browser
    open, Live/Frozen, the layout picker and the address are three armed controls
    over an empty room: the bar looked identical whether the product was working

--- a/src/aihawk/ui/css/06-browser.css
+++ b/src/aihawk/ui/css/06-browser.css
@@ -74,11 +74,14 @@
    controls that look dead, and a screen reader announced them as ordinary
    enabled buttons. `inert` takes them out of both. */
 #right[data-empty="1"] #mode{ pointer-events:none }
-/* And the state word goes altogether: with nothing running it said IDLE, in
-   capitals, and was the brightest thing on a bar describing an empty room -
-   while the room itself already says what it is. */
-#right[data-empty="1"] #state{ position:absolute; width:1px; height:1px;
-                              overflow:hidden; clip-path:inset(50%) }
+/* ⛔ AND `idle` IS HIDDEN BY THE STATE ITSELF, NOT BY THE EMPTY ROOM. A rule
+   here clipped `#state` to one pixel whenever the pane was empty, which is
+   right for the word `idle` - capitals, the brightest thing on a bar describing
+   an empty room - and wrong for every other word that box can hold. Drop the
+   stream on a first run and `offline` was written into a clipped box: the
+   sighted user got a 7px dot changing colour, and nobody got the word. Two
+   places decided whether that word is worth showing; now the one that knows
+   WHICH word it is decides, in `say`. */
 
 /* The frame is solved from the available height, so a wide shot fills the width
    and a tall one fills the height. What is left over is stage, never a hole

--- a/src/aihawk/ui/css/08-stage.css
+++ b/src/aihawk/ui/css/08-stage.css
@@ -29,7 +29,7 @@
          font:inherit; color:inherit; text-align:left; cursor:pointer }
 .frame{ position:relative; overflow:hidden; border:1px solid var(--line-2);
         border-radius:var(--r-lg); background:var(--well);
-        box-shadow:0 12px 30px -20px #000;
+        box-shadow:0 12px 30px -20px var(--shade-3);
         transition:border-color 120ms ease-out }
 .screen:hover .frame{ border-color:var(--line-3) }
 /* The one you are looking at, when there is more than one to look at. A border
@@ -89,7 +89,7 @@
 .tag, .stamp{ position:absolute; top:8px; height:20px; display:flex;
               align-items:center; gap:6px; padding:0 8px; pointer-events:none;
               border-radius:var(--r-sm); background:var(--well);
-              box-shadow:0 0 0 1px rgba(255,255,255,.14);
+              box-shadow:0 0 0 1px var(--line-3);
               font:var(--t-label)/1 var(--mono); letter-spacing:.02em }
 .tag{ left:8px; color:var(--fg-2); max-width:calc(100% - 96px);
       overflow:hidden; text-overflow:ellipsis; white-space:nowrap }

--- a/src/aihawk/ui/js/01-markdown.js
+++ b/src/aihawk/ui/js/01-markdown.js
@@ -184,5 +184,5 @@ const LONG = 48;
 
 const thread = $('thread'), anchor = $('anchor'), log = $('log');
 let turn = null, live = null, hold = null, n = 0, t0 = 0, timer = 0;
-let busyNow = false, queued = null, pinned = false, settle = 0;
+let busyNow = false, queued = null, pinned = false, settle = 0, quiet = 0;
 

--- a/src/aihawk/ui/js/02-transcript.js
+++ b/src/aihawk/ui/js/02-transcript.js
@@ -37,6 +37,17 @@ let pend = null, pendTimer = 0;
 
 const dur = ms => ms < 1000 ? Math.round(ms) + 'ms' : (ms/1000).toFixed(1) + 's';
 
+/* ⛔ THE GUIDANCE IS KEPT, BECAUSE CLEAR USED TO DELETE IT FOR GOOD. It lives
+   in the markup and the first turn removes it, which is right - and `wipe()`
+   then left an empty pane with nothing in it at all, on a page whose entire
+   first-run explanation was those three sentences. Press Clear on a finished
+   conversation and the product forgot how to introduce itself until the tab was
+   reloaded.
+
+   A clone taken before anything can remove it, rather than the same words
+   written a second time in a builder: one declaration, and it is the markup. */
+const hintNode = $('hint').cloneNode(true);
+
 function newTurn(){
   const hint = $('hint'); if(hint) hint.remove();
   n = 0; turn = el('section','turn'); thread.appendChild(turn); return turn;
@@ -146,7 +157,14 @@ function land(kind, text, replay){
      ordinary run most rows are then one line with the answer already visible,
      which is the difference between a list and a stack of accordions. */
   if(text.length <= LONG && text.indexOf('\n') < 0){
-    d.dataset.body = 'none';
+    /* ⛔ AND IT LEAVES THE TAB ORDER WITH THE SAME STATEMENT THAT DECIDES IT
+       HAS NO BODY. Every finished step stayed a focusable disclosure, so a
+       keyboard user crossing a fifty step run pressed Tab fifty times through
+       rows where Enter opens nothing - the transcript between the sessions
+       button and the composer was a minefield of controls that do not
+       control anything. Still reachable by click and in a screen reader's
+       browse mode; only the sequential order gives it up. */
+    d.dataset.body = 'none'; s.tabIndex = -1;
     s.querySelector('.lab').append(' ', el('span','inline', text));
   } else {
     /* Anything that does not fit keeps a body, so the chevron is present for

--- a/src/aihawk/ui/js/02-transcript.js
+++ b/src/aihawk/ui/js/02-transcript.js
@@ -108,16 +108,39 @@ function step(text, replay){
   }
 }
 
+/* ⛔ THE THREE THINGS THAT SETTLE A STEP, IN ONE PLACE, because the end of a
+   turn has to settle a step that nobody landed. Press Stop with a click in
+   flight and no result ever arrives, so that row kept `data-state="run"` and
+   its breathing dot for the life of the page, under a verb in the present
+   tense saying it was still happening.
+
+   ⛔ AND THE OUTCOME IS A WORD, NOT A TINT. A failed row was marked by colour
+   alone - `--err` mixed at 8% against the row, 1.12:1 - and carried the SAME
+   present-tense verb as a row still running, so scrolling back through a ten
+   minute run to find what went wrong there was nothing to look for. In
+   greyscale, or for anybody who does not separate amber from salmon, the
+   failure was not marked at all.
+
+   Past tense only when it finished. `Navigated <address>` on a row that never
+   navigated is the worst kind of line a log can carry. */
+function close(d, state, word){
+  clearInterval(timer);
+  const s = d.firstElementChild;
+  d.dataset.state = state;
+  s.querySelector('.lab b').textContent =
+    (VERB[d.dataset.name] || ['Calling','Called'])[state === 'ok' ? 1 : 0];
+  if(word) s.querySelector('.lab').append(' ', el('span','mark', word));
+  return s;
+}
+
 /* A result or an error folds into the step above it, which is what makes a step
    one unit carrying its target, its timing, its state and its own disclosure. */
 function land(kind, text, replay){
   clearInterval(timer);
   if(!live) return orphan(kind, text, replay);
-  const d = live, s = d.firstElementChild;
+  const d = live;
   live = null;
-  d.dataset.state = kind === 'err' ? 'err' : 'ok';
-  s.querySelector('.lab b').textContent =
-    (VERB[d.dataset.name] || ['Calling','Called'])[kind === 'err' ? 0 : 1];
+  const s = close(d, kind === 'err' ? 'err' : 'ok', kind === 'err' ? 'failed' : '');
   if(!replay) s.lastElementChild.textContent = dur(performance.now() - t0);
   /* Short output goes ON the row and the row stops being expandable. In an
      ordinary run most rows are then one line with the answer already visible,

--- a/src/aihawk/ui/js/02-transcript.js
+++ b/src/aihawk/ui/js/02-transcript.js
@@ -156,6 +156,10 @@ function land(kind, text, replay){
   /* Short output goes ON the row and the row stops being expandable. In an
      ordinary run most rows are then one line with the answer already visible,
      which is the difference between a list and a stack of accordions. */
+  /* On both branches: the row says its whole result on hover whether or not
+     it fits, so a result truncated on the row is readable without opening
+     anything. It used to be set only on the long branch. */
+  s.querySelector('.lab').title = text.slice(0, 400);
   if(text.length <= LONG && text.indexOf('\n') < 0){
     /* ⛔ AND IT LEAVES THE TAB ORDER WITH THE SAME STATEMENT THAT DECIDES IT
        HAS NO BODY. Every finished step stayed a focusable disclosure, so a
@@ -170,9 +174,6 @@ function land(kind, text, replay){
     /* Anything that does not fit keeps a body, so the chevron is present for
        exactly the rows that need it. */
     d.appendChild(el('pre','out', text));
-    /* And the row says it on hover too: nobody should have to open a
-       disclosure to find out whether it is worth opening. */
-    s.querySelector('.lab').title = text.slice(0, 400);
   }
 }
 

--- a/src/aihawk/ui/js/02-transcript.js
+++ b/src/aihawk/ui/js/02-transcript.js
@@ -144,6 +144,19 @@ function close(d, state, word){
   return s;
 }
 
+/* Whether a result says nothing the row does not already say: the settled
+   verb plus the target, compared by words, case and a trailing full stop
+   aside. Read from the row itself rather than recomputed from the tool name,
+   so the two cannot disagree about what the row says. */
+function echoes(s, text){
+  const lab = s.querySelector('.lab');
+  const code = lab.querySelector('code');
+  const said = lab.querySelector('b').textContent + ' ' + (code ? code.textContent : '');
+  const flat = (x) => { x = x.toLowerCase().split(' ').filter(Boolean).join(' ');
+                        return x.endsWith('.') ? x.slice(0, -1) : x; };
+  return flat(text) === flat(said);
+}
+
 /* A result or an error folds into the step above it, which is what makes a step
    one unit carrying its target, its timing, its state and its own disclosure. */
 function land(kind, text, replay){
@@ -169,7 +182,13 @@ function land(kind, text, replay){
        control anything. Still reachable by click and in a screen reader's
        browse mode; only the sequential order gives it up. */
     d.dataset.body = 'none'; s.tabIndex = -1;
-    s.querySelector('.lab').append(' ', el('span','inline', text));
+    /* ⛔ NOT WHEN IT ONLY REPEATS THE ROW. A click answers `clicked <target>`
+       and the row already reads `Clicked <target>`, so the most frequent line
+       in the product said the same four words twice - eighteen times in a
+       row on a real run, and in the owner's own screenshot. An echo is not
+       information. A result that says anything more than the row does, an
+       address with a status, a heading that was read, is still shown. */
+    if(!echoes(s, text)) s.querySelector('.lab').append(' ', el('span','inline', text));
   } else {
     /* Anything that does not fit keeps a body, so the chevron is present for
        exactly the rows that need it. */

--- a/src/aihawk/ui/js/03-which-session.js
+++ b/src/aihawk/ui/js/03-which-session.js
@@ -63,7 +63,7 @@ const onEvent = (e) => {
   if(r){ thread.setAttribute('aria-live', 'off'); clearTimeout(quiet);
          quiet = setTimeout(() => thread.setAttribute('aria-live', 'polite'), 200); }
   switch(m.kind){
-    case 'model': $('model').textContent = m.text; break;
+    case 'model': $('model').textContent = m.text; $('model').hidden = false; break;
     /* Sent to every listener, so a second tab clears too instead of showing a
        transcript the server has already forgotten. */
     case 'fresh': wipe(); break;
@@ -117,5 +117,10 @@ const onEvent = (e) => {
 
 new IntersectionObserver(([e]) => { $('jump').hidden = e.isIntersecting; },
                          {root: log}).observe(anchor);
-$('jump').onclick = () => anchor.scrollIntoView({block:'end', behavior:'smooth'});
+/* ⛔ THE LARGEST MOTION ON THE PAGE, AND THE ONE THE REDUCED-MOTION BLOCK
+   COULD NOT REACH: a smooth scroll is asked for in script, not in CSS, so the
+   rule that quiets every animation had no say over it. Read at click time and
+   not at load, because the setting can change while the tab is open. */
+$('jump').onclick = () => anchor.scrollIntoView({block:'end',
+  behavior: matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth'});
 

--- a/src/aihawk/ui/js/03-which-session.js
+++ b/src/aihawk/ui/js/03-which-session.js
@@ -53,6 +53,15 @@ function dropped(){
 }
 const onEvent = (e) => {
   const m = JSON.parse(e.data), r = m.replay;
+  /* ⛔ A REPLAY IS NOT NEWS, AND IT WAS ANNOUNCED AS IF IT WERE. The
+     transcript is the page's only live region, and a reconnect - a
+     restarted server, a laptop waking, a tab coming back - replays the
+     whole conversation into it, so a screen reader read out an entire
+     hour of work from the beginning while the agent went on adding to
+     it. The burst is silenced and the region comes BACK: switching it
+     off for good would be the louder bug, told quietly. */
+  if(r){ thread.setAttribute('aria-live', 'off'); clearTimeout(quiet);
+         quiet = setTimeout(() => thread.setAttribute('aria-live', 'polite'), 200); }
   switch(m.kind){
     case 'model': $('model').textContent = m.text; break;
     /* Sent to every listener, so a second tab clears too instead of showing a

--- a/src/aihawk/ui/js/03-which-session.js
+++ b/src/aihawk/ui/js/03-which-session.js
@@ -24,8 +24,32 @@ function listen(){
   es.onerror = () => {
     if(es.readyState === EventSource.CONNECTING) say('offline', 'reconnecting');
     if(es.readyState === EventSource.CLOSED) say('offline', 'the stream closed');
+    dropped();
   };
-  es.onopen = () => { if(right.dataset.state === 'offline') say(frozen ? 'frozen' : 'live'); };
+  es.onopen = () => { lost = false;
+                      if(right.dataset.state === 'offline') say(frozen ? 'frozen' : 'live'); };
+}
+
+/* ⛔ THE CLOCK WENT ON COUNTING ON A DEAD STREAM, AND THE CONVERSATION SAID
+   NOTHING. Only a `busy`, `said`, `tool` or `result` event ever ends the wait,
+   so when the stream died mid-run - the server restarted, the laptop slept -
+   the transcript kept a row reading `Thinking 412.7s` and climbing: a counter
+   asserting that an agent is alive, with no way to tell it from one that is.
+   The only contradicting signal was a 7px dot in the OTHER pane.
+
+   Once per drop, cleared when the stream comes back, because EventSource
+   retries on its own and a sentence per retry would be a column of them.
+
+   And the sentence is careful about what it claims: losing the page's
+   connection does not stop the agent, which goes on working server-side, so it
+   must not say that nothing is running. */
+let lost = false;
+function dropped(){
+  if(lost) return;
+  lost = true;
+  waited();
+  orphan('err', 'The connection to the server dropped. Reconnecting - anything '
+         + 'the agent does while it is down appears when it comes back.');
 }
 const onEvent = (e) => {
   const m = JSON.parse(e.data), r = m.replay;
@@ -38,7 +62,15 @@ const onEvent = (e) => {
       busyNow = m.text === '1';
       /* Not on a replay: those events describe a wait that is over. */
       if(busyNow && !r) waiting(); else waited();
-      if(!busyNow){ flush(true, r); live = null; clearInterval(timer);
+      if(!busyNow){ flush(true, r);
+                    /* A turn can end with a step still open: Stop pressed with
+                       a click in flight, a run that died, a model that never
+                       answered. The row is settled HERE because this is the one
+                       place that knows the turn is over - otherwise it keeps
+                       the running state and its breathing dot for as long as
+                       the page stays up, asserting work nobody is doing. */
+                    if(live) close(live, 'off', 'stopped');
+                    live = null; clearInterval(timer);
                     /* The name of a conversation is decided by its FIRST
                        instruction, on the server, so the column is stale from
                        the moment a new session is used until it is redrawn.

--- a/src/aihawk/ui/js/04-composer.js
+++ b/src/aihawk/ui/js/04-composer.js
@@ -47,11 +47,12 @@ i.addEventListener('keydown', e => {
 document.addEventListener('keydown', e => {
   if(e.key !== 'Escape' || !busyNow) return;
   if(document.activeElement === i && i.value.trim()) return;
-  /* Through the same door as the button: a hoisted declaration, so calling it
-     from above where it is written is safe and nothing here depends on the
-     order of the lines. */
-  ask('/chat/stop', undefined,
-      'The stop did not reach the agent - it is still running');
+  /* ⛔ THE BUTTON'S OWN HANDLER, NOT A SECOND COPY OF IT. The same request with
+     the same failure sentence was written out twice, here and on the button, so
+     the half added to either one - reading the answer, saying that nothing was
+     running - reached whichever path the reader happened to be looking at. The
+     key IS the button, so it presses it. */
+  halt.onclick();
 });
 /* A pencil and not a cross: a cross would read as "cancel the queued message".
    This returns it to the composer to be edited.
@@ -246,8 +247,25 @@ fresh.onclick = () => {
   ask('/chat/fresh', undefined, 'Could not clear this conversation');
 };
 
-halt.onclick = () => ask('/chat/stop', undefined,
-                         'The stop did not reach the agent - it is still running');
+/* ⛔ AND THE ANSWER IS READ. `/chat/stop` replies `stopped:false` when there
+   was nothing to stop, which is not hypothetical: a restarted server, a second
+   tab that already stopped the run, a page whose idea of the state is a few
+   seconds stale. The press then did nothing, said nothing, and left the button
+   offering to stop a run that had already ended - so the next reading available
+   to the person is that the product ignores its own panic button.
+
+   `busyNow` is deliberately NOT written here. The event stream is its single
+   writer, and a second one is how two places start disagreeing about whether
+   the agent is working. */
+halt.onclick = async () => {
+  const r = await ask('/chat/stop', undefined,
+                      'The stop did not reach the agent - it is still running');
+  if(!r) return;
+  let stopped = true;
+  try { stopped = (await r.json()).stopped; } catch(err){}
+  if(!stopped) orphan('said', 'There was nothing running to stop: this page was '
+                      + 'showing a run that had already ended.');
+};
 f.onsubmit = (e) => {
   e.preventDefault();
   const t = i.value.trim();

--- a/src/aihawk/ui/js/04-composer.js
+++ b/src/aihawk/ui/js/04-composer.js
@@ -18,6 +18,13 @@ function paint(){
   i.placeholder = queued ? 'Type to replace the queued message'
     : busyNow ? 'Type to queue a message' : 'What should the agent do?';
   chip.hidden = !queued;
+  /* ⛔ AND IT SAYS WHAT IT IS HOLDING. The chip read `1 message queued` and
+     the queued words were never drawn anywhere, so a second Enter replaced a
+     sentence nobody could see with another one, silently and with no way back.
+     Typed work destroyed by a keystroke that looks like sending. With the
+     words on screen the replacement is visible, and what was lost can at least
+     be read off the row before it goes. */
+  if(queued) chip.querySelector('.what').textContent = queued;
 }
 i.addEventListener('input', () => {
   /* ⛔ ONE FORCED LAYOUT PER KEYSTROKE, NOT TWO. Reading scrollHeight after
@@ -47,8 +54,17 @@ document.addEventListener('keydown', e => {
       'The stop did not reach the agent - it is still running');
 });
 /* A pencil and not a cross: a cross would read as "cancel the queued message".
-   This returns it to the composer to be edited. */
-chip.onclick = () => { i.value = queued; setQueued(null); i.focus();
+   This returns it to the composer to be edited.
+
+   ⛔ AND IT DOES NOT EAT WHAT IS IN THE BOX. It assigned over `i.value`, so
+   clicking the chip to see what was queued destroyed whatever was being typed
+   - the same loss as the silent replacement above, in the other direction, and
+   from a control whose whole purpose is to get typed words back. Both survive:
+   the queued sentence arrives above the draft, and what to do with the two of
+   them is a decision for the person rather than for this line. */
+chip.onclick = () => { const draft = i.value.trim();
+                       i.value = draft ? queued + '\n' + i.value : queued;
+                       setQueued(null); i.focus();
                        i.dispatchEvent(new Event('input')); };
 
 /* ⛔ THE BOX IS NOT EMPTIED UNTIL THE SERVER HAS THE SENTENCE. This page

--- a/src/aihawk/ui/js/04-composer.js
+++ b/src/aihawk/ui/js/04-composer.js
@@ -153,6 +153,25 @@ function outOfDate(path){
          + 'Reload to get the current page.');
 }
 
+/* ⛔ ONE OWNER FOR `inert` WHEREVER TWO REASONS CAN HOLD THE SAME BOX. The
+   browser pane goes out of play when this conversation is deleted, and again
+   while the sessions panel lies on top of it, and those two are set from
+   different files. Written by hand, whichever one lets go last wins: press
+   Escape on the panel over a deleted conversation and the browser pane comes
+   back fully lit on a page where nothing is live. A box is inert while ANY
+   reason holds it, and each reason releases only its own.
+
+   A box only one thing can hold does not need this - the layout picker in the
+   stage file has a single reason and writes the flag directly. This is for the
+   boxes where the question "is it still held?" has more than one answer. */
+const heldBy = new WeakMap();
+function outOfPlay(box, why, on){
+  let why_not = heldBy.get(box);
+  if(!why_not){ why_not = new Set(); heldBy.set(box, why_not); }
+  if(on) why_not.add(why); else why_not.delete(why);
+  box.inert = why_not.size > 0;
+}
+
 /* Deleted from the other tab, or from another window. The page says so and
    stops asking, in that order. It does NOT navigate anywhere: the column
    beside it still works, and where to go next is not this page's decision to
@@ -170,7 +189,7 @@ function vanish(){
      while it cannot send is the same lie in a different place. The column of
      sessions keeps its full contrast, because the sentence above tells the
      person to use it. */
-  for(const box of [f, $('right'), $('fresh')]) box.inert = true;
+  for(const box of [f, $('right'), $('fresh')]) outOfPlay(box, 'deleted', true);
   drawChats();
 }
 

--- a/src/aihawk/ui/js/04-composer.js
+++ b/src/aihawk/ui/js/04-composer.js
@@ -104,6 +104,11 @@ function wipe(){
      otherwise left the composer saying "queue for next turn" forever. */
   busyNow = false;
   setQueued(null);
+  /* And the page can introduce itself again. Clear emptied the pane to
+     nothing at all, on a product whose whole first-run explanation was
+     those three sentences: press it on a finished conversation and it
+     had forgotten how to say what it is until the tab was reloaded. */
+  if(!thread.firstElementChild) thread.appendChild(hintNode.cloneNode(true));
 }
 let vanished = false;
 let outdated = false;
@@ -252,4 +257,14 @@ f.onsubmit = (e) => {
   send(t); paint();
 };
 
+/* ⛔ AND THE CARET STARTS WHERE THE WORK STARTS. The one input on the page
+   never had the keyboard on any load or any session switch, so every
+   visit began with a click or a Tab through the frame before a word could
+   be typed - on a page whose entire purpose is to receive a sentence.
 
+   `preventScroll` is not optional: without it the focus drags a restored
+   transcript to the bottom, which is the thing the replay goes out of its
+   way not to do. And if the sessions panel comes back open, it is a modal
+   and the composer is inert behind it, so this quietly does nothing and
+   the panel takes the keyboard instead - which is the right order. */
+i.focus({preventScroll:true});

--- a/src/aihawk/ui/js/04-composer.js
+++ b/src/aihawk/ui/js/04-composer.js
@@ -11,12 +11,28 @@ function paint(){
   /* Refused while a run is in flight, and shown as refused rather than left to
      fail at the server: dropping a transcript something is still writing into
      is not undoable. */
-  fresh.disabled = busyNow;
+  /* ⛔ `aria-disabled`, NOT `disabled`, BECAUSE A DEAD BUTTON CANNOT SAY
+     WHY. Clear greyed out for the whole of a run and never explained itself,
+     and a `disabled` control fires no events - no hover, no click, and in this
+     engine no tooltip either - so there was no way to hang the explanation on
+     it. It keeps the same look through the shared rule, stays reachable, and a
+     press while the agent works says what to do instead of doing nothing. */
+  fresh.setAttribute('aria-disabled', busyNow ? 'true' : 'false');
   go.disabled = !typed;
-  go.setAttribute('aria-label',
-    queued ? 'Replace queued message' : busyNow ? 'Queue for next turn' : 'Send');
-  i.placeholder = queued ? 'Type to replace the queued message'
-    : busyNow ? 'Type to queue a message' : 'What should the agent do?';
+  /* ⛔ THE MODE IS DECIDED ONCE AND DRAWN, because nothing visible said that
+     Enter would QUEUE rather than send. The placeholder said it, and a
+     placeholder disappears at the first keystroke - so the moment a person had
+     typed a follow-up while the agent worked, the one control in front of them
+     looked exactly like Send. The same three-way choice was also written twice,
+     once for the label and once for the placeholder, which is how the two
+     drift. `data-mode` on the button is what the stylesheet draws. */
+  const mode = queued ? 'replace' : busyNow ? 'queue' : 'send';
+  go.dataset.mode = mode;
+  go.setAttribute('aria-label', {replace: 'Replace queued message',
+                                 queue: 'Queue for next turn', send: 'Send'}[mode]);
+  i.placeholder = {replace: 'Type to replace the queued message',
+                   queue: 'Type to queue a message',
+                   send: 'What should the agent do?'}[mode];
   chip.hidden = !queued;
   /* ⛔ AND IT SAYS WHAT IT IS HOLDING. The chip read `1 message queued` and
      the queued words were never drawn anywhere, so a second Enter replaced a
@@ -67,6 +83,20 @@ chip.onclick = () => { const draft = i.value.trim();
                        i.value = draft ? queued + '\n' + i.value : queued;
                        setQueued(null); i.focus();
                        i.dispatchEvent(new Event('input')); };
+
+/* ⛔ THE EXAMPLE IS A BUTTON THAT DOES WHAT IT LOOKS LIKE IT DOES. It was
+   drawn as a suggestion chip - a bordered mono line in the empty transcript -
+   and clicking it did nothing, on the first screen a new user sees. It fills
+   the composer and does not send, the same shape as the queued-message chip:
+   the words are put where the person can read them and change them. Wired by
+   class on the transcript rather than on the node, because the node is cloned
+   back after Clear and a handler on the original would not travel with it. */
+thread.addEventListener('click', (e) => {
+  const eg = e.target.closest('.eg'); if(!eg) return;
+  i.value = eg.textContent.trim();
+  i.dispatchEvent(new Event('input'));
+  i.focus();
+});
 
 /* ⛔ THE BOX IS NOT EMPTIED UNTIL THE SERVER HAS THE SENTENCE. This page
    already argues, about the QUEUED path, that losing typed text with nothing
@@ -203,8 +233,13 @@ function vanish(){
   vanished = true;
   if(es) es.close();
   say('offline', 'deleted');
+  /* The way out is named AND put on screen: the word Sessions is drawn
+     nowhere while the panel is closed - the spine is an icon - so the sentence
+     sent people looking for a label that did not exist. Opening the panel here
+     writes the remembered preference, which is accepted: splitting persistence
+     out of `showRail` would cost more than it saves. */
   orphan('err', 'This conversation was deleted. Nothing here is live any more '
-         + '- open another one from Sessions, or start a new one.');
+         + '- pick another one from the panel, or start a new one.');
   /* Everything goes inert EXCEPT the way out. `inert` rather than `disabled`
      because these are subtrees and not single controls, and it takes them out
      of the pointer AND the tab order - a composer that answers the keyboard
@@ -212,7 +247,7 @@ function vanish(){
      sessions keeps its full contrast, because the sentence above tells the
      person to use it. */
   for(const box of [f, $('right'), $('fresh')]) outOfPlay(box, 'deleted', true);
-  drawChats();
+  showRail(true);
 }
 
 /* ⛔ ONE PLACE KNOWS WHAT TO DO WHEN A REQUEST DOES NOT ARRIVE. Six
@@ -243,6 +278,11 @@ async function ask(path, body, whatFailed){
    guard was on the wrong control. Named on the message, and named again on
    the button. */
 fresh.onclick = () => {
+  if(busyNow){
+    orphan('said', 'Clear is off while the agent is working: stop the run '
+           + 'first, then clear.');
+    return;
+  }
   if(!confirm('Clear this conversation? The agent forgets everything you have told it. Its browsers stay open.')) return;
   ask('/chat/fresh', undefined, 'Could not clear this conversation');
 };

--- a/src/aihawk/ui/js/05-browser.js
+++ b/src/aihawk/ui/js/05-browser.js
@@ -25,9 +25,18 @@ let frozen = false;
    Guarded here rather than at the pump, because there are eight callers and
    the fact "the state changed" is one fact. The early return is safe because
    all three writes below are functions of the two arguments. */
-function say(s, why){ if(right.dataset.state === s && stateEl.title === (why || '')) return;
+/* ⛔ AGAINST WHAT THIS FUNCTION HAS DRAWN, NOT AGAINST THE ATTRIBUTE. The first
+   version compared with `right.dataset.state`, which the MARKUP declares as
+   `idle` before any script runs - so the very first call was swallowed as a
+   repeat and the word never got the class that hides it. Caught by opening the
+   page: IDLE in bright capitals in the corner of an empty room, which is the
+   exact thing a rule deleted in the same change had been there to prevent. A
+   guard that reads the DOM cannot tell "already drawn" from "never drawn". */
+let shown = null;
+function say(s, why){ if(shown === s && stateEl.title === (why || '')) return;
+                      shown = s;
                       right.dataset.state = s; stateEl.textContent = s;
-                      stateEl.classList.toggle('sr', s === 'live' || s === 'frozen');
+                      stateEl.classList.toggle('sr', s === 'live' || s === 'frozen' || s === 'idle');
                       stateEl.title = why || ''; }
 async function reason(r){ try { return (await r.json()).error || ''; } catch(err) { return ''; } }
 

--- a/src/aihawk/ui/js/05-browser.js
+++ b/src/aihawk/ui/js/05-browser.js
@@ -15,7 +15,18 @@ let frozen = false;
    one transition that matters, live to error, was silent for a screen reader
    precisely because the word had been redundant a moment earlier. Off-screen
    instead: the eye sees the tab it repeats, the ear still hears the change. */
-function say(s, why){ right.dataset.state = s; stateEl.textContent = s;
+/* ⛔ AND IT ONLY SPEAKS WHEN SOMETHING CHANGED. This rewrote a live region 25
+   times a second while a browser was being watched, because the frame pump
+   calls it on every pass. A screen reader announces every one of those writes:
+   the word `live`, forever, with the queue never emptying, so the one
+   transition that matters - live to error - could never be reached. Anybody
+   using this product by ear was locked out of it while it worked.
+
+   Guarded here rather than at the pump, because there are eight callers and
+   the fact "the state changed" is one fact. The early return is safe because
+   all three writes below are functions of the two arguments. */
+function say(s, why){ if(right.dataset.state === s && stateEl.title === (why || '')) return;
+                      right.dataset.state = s; stateEl.textContent = s;
                       stateEl.classList.toggle('sr', s === 'live' || s === 'frozen');
                       stateEl.title = why || ''; }
 async function reason(r){ try { return (await r.json()).error || ''; } catch(err) { return ''; } }

--- a/src/aihawk/ui/js/06-sessions.js
+++ b/src/aihawk/ui/js/06-sessions.js
@@ -10,9 +10,17 @@ async function drawChats(){
   catch(err){ return; }
   const box = $('chats');
   box.textContent = '';
+  /* The panel's line belongs to the list as it was: any redraw of the list is
+     a new answer to whatever it was complaining about. */
+  railsay('');
   /* An empty column is a state, not a blank: on a first run there is exactly
      one conversation and it is this one, so the panel would otherwise open on
      nothing at all. */
+  /* A paragraph is not a list item, and `role="list"` promises that everything
+     inside it is one. With nothing to list, the box stops claiming to be a
+     list rather than holding one invalid child. */
+  if(rows.length) box.setAttribute('role', 'list');
+  else box.removeAttribute('role');
   if(!rows.length){
     const none = el('p','none', 'No saved conversations yet. This one is saved '
                     + 'as soon as you send an instruction.');
@@ -21,15 +29,29 @@ async function drawChats(){
   for(const s of rows){
     const row = el('div','chat');
     row.setAttribute('role','listitem');
-    if(s.id === here) row.setAttribute('aria-current','true');
     const open = el('button', 'nm', s.name || s.id);
     open.type = 'button';
+    /* ⛔ ON THE BUTTON, NOT ON THE ROW AROUND IT. `aria-current` was set on the
+       `listitem` wrapper, which is a container with no name of its own, so the
+       one conversation a person is actually in was announced to nobody: you
+       hear the name from the button and the "current" from a node the reader
+       walks straight past. The mark goes on the thing that says the name. */
+    if(s.id === here) open.setAttribute('aria-current','true');
 
     /* Switching is a NAVIGATION, not a repaint: the transcript, the picture and
        the stream all belong to the conversation, and the server hands back the
        whole of it for an id. Rebuilding that by hand would be a second
        implementation of what a page load already does correctly. */
-    open.onclick = () => { if(s.id !== here) location.search = '?s=' + encodeURIComponent(s.id); };
+    /* ⛔ AND IT CLOSES ON THE WAY OUT, UNCONDITIONALLY. The panel stayed open
+       across the navigation, so the conversation you had just chosen arrived
+       already covered by the panel you chose it from - and choosing the one you
+       were already in left it open over the same page for no reason at all.
+       `showRail` is the one writer of the remembered state, so closing through
+       it is also what stops the next page load reopening it. */
+    open.onclick = () => {
+      showRail(false);
+      if(s.id !== here) location.search = '?s=' + encodeURIComponent(s.id);
+    };
     open.ondblclick = () => renameChat(s.id, s.name || s.id);
     /* ⛔ AND A KEY, because a double click is not a keyboard path and nothing
        on the screen advertises it. F2 is what renames a thing in a list

--- a/src/aihawk/ui/js/06-sessions.js
+++ b/src/aihawk/ui/js/06-sessions.js
@@ -4,10 +4,15 @@
    the server, so a column the page maintained locally would be right until
    somebody actually used a session. */
 async function drawChats(){
-  let rows = [];
+  /* ⛔ THREE OUTCOMES, AND THE OLD CODE HAD TWO. A list that could not be
+     LOADED returned early and left whatever was drawn before, and a list that
+     arrived empty said `No saved conversations yet`, which was also what a
+     failed fetch showed if nothing had been drawn yet: a lie in the shape of
+     an empty state. `null` is the answer for "I do not know". */
+  let rows = null;
   try { const r = await plainDoor('/sessions', {cache:'no-store'});
         if(r.ok) rows = (await r.json()).sessions || []; }
-  catch(err){ return; }
+  catch(err){ rows = null; }
   const box = $('chats');
   box.textContent = '';
   /* The panel's line belongs to the list as it was: any redraw of the list is
@@ -19,8 +24,13 @@ async function drawChats(){
   /* A paragraph is not a list item, and `role="list"` promises that everything
      inside it is one. With nothing to list, the box stops claiming to be a
      list rather than holding one invalid child. */
-  if(rows.length) box.setAttribute('role', 'list');
+  if(rows && rows.length) box.setAttribute('role', 'list');
   else box.removeAttribute('role');
+  if(rows === null){
+    box.appendChild(el('p','none', 'The list could not be loaded. It is asked '
+                       + 'for again the next time this panel opens.'));
+    return;
+  }
   if(!rows.length){
     const none = el('p','none', 'No saved conversations yet. This one is saved '
                     + 'as soon as you send an instruction.');
@@ -58,6 +68,9 @@ async function drawChats(){
        everywhere else on this machine. */
     open.onkeydown = (e) => { if(e.key === 'F2') renameChat(s.id, s.name || s.id); };
     open.title = (s.name || s.id) + ' - F2 to rename';
+    /* Drawn for the keyboard, which the native tooltip never serves: the tip
+       appears on the row when its name has keyboard focus, and nowhere else. */
+    row.dataset.tip = 'F2 renames';
     row.appendChild(open);
     if(s.turns) row.appendChild(el('span','cnt', String(s.turns)));
     const kill = el('button','x','x');

--- a/src/aihawk/ui/js/07-rail.js
+++ b/src/aihawk/ui/js/07-rail.js
@@ -5,31 +5,35 @@
    property of the work. */
 const RAILKEY = 'aihawk.rail';
 
-/* How far the drawer must stop short of the bottom, so that it never lies
-   over the input. Measured rather than declared: the textarea grows with what
-   is typed. The composer knows nothing about the panel - this reads the
-   composer, and the CSS reads this.
+/* The panel's own line, for what the panel itself failed to do. Emptied by the
+   next `drawChats`, so nothing has to remember to clear it. */
+function railsay(words){ $('railsay').textContent = words || ''; }
 
-   ⛔ THE DISTANCE TO THE INPUT, NOT ITS HEIGHT, and the first version had it
-   the other way. The two are the same number only while the composer sits at
-   the bottom of the window; below 720px the panes stack and the input is in
-   the middle, where the drawer ran over it again - 34% at 719px, 43% at 600.
-   Re-measured on window resize as well as on the composer's own, because the
-   input MOVES without changing size when the layout stacks. */
-function publishRailFloor(){
-  const f = $('f'); if(!f) return;
-  const gap = Math.max(0, Math.round(window.innerHeight
-                                     - f.getBoundingClientRect().top));
-  document.documentElement.style.setProperty('--rail-bottom', gap + 'px');
-}
-if(typeof ResizeObserver === 'function' && $('f')){
-  new ResizeObserver(publishRailFloor).observe($('f'));
-}
-addEventListener('resize', publishRailFloor);
-publishRailFloor();
+/* ⛔ OPENING IT PUTS THE PAGE BEHIND IT OUT OF PLAY, AND THAT IS THE WHOLE
+   CORRECTION. It used to lie over the near edge of the conversation and leave
+   it looking readable: 240px off the front of every line, 29 rows at a time,
+   the verb and the step number underneath the panel. The words were not gone,
+   they were unreachable while still inviting you to read them.
+
+   Now the two panes are held inert - dimmed to 2.36:1 by the shell's one
+   `[inert]` rule, out of the tab order, out of reach of the pointer - so what
+   is covered is visibly not in play. That is only honest because it is also
+   cheap to undo: Escape, a click on the page behind, or choosing a name, all
+   below.
+
+   Held through `outOfPlay` rather than written here, because the browser pane has a
+   second reason to be out of play - a conversation deleted elsewhere - and
+   whichever of the two let go last would otherwise revive it. */
 function showRail(open){
-  $('rail').hidden = !open;
+  const rail = $('rail');
+  /* Where the keyboard was, before hiding the panel can take it away: a
+     subtree that holds the focus and goes `hidden` drops it on the document,
+     and the next Tab starts at the top of the page instead of at the control
+     that was just used. */
+  const hadFocus = !open && rail.contains(document.activeElement);
+  rail.hidden = !open;
   $('railtab').setAttribute('aria-expanded', open ? 'true' : 'false');
+  for(const box of [$('left'), $('right')]) outOfPlay(box, 'sessions', open);
   /* ⛔ AND NO aria-label ANY MORE. It used to say "Show sessions" / "Hide
      sessions", which was right while the control was three lines and nothing
      else. Now the button says Sessions in words, and an aria-label REPLACES
@@ -40,9 +44,43 @@ function showRail(open){
      source: removing the attribute from the markup left this line putting it
      back. */
   try { localStorage.setItem(RAILKEY, open ? '1' : '0'); } catch(err){}
-  if(open) drawChats();
+  if(open){
+    drawChats();
+    /* The keyboard follows the eyes. Tab would walk in here anyway, but
+       Escape, the arrows and a screen reader all start from wherever the focus
+       is standing - which, a moment after this, is behind an inert subtree
+       none of them can reach. */
+    $('newchat').focus();
+  } else if(hadFocus){
+    $('railtab').focus();
+  }
 }
 $('railtab').onclick = () => showRail($('rail').hidden);
+
+/* ⛔ ESCAPE, ON THE WAY DOWN, AND THE INTERCEPTION IS DELIBERATE. Two other
+   handlers on `document` answer this key: one stops the run, the other resets
+   the split. Capture runs before both, so `stopPropagation` here keeps the key
+   from reaching them, and that is the point rather than a side effect - while
+   a modal is up, Escape means close the modal and nothing else, which is what
+   it means in every other window on the machine. Without this the key a person
+   presses to dismiss a panel STOPPED THE AGENT instead. */
+addEventListener('keydown', (e) => {
+  if(e.key !== 'Escape' || $('rail').hidden) return;
+  e.stopPropagation();
+  showRail(false);
+}, true);
+
+/* And a press on the page behind it, which is the other half of what makes
+   covering honest. Both guards are needed and the second one is not obvious:
+   without it, pressing the spine closes the panel here and the button's own
+   handler reopens it in the same gesture, so the one control that opens the
+   panel could never close it. */
+addEventListener('pointerdown', (e) => {
+  if($('rail').hidden) return;
+  if($('rail').contains(e.target) || $('railtab').contains(e.target)) return;
+  showRail(false);
+}, true);
+
 try { showRail(localStorage.getItem(RAILKEY) === '1'); } catch(err){ showRail(false); }
 
 async function renameChat(id, was){
@@ -52,10 +90,12 @@ async function renameChat(id, was){
      `renamed:false`; without reading it the column simply redrew the old
      name, which reads as the rename having been ignored. */
   const r = await ask('/sessions/rename', {id, name}, 'Could not rename it');
-  if(r && !(await r.json()).renamed){
-    orphan('err', 'A session needs a name with something in it.');
-  }
-  drawChats();
+  const refused = r && !(await r.json()).renamed;
+  /* The draw first and the sentence after, in that order: `drawChats` empties
+     the panel's line, so a sentence written before it would be wiped by the
+     redraw it was written about. */
+  await drawChats();
+  if(refused) railsay('A session needs a name with something in it.');
 }
 
 async function forgetChat(id, name){
@@ -75,9 +115,13 @@ async function forgetChat(id, name){
     gone = r.ok && (await r.json()).forgotten;
   } catch(err){ gone = false; }
   if(!gone){
-    orphan('err', 'That session is still working, so it was not deleted. '
-           + 'Stop its run first, then delete it.');
-    drawChats();
+    /* ⛔ AND IT IS SAID IN THE PANEL, NOT IN THE TRANSCRIPT. This went to the
+       conversation, which is the thing the panel is lying on top of and the
+       page has just put out of play: the sentence landed where the person who
+       pressed the button could not read it. */
+    await drawChats();
+    railsay('That session is still working, so it was not deleted. '
+            + 'Stop its run first, then delete it.');
     return;
   }
   if(id === here){ location.search = ''; return; }

--- a/src/aihawk/ui/js/08-workspace.js
+++ b/src/aihawk/ui/js/08-workspace.js
@@ -37,7 +37,10 @@ function thumbFor(b){
   if(!b.running){
     const chip = document.createElement('button');
     chip.type = 'button'; chip.className = 'chip'; chip.dataset.id = b.id;
-    chip.title = 'Watch ' + b.id;
+    /* "Not running" was a 6px ring and nothing else - no text anywhere. The
+       state goes into the name, from the one place that already knows it. */
+    chip.title = 'Watch ' + b.id + ' - not running';
+    chip.setAttribute('aria-label', 'Watch ' + b.id + ' - not running');
     /* Clicking a chip changes what the address bar and the stage follow, and
        nothing said so: the identical control one row up, the preview card,
        has carried this mark from the start. */
@@ -48,7 +51,8 @@ function thumbFor(b){
   }
   const el2 = document.createElement('button');
   el2.type = 'button'; el2.className = 'thumb'; el2.dataset.id = b.id;
-  el2.title = 'Watch ' + b.id;
+  el2.title = 'Watch ' + b.id + ' - running';
+  el2.setAttribute('aria-label', 'Watch ' + b.id + ' - running');
   const pic = el('div','pic');
   /* Three states, not two, and the third is the one that read as a failure.
      A browser that is RUNNING WITH NO TAB cannot be captured - the engine

--- a/src/aihawk/ui/js/09-stage.js
+++ b/src/aihawk/ui/js/09-stage.js
@@ -96,15 +96,16 @@ function drawStage(){
        guess where the button is. There is no button - browsers are opened by
        asking - so this is the one place that has to say so, and to show the
        shape of the sentence that does it. */
-    const cell = el('div','empty');
-    cell.append(el('b', null, 'No browser open'),
-                el('span', null, 'Ask in the chat and one opens here. There is no button for it, on purpose.'),
-                el('code', null, 'open a browser and go to example.com'));
-    box.appendChild(cell);
+    box.appendChild(emptyCell.cloneNode(true));
     return;
   }
   for(const b of show) box.appendChild(screenFor(b, b.id === watched()));
 }
+
+/* Taken before anything can empty the stage: the same three lines used to be
+   built here AND described in the markup, which is one sentence in two
+   places waiting to disagree. */
+const emptyCell = $('stage').firstElementChild.cloneNode(true);
 
 async function drawFleet(){
   let got = {browsers: []};

--- a/src/aihawk/ui/js/09-stage.js
+++ b/src/aihawk/ui/js/09-stage.js
@@ -35,7 +35,11 @@ function screenFor(b, current){
   const cell = document.createElement('button');
   cell.type = 'button'; cell.className = 'screen'; cell.dataset.id = b.id;
   cell.setAttribute('aria-current', String(current));
+  /* The NAME is the action and the state is the description. With the name
+     taken from the contents, a screen reader heard the address, the tag and
+     the veil's sentence run together, and `title` was never the name. */
   cell.title = 'Watch ' + b.id;
+  cell.setAttribute('aria-label', 'Watch ' + b.id);
   const box = el('div','frame');
   const im = document.createElement('img'); im.alt = ''; im.hidden = true;
   const tag = el('span','tag');
@@ -48,7 +52,9 @@ function screenFor(b, current){
     tag.appendChild(dot);
   }
   const stamp = el('span','stamp'); stamp.hidden = true;
-  box.append(im, el('div','veil'), tag, stamp);
+  const veil = el('div','veil'); veil.id = 'veil-' + b.id;
+  cell.setAttribute('aria-describedby', veil.id);
+  box.append(im, veil, tag, stamp);
   cell.appendChild(box);
   /* Three states and not two, and the third is the one that reads as a
      failure: a browser that is RUNNING WITH NO TAB cannot be captured - the

--- a/src/aihawk/ui/js/10-splitter.js
+++ b/src/aihawk/ui/js/10-splitter.js
@@ -11,15 +11,27 @@
    the top level of this script may depend on the order of the lines. */
 const SPLITKEY = 'aihawk.split';
 
+/* ⛔ THE FLOOR AND THE CEILING COME FROM THE TOKENS, AND THE CEILING WAS 57px
+   OPTIMISTIC WITHOUT THEM. It subtracted the picture's minimum from the whole
+   WINDOW, while the spine and the separator sit outside the split: dragged to
+   the end, the browser pane got 423px where the number promised 480, and the
+   separator announced a ceiling it could not reach. Four places knew 420 and
+   two knew 9; now one declaration has three readers - this, the pane's own
+   clamp, and the separator's width. */
+function limits(){
+  const css = getComputedStyle(document.documentElement);
+  const px = name => parseFloat(css.getPropertyValue(name)) || 0;
+  const min = px('--pane-min');
+  return {min, max: Math.max(min, window.innerWidth - px('--stage-min')
+                                  - px('--spine') - px('--split'))};
+}
+
 function splitTo(px, remember){
-  /* The floor is the narrowest the conversation stays usable at; the ceiling
-     leaves the browser pane enough to be a picture rather than a strip. Both
-     are recomputed against the window, so a value dragged wide on a big
-     monitor does not strand the right pane on a laptop. */
-  const min = 420, max = Math.max(min, window.innerWidth - 480);
+  const {min, max} = limits();
   const w = Math.round(Math.min(max, Math.max(min, px)));
   $('left').style.width = w + 'px';
   $('split').setAttribute('aria-valuenow', String(w));
+  $('split').setAttribute('aria-valuemin', String(min));
   $('split').setAttribute('aria-valuemax', String(max));
   if(remember){ try { localStorage.setItem(SPLITKEY, String(w)); } catch(e) {} }
 }
@@ -30,9 +42,12 @@ function splitReset(){
   $('split').setAttribute('aria-valuenow',
                           String(Math.round($('left').getBoundingClientRect().width)));
   /* The ceiling too: this is the FIRST-RUN path, so without it a range widget
-     was announced with a floor and a value and no top for every new user. */
-  $('split').setAttribute('aria-valuemax',
-                          String(Math.max(420, window.innerWidth - 480)));
+     was announced with a floor and a value and no top for every new user.
+     And the floor, which was in the markup as a literal: three numbers
+     describing one range, from one place. */
+  const {min, max} = limits();
+  $('split').setAttribute('aria-valuemin', String(min));
+  $('split').setAttribute('aria-valuemax', String(max));
 }
 
 function splitter(){
@@ -81,7 +96,12 @@ function splitter(){
     const now = $('left').getBoundingClientRect().width;
     if(e.key === 'ArrowLeft'){ splitTo(now - step, true); e.preventDefault(); }
     else if(e.key === 'ArrowRight'){ splitTo(now + step, true); e.preventDefault(); }
-    else if(e.key === 'Home' || e.key === 'Escape'){ splitReset(); e.preventDefault(); }
+    /* ⛔ AND NOT ESCAPE. It reset the split here AND reached the document,
+       where it stops the run: one key, two things, one of them the thing
+       that ends the agent's work. Home is what returns a control to its
+       default everywhere else, and Escape now means close the panel, or
+       stop the run, and nothing at all when neither applies. */
+    else if(e.key === 'Home'){ splitReset(); e.preventDefault(); }
   });
   /* A width saved on a wide monitor is not a width on a laptop: put it back
      through the same clamp whenever the window changes. */

--- a/src/aihawk/ui/page.html
+++ b/src/aihawk/ui/page.html
@@ -100,7 +100,13 @@
          size, so at 200% with a queued message it landed on top of the thing
          it floats above. -->
     <button id="jump" hidden type="button">jump to latest</button>
-    <button id="chip" type="button" hidden>1 message queued
+    <!-- ⛔ THE SENTENCE ITSELF, NOT A COUNT OF SENTENCES. This read
+         `1 message queued`, a literal, so the one thing worth showing - the
+         words waiting to be sent - was the one thing never on screen. The
+         composer paints it, because the composer is the single writer of how
+         the composer looks. The hidden prefix keeps the button's name saying
+         what it is, without putting a word on screen that is not needed. -->
+    <button id="chip" type="button" hidden><span class="sr">Queued message: </span><span class="what"></span>
       <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true"
            stroke="currentColor" stroke-width="1.6" stroke-linecap="round"
            stroke-linejoin="round"><path d="M10.6 2.9l2.5 2.5L5.6 12.9 2.5 13.5l.6-3.1z"/></svg></button>

--- a/src/aihawk/ui/page.html
+++ b/src/aihawk/ui/page.html
@@ -136,10 +136,15 @@
      the room is a property of the TASK - reading a long answer wants one
      ratio, watching a form being filled wants another - so it is not a number
      this file gets to decide once. -->
+<!-- ⛔ NO `aria-valuemin` ON THE SEPARATOR, AND NO COMMENT INSIDE ITS TAG.
+     The floor is a token the script reads, and a literal here would be a
+     second copy of it that nothing updates; the script writes all three
+     bounds on the first pass. The first version of this note sat BETWEEN the
+     attributes, where the `>` that ends a comment ends the start tag instead:
+     every attribute after it became visible text between the two panes,
+     `aria-label="Width of the conversation"` printed down the seam, with
+     577 tests green. Found by looking at a screenshot. -->
 <div id="split" role="separator" aria-orientation="vertical" tabindex="0"
-     <!-- No `aria-valuemin` here: the floor is a token the script reads, and a
-          literal in the markup would be a second copy of it that nothing
-          updates. The script writes all three bounds on the first pass. -->
      aria-label="Width of the conversation"
      aria-valuenow="530"></div>
 

--- a/src/aihawk/ui/page.html
+++ b/src/aihawk/ui/page.html
@@ -151,9 +151,26 @@
       <button aria-pressed="false" data-v="hold" type="button"
               title="Stop updating the picture. The agent keeps working.">Frozen</button>
     </span>
-    <span id="state" class="label" aria-live="polite">idle</span>
+    <!-- ⛔ IT STARTS OFF-SCREEN, BECAUSE THE WORD IT STARTS WITH IS THE ONE
+         WORD NOT WORTH SHOWING. `idle` in capitals was the brightest thing
+         on a bar describing an empty room, and it was hidden by a CSS rule
+         keyed on the room being empty - a second place deciding what `say`
+         already decides, and the one that hid every OTHER word too: drop
+         the stream on a first run and `offline` landed in a box one pixel
+         wide. The rule is gone, so the starting state is drawn here the way
+         `say` would draw it, and the word stays for a screen reader. -->
+    <span id="state" class="label sr" aria-live="polite">idle</span>
   </div>
-  <div id="stage" data-grid="1"></div>
+  <!-- ⛔ THE EMPTY STATE SHIPS AS MARKUP, because the right half of the
+       window was a black rectangle from first paint until the browsers came
+       back: one round trip for the default conversation, seconds for any
+       other, because asking spawns a server process first. Half the product
+       showed nothing at all, under an armed toolbar, exactly while a new
+       user was deciding what this is. The script clones this node when it
+       needs it again, so the words are declared once. -->
+  <div id="stage" data-grid="1">
+    <div class="empty"><b>No browser open</b><span>Ask in the chat and one opens here. There is no button for it, on purpose.</span><code>open a browser and go to example.com</code></div>
+  </div>
   <!-- role, or the label is ignored: a bare div takes no accessible name. -->
   <div id="thumbs" role="group" aria-label="The other browsers in this session"></div>
 </section>

--- a/src/aihawk/ui/page.html
+++ b/src/aihawk/ui/page.html
@@ -30,7 +30,14 @@
     <path d="M9.2 4.4v15.2" stroke="currentColor" stroke-width="1.6"/>
   </svg></button>
 
-<nav id="rail" aria-labelledby="railtitle" hidden>
+<!-- ⛔ A DIALOG, BECAUSE THAT IS WHAT IT BEHAVES LIKE NOW. It lies over the
+     conversation and puts the two panes behind it out of play, which is a modal
+     whatever the element is called. `role` overrides the `nav` mapping, and
+     `aria-modal` is what tells a screen reader that the rest of the page is not
+     there for the moment - the half that `inert` does for everybody else. It
+     was a plain `nav` floating over live content, which announced a page where
+     everything was still reachable while a panel covered half of it. -->
+<nav id="rail" role="dialog" aria-modal="true" aria-labelledby="railtitle" hidden>
   <!-- No title here any more: the spine to the left of this column carries the
        word, and with the column open the two sat twenty pixels apart saying the
        same thing. The row keeps its height from its padding, so it still lines
@@ -47,6 +54,10 @@
            stroke-width="1.6" stroke-linecap="round"><path d="M9 3.5v11M3.5 9h11"/></svg>
     </button>
   </div>
+  <!-- Where this panel answers for itself: a refused rename, a delete the
+       server would not do. Empty until there is something to say, and emptied
+       again the next time the list is drawn. -->
+  <p id="railsay" role="status"></p>
   <div id="chats" role="list"></div>
 </nav>
 

--- a/src/aihawk/ui/page.html
+++ b/src/aihawk/ui/page.html
@@ -73,7 +73,11 @@
          here. What was removed is the NAME ON THE SCREEN, which said the same
          thing as the tab, the window and the address bar. -->
     <h1 class="sr">AIHawk</h1>
-    <span class="badge" id="model">no model</span>
+    <!-- Empty and hidden until the server says which model: `no model` was a
+         literal here, a second declaration of a fact the server owns, and it
+         was on screen for the first second of every load as though it were
+         true. -->
+    <span class="badge" id="model" hidden></span>
     <span class="vr" aria-hidden="true"></span>
     <button id="fresh" type="button" title="Clear this conversation">Clear</button></div>
   <div id="log">
@@ -86,7 +90,7 @@
       <div id="hint">
         <p>Tell it what to do, in a sentence. It opens the pages, reads them and
            clicks, and you watch on the right.</p>
-        <p class="eg">Go to example.com and tell me the main heading.</p>
+        <button type="button" class="eg">Go to example.com and tell me the main heading.</button>
         <p class="sm">Plain language: the model works out the clicks. One
            instruction at a time works best.</p>
       </div>
@@ -172,7 +176,7 @@
        user was deciding what this is. The script clones this node when it
        needs it again, so the words are declared once. -->
   <div id="stage" data-grid="1">
-    <div class="empty"><b>No browser open</b><span>Ask in the chat and one opens here. There is no button for it, on purpose.</span><code>open a browser and go to example.com</code></div>
+    <div class="empty"><b>No browser open</b><span>Ask in the chat and one opens here. There is no button for it, on purpose.</span></div>
   </div>
   <!-- role, or the label is ignored: a bare div takes no accessible name. -->
   <div id="thumbs" role="group" aria-label="The other browsers in this session"></div>

--- a/src/aihawk/ui/page.html
+++ b/src/aihawk/ui/page.html
@@ -133,7 +133,10 @@
      ratio, watching a form being filled wants another - so it is not a number
      this file gets to decide once. -->
 <div id="split" role="separator" aria-orientation="vertical" tabindex="0"
-     aria-label="Width of the conversation" aria-valuemin="420"
+     <!-- No `aria-valuemin` here: the floor is a token the script reads, and a
+          literal in the markup would be a second copy of it that nothing
+          updates. The script writes all three bounds on the first pass. -->
+     aria-label="Width of the conversation"
      aria-valuenow="530"></div>
 
 <section id="right" data-state="idle" aria-label="The browsers this session holds">

--- a/tests/test_a_screen_says_what_it_is_showing.py
+++ b/tests/test_a_screen_says_what_it_is_showing.py
@@ -298,8 +298,44 @@ def test_an_empty_stage_says_what_to_do_about_being_empty():
         "nothing puts the empty state back after a browser closes")
     assert "Ask in the chat and one opens here" in PAGE, \
         "the empty stage no longer says how a browser gets opened"
-    assert "open a browser and go to example.com" in PAGE, \
-        "the empty stage says to ask but not what asking looks like"
+    # ⛔ AND IT NO LONGER CARRIES AN EXAMPLE OF ITS OWN. The stage taught
+    # `open a browser and go to example.com` while the hint beside it taught
+    # `Go to example.com and tell me the main heading`: two halves of one
+    # page, two different first instructions. The hint keeps the one example
+    # and the stage says how a browser gets opened, which is its own job.
+    stage = PAGE[PAGE.index('id="stage"'):]
+    assert "<code>" not in stage[:stage.index("</div>")], \
+        "the stage teaches a second first instruction beside the one in the hint"
     assert PAGE.count("Ask in the chat and one opens here") == 1, (
         "the sentence is written in two places, which is how one of them goes "
         "stale")
+
+
+def test_a_screen_is_named_by_its_action_and_described_by_its_state():
+    """⛔ THE NAME WAS WHATEVER WAS INSIDE THE BUTTON. A screen, a thumbnail
+    and a chip took their accessible name from their contents, so a screen
+    reader heard the address, the tag and the veil's sentence run together,
+    and `title` - which is never the name - carried the one word that said
+    what pressing does. And "not running" was a 6px ring with no text
+    equivalent anywhere.
+
+    The name is the action, the state is the description, and the veil that
+    already says the state on screen is what describes the control.
+
+    Known-bad, two: drop the label and let the contents be the name again;
+    drop the description and leave the veil unheard.
+    """
+    got = cells("""
+      const cell = screenFor({id: 'b-two', running: true, urls: ['http://x/']}, true);
+      const veil = cell.querySelector('.veil');
+      process.stdout.write(JSON.stringify({label: cell.attrs['aria-label'],
+        title: cell.title, describedBy: cell.attrs['aria-describedby'],
+        veilId: veil ? veil.id : null}));
+    """)
+    assert got["label"] == "Watch b-two", (
+        "a screen takes its name from its contents, so it is announced as the "
+        "address and the veil's sentence run together: %r" % (got,))
+    assert got["describedBy"] and got["describedBy"] == got["veilId"], (
+        "the veil says the state on screen and nothing points the control at "
+        "it, so the state is unheard: %r" % (got,))
+

--- a/tests/test_a_screen_says_what_it_is_showing.py
+++ b/tests/test_a_screen_says_what_it_is_showing.py
@@ -280,9 +280,26 @@ def test_an_empty_stage_says_what_to_do_about_being_empty():
 
     Known-bad: go back to naming the condition and stopping.
     """
-    code = re.sub(r"/\*.*?\*/", "", PAGE, flags=re.S)
-    assert "el('div','empty')" in code, "the empty stage is a screen with no picture again"
+    code = re.sub(r"/\*.*?\*/|<!--.*?-->", "", PAGE, flags=re.S)
+    # ⛔ AND IT IS THERE FROM THE FIRST PAINT, which is what this used to miss by
+    # asserting that the SCRIPT built the cell. Built in the script, the right
+    # half of the window was a near-black rectangle under an armed toolbar until
+    # `/live/browsers` answered: one round trip for the default conversation and
+    # seconds for any other, because asking spawns a server process first. Half
+    # the product showed nothing at all exactly while a new user was deciding
+    # what this is. So it ships as markup, and the script CLONES it - one
+    # declaration, in the place that draws before any request.
+    stage = code[code.index('id="stage"'):]
+    stage = stage[:stage.index("</div>")]
+    assert 'class="empty"' in stage, (
+        "the empty state is built by the script again, so the stage is blank "
+        "until the first answer comes back: %r" % stage[:120])
+    assert "emptyCell.cloneNode(true)" in code, (
+        "nothing puts the empty state back after a browser closes")
     assert "Ask in the chat and one opens here" in PAGE, \
         "the empty stage no longer says how a browser gets opened"
     assert "open a browser and go to example.com" in PAGE, \
         "the empty stage says to ask but not what asking looks like"
+    assert PAGE.count("Ask in the chat and one opens here") == 1, (
+        "the sentence is written in two places, which is how one of them goes "
+        "stale")

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -619,9 +619,17 @@ async def test_a_tool_result_longer_than_8000_characters_is_truncated_to_8000():
     await run_task(mcp, "read", client=model, model="m")
 
     sent = tool_messages(model.requests[1])[0]["content"]
-    assert len(sent) == 8000
-    assert sent.endswith("Z")
-    assert "b" not in sent
+    kept, _, said = sent.partition("\n[...")
+    assert len(kept) == 8000
+    assert kept.endswith("Z")
+    assert "b" not in kept
+    # ⛔ AND IT IS TOLD THAT THERE IS MORE. A model reading the first 8000
+    # characters of a page with no sign that it is the first 8000 answers about
+    # the whole page from a fragment. The count is in the sentence so it can
+    # decide whether to go and get the rest.
+    assert said.startswith(" 1000 more characters, not sent]"), (
+        "the cut is silent, so the model reads a fragment as the whole thing: "
+        "%r" % sent[-80:])
 
 
 async def test_a_result_at_or_below_the_limit_is_sent_whole():

--- a/tests/test_every_control_says_what_it_does.py
+++ b/tests/test_every_control_says_what_it_does.py
@@ -1,0 +1,299 @@
+"""Every control on the page says what it will do, before it is pressed and
+after, and one rule says "this cannot be used".
+
+Found by the UX audit of 2026-09-12, all on the running page: Enter queued a
+sentence while the button looked exactly like Send; Clear went grey for a whole
+run and never said why; the first-run example was drawn as a chip and did
+nothing when clicked; a failed load of the session list looked like an empty
+one; the largest motion on the page ignored the reduced-motion setting because
+it was asked for in script; and four rules spelled "cannot be used" with two
+different numbers.
+
+Executed rather than read wherever a fact is about what a handler DOES: the
+text of `paint` says nothing about which mode it will pick, and the text of a
+click handler says nothing about whether it fires the request.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+
+import pytest
+
+from aihawk.web import PAGE
+
+NODE = shutil.which("node")
+CODE = re.sub(r"/\*.*?\*/|<!--.*?-->", "", PAGE, flags=re.S)
+CSS = re.sub(r"/\*.*?\*/", "", PAGE[PAGE.index("<style>"):PAGE.index("</style>")], flags=re.S)
+
+
+def run(js):
+    done = subprocess.run([NODE, "-e", js], capture_output=True, text=True,
+                          encoding="utf-8", timeout=30)
+    assert done.returncode == 0, done.stderr
+    return json.loads(done.stdout)
+
+
+def whole(start, end):
+    src = CODE[CODE.index(start):]
+    return src[:src.index(end) + len(end)]
+
+
+needs_node = pytest.mark.skipif(not NODE, reason="needs node to EXECUTE the page")
+
+
+@needs_node
+def test_the_send_button_says_when_enter_will_queue():
+    """⛔ NOTHING VISIBLE SAID THAT ENTER WOULD QUEUE. The placeholder said it,
+    and a placeholder disappears at the first keystroke: the moment somebody
+    had typed a follow-up while the agent worked, the one control in front of
+    them looked exactly like Send. The three-way choice was also written twice,
+    once for the label and once for the placeholder.
+
+    The mode is decided once, published on the button, and the stylesheet draws
+    the queue as the same shape held back - outlined, not filled.
+
+    Known-bad, three: stop publishing the mode; publish it and give it no rule;
+    let the ordinary hover rule fill the outlined button back in.
+    """
+    paint = whole("function paint(){", chr(10) + "}")
+    harness = [
+        "const what = {textContent:''};",
+        "globalThis.chip = {hidden:true, querySelector: () => what};",
+        "globalThis.i = {value:'a follow-up', placeholder:''};",
+        "globalThis.go = {disabled:false, dataset:{}, setAttribute(){}};",
+        "globalThis.halt = {hidden:true};",
+        "globalThis.fresh = {attrs:{}, setAttribute(k, v){ this.attrs[k] = v; }};",
+        "const seen = {};",
+        "globalThis.busyNow = false; globalThis.queued = null; paint(); seen.idle = go.dataset.mode;",
+        "globalThis.busyNow = true; paint(); seen.working = go.dataset.mode;",
+        "globalThis.queued = 'the first one'; paint(); seen.held = go.dataset.mode;",
+        "process.stdout.write(JSON.stringify(seen));",
+    ]
+    got = run(paint + chr(10) + chr(10).join(harness))
+    assert got == {"idle": "send", "working": "queue", "held": "replace"}, (
+        "the button does not publish what Enter will do: %r" % (got,))
+
+    #: and the stylesheet draws the difference, and keeps drawing it on hover.
+    queue = re.search(r'#go\[data-mode="queue"\][^{]*\{([^}]*)\}', CSS)
+    assert queue and "background:transparent" in queue.group(1).replace(" ", ""), (
+        "queue mode is published and drawn like Send, so the signal exists only "
+        "in the DOM")
+    assert re.search(r'#go\[data-mode="queue"\]:hover[^{]*\{[^}]*background', CSS), (
+        "the ordinary hover rule fills the outlined button back in, undoing the "
+        "signal at the exact moment the pointer arrives")
+
+
+@needs_node
+def test_clear_explains_itself_instead_of_going_dead():
+    """⛔ CLEAR WENT GREY FOR THE WHOLE RUN AND NEVER SAID WHY. A `disabled`
+    button fires no events - no hover, no click, and in this engine no tooltip -
+    so there was nowhere to hang the explanation. It carries `aria-disabled`
+    now, keeps the same look through the shared rule, and a press while the
+    agent works says what to do.
+
+    Known-bad, three: set `disabled` again; drop the sentence; let the press
+    clear anyway.
+    """
+    paint = whole("function paint(){", chr(10) + "}")
+    click = whole("fresh.onclick = () => {", chr(10) + "};")
+    harness = [
+        "const what = {textContent:''};",
+        "globalThis.chip = {hidden:true, querySelector: () => what};",
+        "globalThis.i = {value:'', placeholder:''};",
+        "globalThis.go = {disabled:false, dataset:{}, setAttribute(){}};",
+        "globalThis.halt = {hidden:true};",
+        "globalThis.fresh = {attrs:{}, setAttribute(k, v){ this.attrs[k] = v; }};",
+        "let said = [], asked = [];",
+        "globalThis.orphan = (k, t) => said.push(t);",
+        "globalThis.ask = (path) => { asked.push(path); };",
+        "globalThis.confirm = () => true;",
+        "globalThis.queued = null;",
+        "globalThis.busyNow = true; paint();",
+        "const look = fresh.attrs['aria-disabled'];",
+        "fresh.onclick();",
+        "const whileWorking = {said: said.slice(), asked: asked.slice()};",
+        "said = []; asked = [];",
+        "globalThis.busyNow = false; paint(); fresh.onclick();",
+        "process.stdout.write(JSON.stringify({look, whileWorking,",
+        "  idle: {said, asked, disabled: !!fresh.disabled}}));",
+    ]
+    #: the stubs first, then the code that binds to them, then the actions:
+    #: `fresh.onclick = ...` runs the moment the script is evaluated.
+    at = harness.index("let said = [], asked = [];")
+    got = run(chr(10).join(harness[:at]) + chr(10) + paint + chr(10) + click
+              + chr(10) + chr(10).join(harness[at:]))
+    assert got["look"] == "true", (
+        "Clear does not say it is off while the agent works: %r" % (got,))
+    assert got["whileWorking"]["asked"] == [], (
+        "a press on Clear during a run clears the conversation the agent is "
+        "still writing into: %r" % (got["whileWorking"],))
+    assert len(got["whileWorking"]["said"]) == 1 and "stop the run" in got["whileWorking"]["said"][0], (
+        "a press on Clear during a run does nothing and says nothing: %r"
+        % (got["whileWorking"],))
+    assert got["idle"] == {"said": [], "asked": ["/chat/fresh"], "disabled": False}, (
+        "Clear at rest no longer clears, or explains something to nobody: %r"
+        % (got["idle"],))
+
+
+@needs_node
+def test_the_first_run_example_fills_the_box_and_sends_nothing():
+    """⛔ THE EXAMPLE WAS DRAWN AS A CHIP AND DID NOTHING WHEN CLICKED, on the
+    first screen a new user sees. It fills the composer and does not send - the
+    words are put where they can be read and changed. Wired by class on the
+    transcript, because the node is cloned back after Clear and a handler on the
+    original would not travel with the clone.
+
+    And there is ONE first instruction on the page. The stage's empty state
+    carried a second, different one, so the two halves of the page taught two
+    different sentences.
+
+    Known-bad, three: make it a paragraph again; send on click; put a second
+    example back on the stage.
+    """
+    assert '<button type="button" class="eg">' in PAGE, (
+        "the first-run example is not a button, so it looks pressable and is not")
+    stage = PAGE[PAGE.index('id="stage"'):]
+    stage = stage[:stage.index("</div>")]
+    assert "<code>" not in stage, (
+        "the stage teaches a second first instruction beside the one in the hint")
+
+    src = whole("thread.addEventListener('click'", chr(10) + "});")
+    harness = [
+        "let handler = null, sent = [];",
+        "globalThis.thread = {addEventListener(t, fn){ handler = fn; }};",
+        "globalThis.i = {value:'', focused:false, events:[],",
+        "  dispatchEvent(e){ this.events.push(e.type); }, focus(){ this.focused = true; }};",
+        "globalThis.Event = function(type){ this.type = type; };",
+        "globalThis.send = (t) => sent.push(t);",
+        "HERE",
+        "const eg = {textContent: ' Go to example.com and tell me the main heading. ',",
+        "            closest: sel => sel === '.eg' ? eg : null};",
+        "handler({target: eg});",
+        "const other = {closest: () => null};",
+        "const before = i.value; handler({target: other});",
+        "process.stdout.write(JSON.stringify({value: i.value, focused: i.focused,",
+        "  events: i.events, sent, untouched: i.value === before}));",
+    ]
+    got = run(chr(10).join(harness).replace("HERE", src))
+    assert got["value"] == "Go to example.com and tell me the main heading.", (
+        "clicking the example does not put its sentence in the box: %r" % (got,))
+    assert got["sent"] == [] and got["focused"] and got["events"] == ["input"], (
+        "the example sends, or fills the box without handing it the keyboard: %r"
+        % (got,))
+    assert got["untouched"], "a click anywhere in the transcript rewrites the box"
+
+
+@needs_node
+def test_the_session_list_tells_a_failed_load_from_an_empty_one():
+    """⛔ A LIST THAT COULD NOT BE LOADED LOOKED LIKE AN EMPTY ONE. The fetch
+    failing returned early and left whatever was drawn before - or, on a first
+    open, the sentence `No saved conversations yet`, which was a lie in the
+    shape of an empty state. Three outcomes now, and `null` is the answer for
+    "I do not know".
+
+    Known-bad: return early in the catch again, or fold the two cases back
+    into one sentence.
+    """
+    src = whole("async function drawChats(){", chr(10) + "}")
+    harness = [
+        "const made = () => ({kids:[], attrs:{}, dataset:{}, textContent:'',",
+        "  appendChild(k){ this.kids.push(k); }, append(...k){ this.kids.push(...k); },",
+        "  setAttribute(k, v){ this.attrs[k] = v; }, removeAttribute(k){ delete this.attrs[k]; }});",
+        "const box = made();",
+        "globalThis.$ = () => box;",
+        "globalThis.el = (tag, cls, t) => Object.assign(made(), {tag, cls, t});",
+        "globalThis.railsay = () => {}; globalThis.here = 'default';",
+        "globalThis.showRail = () => {}; globalThis.renameChat = () => {};",
+        "globalThis.forgetChat = () => {};",
+        "let answer = null;",
+        "globalThis.plainDoor = async () => { if(answer === 'down') throw new Error('down');",
+        "  return {ok: true, json: async () => ({sessions: answer})}; };",
+        "HERE",
+        "(async () => {",
+        "  const out = {};",
+        "  answer = 'down'; box.kids = []; await drawChats();",
+        "  out.down = box.kids.map(k => k.t || k.cls);",
+        "  answer = []; box.kids = []; await drawChats();",
+        "  out.empty = box.kids.map(k => k.t || k.cls);",
+        "  answer = [{id:'a', name:'first'}, {id:'b', name:'second'}]; box.kids = [];",
+        "  await drawChats();",
+        "  out.rows = box.kids.map(k => k.cls);",
+        "  out.role = box.attrs.role;",
+        "  process.stdout.write(JSON.stringify(out));",
+        "})();",
+    ]
+    got = run(chr(10).join(harness).replace("HERE", src))
+    assert len(got["down"]) == 1 and "could not be loaded" in got["down"][0], (
+        "a failed load of the session list is drawn as something else: %r" % (got,))
+    assert len(got["empty"]) == 1 and "No saved conversations" in got["empty"][0], (
+        "an empty list lost its own sentence: %r" % (got,))
+    assert got["rows"] == ["chat", "chat"] and got["role"] == "list", (
+        "a list that arrived is not drawn as a list: %r" % (got,))
+
+
+@needs_node
+def test_jump_to_latest_respects_the_reduced_motion_setting():
+    """⛔ THE LARGEST MOTION ON THE PAGE WAS THE ONE THE REDUCED-MOTION BLOCK
+    COULD NOT REACH: a smooth scroll asked for in script is outside every CSS
+    rule. Read at click time, not at load, because the setting can change while
+    the tab is open.
+
+    Known-bad: hardcode `smooth`, or read the setting once at load.
+    """
+    src = whole("$('jump').onclick =", ";" + chr(10))
+    harness = [
+        "let jump = null, calls = [], reduce = false;",
+        "globalThis.$ = () => ({set onclick(fn){ jump = fn; }});",
+        "globalThis.anchor = {scrollIntoView(o){ calls.push(o.behavior); }};",
+        "globalThis.matchMedia = (q) => ({matches: reduce && q.indexOf('reduce') >= 0});",
+        "HERE",
+        "jump(); reduce = true; jump();",
+        "process.stdout.write(JSON.stringify(calls));",
+    ]
+    got = run(chr(10).join(harness).replace("HERE", src))
+    assert got == ["smooth", "auto"], (
+        "jump to latest does not follow the reduced-motion setting at the time "
+        "of the click: %r" % (got,))
+
+
+def test_one_rule_says_a_control_cannot_be_used():
+    """⛔ FOUR RULES SAID IT WITH TWO DIFFERENT NUMBERS. .3 on two disabled
+    buttons and on inert subtrees, .4 on the empty room's picker, and the
+    newest control left out altogether. One rule owns the look, whatever the
+    mechanism - `disabled`, `inert` or `aria-disabled`.
+
+    Known-bad: give any control its own opacity back.
+    """
+    rules = re.findall(r"([^{}]+)\{([^{}]*)\}", CSS)
+    own = [sel.strip() for sel, decl in rules
+           if re.search(r"opacity:\s*\.[34]\b", decl)
+           and not sel.strip().startswith(":disabled")
+           and "@keyframes" not in sel and "breathe" not in sel]
+    assert own == [], (
+        "%d rule(s) say 'cannot be used' with their own number instead of the "
+        "shared one: %s" % (len(own), own))
+    shared = [sel for sel, decl in rules if sel.strip().startswith(":disabled")]
+    assert shared and all(k in shared[0] for k in ("[inert]", '[aria-disabled="true"]')), (
+        "the shared rule does not cover every mechanism the page uses: %s" % shared)
+
+
+def test_a_drawn_word_has_one_look_wherever_it_hangs():
+    """The rail's tip carried nine declarations of its own; the second tip - F2
+    on a session row, for the keyboard the native tooltip never serves - would
+    have copied all nine. The look belongs to the attribute, and each element
+    keeps only where the word goes and when it shows.
+
+    Known-bad: give either placement rule a background or padding of its own.
+    """
+    look = re.search(r"\[data-tip\]::after\{([^}]*)\}", CSS)
+    assert look and "content:attr(data-tip)" in look.group(1).replace(" ", ""), (
+        "no shared rule draws a data-tip")
+    for placed in ("#railtab::after", ".chat::after"):
+        rule = re.search(re.escape(placed) + r"\{([^}]*)\}", CSS)
+        assert rule, "%s has no placement" % placed
+        assert not re.search(r"background|padding", rule.group(1)), (
+            "%s re-declares the look instead of only placing the word: %s"
+            % (placed, rule.group(1)))

--- a/tests/test_no_tracked_file_carries_a_control_byte.py
+++ b/tests/test_no_tracked_file_carries_a_control_byte.py
@@ -1,0 +1,54 @@
+"""No tracked text file carries a control byte, because a corrupted regex does
+not fail: it matches nothing, and a gate built on it prints PASS for ever.
+
+⛔ TWICE IN ONE AFTERNOON, 2026-09-12, IN THIS SUITE. A word boundary written
+as `\\b` and passed through a shell reached the file as the byte 0x08. The
+regex `border-radius:\\s*([\\d]+px)<BS>` then required a backspace after `px`,
+found none, and the gate that was supposed to refuse a retyped radius passed
+with the retyped radius on disk. A second gate in another file carried two more
+of the same byte around a pattern meant to catch a layout number typed back
+into the drag code; it was blind from the moment it was written. Both were
+found by a known-bad mutation SURVIVING, not by reading the code - `sed` prints
+a backspace as nothing at all, so the two files read as correct.
+
+The class is wider than `\\b`: `\\f` becomes a form feed, `\\t` a tab inside a
+path, `\\0` a NUL. None of them error. So this reads the BYTES of every text
+file git tracks and refuses any control character that is not a tab, a line
+feed or a carriage return.
+
+Known-bad: write a 0x08 into any tracked text file.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+#: What may legitimately appear below 0x20 in a text file.
+ALLOWED = {9, 10, 13}
+
+#: Files whose bytes are not text and are not read by any regex here.
+BINARY = (".png", ".jpg", ".jpeg", ".gif", ".ico", ".woff", ".woff2", ".pdf")
+
+
+def test_no_tracked_text_file_carries_a_control_byte():
+    tracked = subprocess.run(["git", "ls-files", "-z"], cwd=ROOT, capture_output=True,
+                             check=True).stdout.decode("utf-8").split("\0")
+    assert len(tracked) > 50, "found almost nothing tracked, so this is not looking"
+
+    found = []
+    for rel in tracked:
+        if not rel or rel.endswith(BINARY):
+            continue
+        path = ROOT / rel
+        if not path.is_file():
+            continue
+        data = path.read_bytes()
+        bad = sorted({b for b in data if b < 32 and b not in ALLOWED})
+        if bad:
+            found.append((rel, [hex(b) for b in bad]))
+
+    assert not found, (
+        "%d tracked file(s) carry a control byte, which a regex or a path in "
+        "them will read as a character that is never there: %s" % (len(found), found))

--- a/tests/test_the_browser_workspace.py
+++ b/tests/test_the_browser_workspace.py
@@ -463,7 +463,8 @@ def test_every_handler_the_page_wires_up_exists():
     defined = set(re.findall(r"(?:async\s+)?function\s+([A-Za-z_$][\w$]*)", code))
     defined |= set(re.findall(r"(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=", code))
     # Things the language and the document provide.
-    BUILT_IN = {"fetch", "alert", "confirm", "prompt", "parseInt", "String",
+    BUILT_IN = {"fetch", "alert", "confirm", "prompt", "parseInt", "parseFloat",
+                "getComputedStyle", "String",
                 "Number", "JSON", "Math", "Object", "Array", "setTimeout",
                 "clearTimeout", "setInterval", "clearInterval", "el", "$"}
 
@@ -499,8 +500,15 @@ def test_the_answer_measure_is_inside_the_range_every_source_agrees_on():
     """
     import re
 
-    pane = float(re.search(r"#left \{ width:clamp\([\d.]+px, ?\d+%, ?([\d.]+)px\)",
-                           PAGE).group(1))
+    #: ⛔ THE FLOOR IS A TOKEN NOW, so the rule no longer spells three pixel
+    #: literals and a regex pinned to that shape stopped matching at all -
+    #: which is an AttributeError, not a red assertion, and reads as the gate
+    #: being broken rather than as the page having changed. The only pixel
+    #: literal left in the rule is the ceiling, which is the number this
+    #: whole calculation is about.
+    rule = PAGE[PAGE.index("#left {"):]
+    rule = " ".join(rule[:rule.index("}")].split())
+    pane = float(re.search(r"([\d.]+)px", rule).group(1))
     assert re.search(r"#log\{[^}]*padding:var\(--s5\) var\(--s4\)", PAGE), (
         "the transcript no longer states its own padding, so this cannot be "
         "computed from the file")

--- a/tests/test_the_page_can_be_read.py
+++ b/tests/test_the_page_can_be_read.py
@@ -115,3 +115,51 @@ def test_nothing_you_have_to_click_is_smaller_than_the_floor():
     assert not small, (
         "%d control(s) declare less than the 24px WCAG 2.2 asks for: %s"
         % (len(small), ", ".join(small)))
+
+
+def test_no_attribute_leaks_onto_the_page_as_text():
+    """⛔ A COMMENT INSIDE A START TAG ENDS THE TAG. The `>` that closes an HTML
+    comment is the `>` that closes whatever tag it sits in, so every attribute
+    written after it becomes visible text. It happened to the separator on
+    2026-09-12: `aria-label="Width of the conversation" aria-valuenow="530">`
+    printed down the seam between the two panes, in body type, with 577 tests
+    green - because nothing in the suite reads the page the way a browser
+    does. Found by looking at a screenshot.
+
+    Two checks, from the parser side and from the source side: no text node
+    outside script and style may carry attribute syntax, and no start tag may
+    contain a comment opener.
+
+    Known-bad: put a comment back between two attributes of any tag.
+    """
+    from html.parser import HTMLParser
+
+    class Reader(HTMLParser):
+        def __init__(self):
+            super().__init__()
+            self.inside = None
+            self.leaks = []
+
+        def handle_starttag(self, tag, attrs):
+            if tag in ("script", "style"):
+                self.inside = tag
+
+        def handle_endtag(self, tag):
+            if tag == self.inside:
+                self.inside = None
+
+        def handle_data(self, data):
+            if self.inside is None and '="' in data:
+                self.leaks.append(" ".join(data.split())[:90])
+
+    reader = Reader()
+    reader.feed(PAGE)
+    assert not reader.leaks, (
+        "attribute syntax is drawn on the page as text, which is what a comment "
+        "inside a start tag does to everything after it: %s" % reader.leaks)
+
+    inside = re.findall(r"<[a-zA-Z][^<>]*<!--", PAGE)
+    assert not inside, (
+        "%d start tag(s) carry a comment opener, and the comment's closing "
+        "bracket will end the tag early: %s" % (len(inside), inside))
+

--- a/tests/test_the_page_meets_the_craft_floor.py
+++ b/tests/test_the_page_meets_the_craft_floor.py
@@ -268,3 +268,51 @@ def test_the_type_scale_has_steps_a_reader_can_see():
             assert rule and ("font-weight" in rule.group(1)
                              or "color" in rule.group(1)), (
                 "%s is the body's size and nothing else separates it" % role)
+
+
+def test_a_recipe_is_written_once_and_read_everywhere():
+    """⛔ THE SAME SURFACE, DESCRIBED TWICE, WITH DIFFERENT NUMBERS. The error
+    fill was 9% in one rule and 8% in the other, its edge 32% and 30%, on two
+    things that are the same thing to the eye - a free-standing box and a step
+    row. Seven shadows were written by hand with six geometries and five alphas,
+    one of them retyping a line token as a raw rgba. Two radii spelled out the
+    pixel value of a token declared a few lines above them. None of this is
+    visible as a defect: it is visible later, as the day one of the two copies
+    moves.
+
+    What is shared is the INK and not the geometry. A whole-value shadow token
+    cannot work here - the drawer throws sideways and the composer throws
+    upward, because it separates an input from a transcript scrolling under it
+    - so the depth is a token and the direction stays with the component.
+
+    Known-bad, four: write a raw rgba shadow ink; re-expand the error mix in a
+    rule; type a radius that a token already names; give a mono surface a rem
+    size when the file declares one for exactly that job.
+    """
+    css = re.sub(r"/\*.*?\*/", "", CSS, flags=re.S)
+    #: the token block itself is where the values are allowed to be literal.
+    body = css[css.index("}", css.index(":root")):]
+
+    inks = re.findall(r"box-shadow:[^;}]*rgba\(0,\s*0,\s*0", body)
+    assert not inks, (
+        "%d shadow(s) mix their own ink instead of taking a shade token, so the "
+        "page has that many opinions about how dark a shadow is: %s"
+        % (len(inks), inks))
+
+    mixes = re.findall(r"color-mix\([^)]*--err[^)]*\)", body)
+    assert not mixes, (
+        "the error surface is re-mixed in a rule instead of read from the two "
+        "tokens that describe it: %s" % mixes)
+
+    sizes = {"4px": "--r-sm", "8px": "--r", "12px": "--r-lg", "999px": "--r-pill"}
+    typed = [(m, sizes[m]) for m in re.findall(r"border-radius:\s*([\d]+px)", body)
+             if m in sizes]
+    assert not typed, (
+        "%d radius(es) spell out a value a token already names: %s"
+        % (len(typed), typed))
+
+    mono = re.findall(r"font:\s*([\d.]+rem)[^;}]*var\(--mono\)", body)
+    assert not mono, (
+        "%d mono surface(s) state their own size while the file declares one "
+        "for steps, code and addresses by name: %s" % (len(mono), mono))
+

--- a/tests/test_the_page_tells_the_truth.py
+++ b/tests/test_the_page_tells_the_truth.py
@@ -472,7 +472,11 @@ def test_a_subtree_that_cannot_be_used_does_not_look_usable():
     Known-bad: drop the rule and let each caller remember to dim its own subtree.
     """
     css = CODE[CODE.index("<style>"):CODE.index("</style>")]
-    assert re.search(r"\[inert\]\{[^}]*opacity", css), (
+    # ⛔ ONE RULE FOR THE CLASS, so the selector is shared with `:disabled` and
+    # `[aria-disabled]`: four rules used to say "cannot be used" with two
+    # different numbers. The pattern allows the company and still demands that
+    # an inert subtree is what the rule dims.
+    assert re.search(r"\[inert\][^{]*\{[^}]*opacity", css), (
         "nothing makes an inert subtree look inert, so every control inside one "
         "keeps inviting an action it cannot perform")
 
@@ -1145,8 +1149,9 @@ def test_the_queued_sentence_is_on_screen_and_survives_a_click():
         "                   focus(){}};",
         "globalThis.i = {value: '', placeholder: '',",
         "                dispatchEvent(){}, focus(){}};",
-        "globalThis.go = {disabled:false, setAttribute(){}};",
-        "globalThis.halt = {hidden:true}; globalThis.fresh = {disabled:false};",
+        "globalThis.go = {disabled:false, dataset:{}, setAttribute(){}};",
+        "globalThis.halt = {hidden:true};",
+        "globalThis.fresh = {disabled:false, setAttribute(){}};",
         "globalThis.Event = function(){};",
         "globalThis.queued = 'go to the second page and read the heading';",
         "globalThis.busyNow = true;",

--- a/tests/test_the_page_tells_the_truth.py
+++ b/tests/test_the_page_tells_the_truth.py
@@ -855,7 +855,7 @@ def test_a_reopened_conversation_keeps_the_answer_of_every_turn():
 
     js = (whole("function flush(", chr(10) + "}") + chr(10)
           + whole("const onEvent =", chr(10) + "};") + chr(10)
-          + "let drawn = [];\nglobalThis.hold = null; globalThis.busyNow = false;\nglobalThis.live = null; globalThis.timer = 0; globalThis.queued = null;\nglobalThis.LEAD = /^(I will |I'll |Let me )/i;\nglobalThis.el = (tag, cls, t) => ({tag, cls, t, kids: [],\n                                   appendChild(k){ this.kids.push(k); }});\nglobalThis.rich = t => ({tag: 'rich', t});\nglobalThis.put = n => drawn.push(n);\nglobalThis.$ = () => ({textContent: '', hidden: false});\nfor (const name of ['wipe','waiting','waited','drawChats','paint',\n                    'settleOnce','newTurn','step','land','orphan',\n                    'setQueued','send','clearInterval'])\n  globalThis[name] = () => {};\n\nconst feed = m => onEvent({data: JSON.stringify(m)});\nconst history = [\n  {kind:'you',    text:'first instruction',  replay:true},\n  {kind:'said',   text:'Let me open the page.', replay:true},\n  {kind:'tool',   text:'browser_navigate a', replay:true},\n  {kind:'result', text:'ok',                 replay:true},\n  {kind:'said',   text:'THE FIRST ANSWER.',  replay:true},\n  {kind:'you',    text:'second instruction', replay:true},\n  {kind:'tool',   text:'browser_navigate b', replay:true},\n  {kind:'result', text:'ok',                 replay:true},\n  {kind:'said',   text:'THE SECOND ANSWER.', replay:true},\n];\nhistory.forEach(feed);\n/* what the server sends after the replay, once it is idle */\nfeed({kind:'busy', text:'0'});\nconst answers = drawn.filter(d => d.cls === 'answer')\n                     .map(d => (d.kids[0] && d.kids[0].t) || '');\nprocess.stdout.write(JSON.stringify({answers, total: drawn.length}));")
+          + "let drawn = [];\nglobalThis.hold = null; globalThis.busyNow = false;\nlet announced = [], later = null;\nglobalThis.quiet = 0;\nglobalThis.thread = {setAttribute(k, v){ announced.push(v); }};\nglobalThis.clearTimeout = () => {};\nglobalThis.setTimeout = (fn) => { later = fn; return 1; };\nglobalThis.live = null; globalThis.timer = 0; globalThis.queued = null;\nglobalThis.LEAD = /^(I will |I'll |Let me )/i;\nglobalThis.el = (tag, cls, t) => ({tag, cls, t, kids: [],\n                                   appendChild(k){ this.kids.push(k); }});\nglobalThis.rich = t => ({tag: 'rich', t});\nglobalThis.put = n => drawn.push(n);\nglobalThis.$ = () => ({textContent: '', hidden: false});\nfor (const name of ['wipe','waiting','waited','drawChats','paint',\n                    'settleOnce','newTurn','step','land','orphan',\n                    'setQueued','send','clearInterval'])\n  globalThis[name] = () => {};\n\nconst feed = m => onEvent({data: JSON.stringify(m)});\nconst history = [\n  {kind:'you',    text:'first instruction',  replay:true},\n  {kind:'said',   text:'Let me open the page.', replay:true},\n  {kind:'tool',   text:'browser_navigate a', replay:true},\n  {kind:'result', text:'ok',                 replay:true},\n  {kind:'said',   text:'THE FIRST ANSWER.',  replay:true},\n  {kind:'you',    text:'second instruction', replay:true},\n  {kind:'tool',   text:'browser_navigate b', replay:true},\n  {kind:'result', text:'ok',                 replay:true},\n  {kind:'said',   text:'THE SECOND ANSWER.', replay:true},\n];\nhistory.forEach(feed);\n/* what the server sends after the replay, once it is idle */\nfeed({kind:'busy', text:'0'});\nconst answers = drawn.filter(d => d.cls === 'answer')\n                     .map(d => (d.kids[0] && d.kids[0].t) || '');\nif (later) later();\nprocess.stdout.write(JSON.stringify({answers, total: drawn.length, announced}));")
     done = subprocess.run([node, "-e", js], capture_output=True, text=True,
                           encoding="utf-8", timeout=30)
     assert done.returncode == 0, done.stderr
@@ -864,6 +864,18 @@ def test_a_reopened_conversation_keeps_the_answer_of_every_turn():
     assert got["answers"] == ["THE FIRST ANSWER.", "THE SECOND ANSWER."], (
         "a reopened conversation lost the answer of a turn that is not the "
         "last: %r" % (got["answers"],))
+    #: ⛔ AND THE REPLAY IS NOT READ OUT. The transcript is the page's only
+    #: live region, and a reconnect pours the whole conversation back into it:
+    #: a screen reader announced an hour of finished work from the top while
+    #: the agent went on adding to it. Silenced for the burst and restored
+    #: after, because leaving it off for good is the louder bug told quietly.
+    assert got["announced"] and got["announced"][0] == "off", (
+        "a replayed conversation is announced as though it were happening "
+        "now: %r" % (got["announced"],))
+    assert got["announced"][-1] == "polite", (
+        "the live region is left switched off after a replay, so nothing the "
+        "agent does afterwards is announced at all: %r" % (got["announced"],))
+
     #: and the lead-in is still dropped, which is the thing this must not undo.
     assert not any("open the page" in a for a in got["answers"]), (
         "the sentence that came with the tool calls came back as an answer")
@@ -1016,7 +1028,7 @@ def test_a_step_nobody_landed_stops_claiming_to_be_running():
         "    append(...xs){ for (const x of xs)",
         "      if (x && x.cls === 'mark') this.words.push(x.t); }};",
         "  const row = {querySelector: s => s === '.lab b' ? lab.b : lab,",
-        "               lastElementChild:{textContent:''}};",
+        "               tabIndex: 0, lastElementChild:{textContent:''}};",
         "  return {dataset:{name:'browser_click', state:'run'},",
         "          firstElementChild: row, appendChild(){}, lab};",
         "};",
@@ -1045,7 +1057,8 @@ def test_a_step_nobody_landed_stops_claiming_to_be_running():
         "/* and one that actually worked */",
         "const good = made(); globalThis.live = good;",
         "land('result', 'ok', false);",
-        "const worked = {state: good.dataset.state,",
+        "const worked = {state: good.dataset.state, body: good.dataset.body,",
+        "                tab: good.firstElementChild.tabIndex,",
         "                verb: good.lab.b.textContent, words: good.lab.words};",
         "process.stdout.write(JSON.stringify({stopped, failed, worked}));",
     ]
@@ -1077,6 +1090,15 @@ def test_a_step_nobody_landed_stops_claiming_to_be_running():
 
     assert got["worked"]["state"] == "ok" and got["worked"]["verb"] == "Clicked", (
         "a step that worked lost its past tense: %r" % (got["worked"],))
+    #: ⛔ AND A ROW WITH NOTHING TO OPEN LEAVES THE TAB ORDER. Every finished
+    #: step stayed a focusable disclosure, so crossing a fifty step run by
+    #: keyboard was fifty presses through rows where Enter opens nothing: the
+    #: distance between the sessions button and the composer was a minefield of
+    #: controls that do not control anything. Decided by the same statement that
+    #: decides the row has no body, so the two cannot drift apart.
+    assert got["worked"]["body"] == "none" and got["worked"]["tab"] == -1, (
+        "a step with its whole result on the row is still a tab stop that "
+        "opens nothing: %r" % (got["worked"],))
     assert got["worked"]["words"] == [], (
         "an ordinary result is annotated with an outcome word, which is noise "
         "on the rows that make up most of a run: %r" % (got["worked"],))
@@ -1155,3 +1177,152 @@ def test_the_queued_sentence_is_on_screen_and_survives_a_click():
     assert "go to the second page" in got["box"], (
         "clicking the chip did not give the queued sentence back: %r"
         % (got["box"],))
+
+
+def test_the_browser_state_is_only_announced_when_it_changes():
+    """⛔ IT REWROTE THE PAGE'S LIVE REGION 25 TIMES A SECOND.
+
+    The frame pump calls `say` on every pass, and `say` wrote the state, the
+    word beside it and a title whether or not anything had changed. A screen
+    reader announces every one of those writes: the word `live`, over and over,
+    with the queue never emptying - so the one transition that matters, live to
+    error, could never be reached. Somebody using this product by ear was shut
+    out of it for exactly as long as it was working.
+
+    Guarded in `say` and not at the pump, because there are eight callers and
+    "the state changed" is one fact. Executed: the defect is not visible in the
+    text of a function that always wrote the same three properties.
+
+    Known-bad: drop the guard, or guard only the pump's call site.
+    """
+    import json
+    import shutil
+    import subprocess
+
+    import pytest
+
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("needs node to EXECUTE say()")
+
+    end = "stateEl.title = why || ''; }"
+    src = CODE[CODE.index("function say(s, why){"):]
+    src = src[:src.index(end) + len(end)]
+
+    harness = [
+        "let writes = 0;",
+        "globalThis.right = {dataset: new Proxy({}, {set(t, k, v){",
+        "  writes++; t[k] = v; return true; }})};",
+        "globalThis.stateEl = {textContent:'', title:'',",
+        "                      classList:{toggle(){}}};",
+        "/* the pump, a hundred passes of a browser that has not changed */",
+        "for (let k = 0; k < 100; k++) say('live');",
+        "const steady = writes;",
+        "say('offline', 'the stream closed');",
+        "const afterChange = writes;",
+        "/* and the same state with a different reason is a change too */",
+        "say('offline', 'reconnecting');",
+        "process.stdout.write(JSON.stringify({steady, afterChange,",
+        "                                     afterReason: writes}));",
+    ]
+
+    done = subprocess.run([node, "-e", src + chr(10) + chr(10).join(harness)],
+                          capture_output=True, text=True, encoding="utf-8",
+                          timeout=30)
+    assert done.returncode == 0, done.stderr
+    got = json.loads(done.stdout)
+
+    assert got["steady"] == 1, (
+        "a hundred passes of an unchanged browser wrote the live region %d "
+        "times, which a screen reader reads out %d times"
+        % (got["steady"], got["steady"]))
+    assert got["afterChange"] == 2, (
+        "the guard swallowed a real change, which is the one thing it must "
+        "never do: %r" % (got,))
+    assert got["afterReason"] == 3, (
+        "the same state with a different reason was swallowed, so the word "
+        "explaining WHY it went offline never arrives: %r" % (got,))
+
+
+def test_the_one_input_on_the_page_keeps_its_focus_ring():
+    """⛔ `#i{outline:none}` BEAT `:focus-visible` ON SPECIFICITY, so the only
+    way to talk to the agent had no focus indicator at all for anybody arriving
+    by keyboard. The caret was the whole signal - invisible at a glance, in a
+    screenshot, and to most people scanning a window.
+
+    The declaration was written for the mouse case, where the composer's own
+    border answers a click, so it is scoped to exactly that instead of removed:
+    the pointer path stays clean and the keyboard path gets the page's ring.
+
+    Known-bad, two: put the bare `outline:none` back into the `#i` rule, or
+    drop the scoped rule and leave the keyboard path relying on a caret.
+    """
+    import re
+
+    css = re.sub(r"/\*.*?\*/", "",
+                 PAGE[PAGE.index("<style>"):PAGE.index("</style>")], flags=re.S)
+    rule = css[css.index("#i{"):]
+    rule = rule[:rule.index("}")]
+    assert "outline:none" not in rule.replace(" ", ""), (
+        "the composer kills its own focus ring for every path, including the "
+        "keyboard: %s" % " ".join(rule.split()))
+    assert "#i:focus:not(:focus-visible)" in css.replace(" ", ""), (
+        "nothing scopes the outline removal to the pointer, so either the "
+        "mouse case draws a ring it does not need or the keyboard case has "
+        "none at all")
+
+
+def test_clearing_the_conversation_leaves_the_page_able_to_explain_itself():
+    """⛔ CLEAR DELETED THE PRODUCT'S ONLY GUIDANCE OUT OF THE DOM FOR GOOD.
+
+    The three sentences that say what this is live in the markup and the first
+    turn removes them, which is right. `wipe()` emptied the transcript without
+    putting them back, so pressing Clear on a finished conversation left a void
+    - and the page had forgotten how to introduce itself until the tab was
+    reloaded.
+
+    Cloned from the markup rather than rebuilt in a builder: the same three
+    sentences written twice is the duplication that makes one of the two go
+    stale.
+
+    Known-bad: drop the restore from `wipe`, or write the sentences a second
+    time in the script instead of cloning the node.
+    """
+    import json
+    import shutil
+    import subprocess
+
+    import pytest
+
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("needs node to EXECUTE wipe()")
+
+    src = CODE[CODE.index("function wipe(){"):]
+    src = src[:src.index(chr(10) + "}") + 2]
+
+    harness = [
+        "let kids = ['a turn', 'another turn'];",
+        "globalThis.thread = {",
+        "  set textContent(v){ kids = []; },",
+        "  get firstElementChild(){ return kids.length ? kids[0] : null; },",
+        "  appendChild(n){ kids.push(n); }};",
+        "globalThis.hintNode = {cloneNode: () => 'the guidance'};",
+        "globalThis.turn = 1; globalThis.live = 1; globalThis.hold = 1;",
+        "globalThis.n = 3; globalThis.timer = 0; globalThis.busyNow = true;",
+        "globalThis.waited = () => {}; globalThis.setQueued = () => {};",
+        "globalThis.clearInterval = () => {};",
+        "wipe();",
+        "process.stdout.write(JSON.stringify({left: kids}));",
+    ]
+
+    done = subprocess.run([node, "-e", src + chr(10) + chr(10).join(harness)],
+                          capture_output=True, text=True, encoding="utf-8",
+                          timeout=30)
+    assert done.returncode == 0, done.stderr
+    got = json.loads(done.stdout)
+
+    assert got["left"] == ["the guidance"], (
+        "clearing the conversation leaves a pane with nothing in it, on a "
+        "product whose whole first-run explanation was what it just deleted: "
+        "%r" % (got["left"],))

--- a/tests/test_the_page_tells_the_truth.py
+++ b/tests/test_the_page_tells_the_truth.py
@@ -1265,31 +1265,41 @@ def test_the_browser_state_is_only_announced_when_it_changes():
 
 
 def test_the_one_input_on_the_page_keeps_its_focus_ring():
-    """⛔ `#i{outline:none}` BEAT `:focus-visible` ON SPECIFICITY, so the only
-    way to talk to the agent had no focus indicator at all for anybody arriving
-    by keyboard. The caret was the whole signal - invisible at a glance, in a
-    screenshot, and to most people scanning a window.
+    """⛔ FIRST THE INPUT HAD NO FOCUS RING; THEN IT HAD TWO. `#i{outline:none}`
+    beat `:focus-visible` on specificity, so the only way to talk to the agent
+    signalled the keyboard with a caret and nothing else. The first repair
+    scoped the removal to `:focus:not(:focus-visible)` - and on a textarea
+    `:focus-visible` matches on EVERY focus, a click included, because the
+    element takes keyboard input. So the page opened on two nested rectangles,
+    the accent ring on the field inside the bordered box, and drew them again
+    on every click. Found in the final screenshot pass, not by any assertion.
 
-    The declaration was written for the mouse case, where the composer's own
-    border answers a click, so it is scoped to exactly that instead of removed:
-    the pointer path stays clean and the keyboard path gets the page's ring.
+    The visible control and the focusable element are two different boxes
+    here, which is the one place on the page where that is true. So the BOX
+    says it has the keyboard: a 2px ring at 3.92:1 on `.composer:focus-within`,
+    for everybody, and the field draws none of its own.
 
-    Known-bad, two: put the bare `outline:none` back into the `#i` rule, or
-    drop the scoped rule and leave the keyboard path relying on a caret.
+    Known-bad, two: give the field a ring of its own again; drop the shadow and
+    leave a 1px border as the whole indicator.
     """
     import re
 
     css = re.sub(r"/\*.*?\*/", "",
                  PAGE[PAGE.index("<style>"):PAGE.index("</style>")], flags=re.S)
-    rule = css[css.index("#i{"):]
-    rule = rule[:rule.index("}")]
-    assert "outline:none" not in rule.replace(" ", ""), (
-        "the composer kills its own focus ring for every path, including the "
-        "keyboard: %s" % " ".join(rule.split()))
-    assert "#i:focus:not(:focus-visible)" in css.replace(" ", ""), (
-        "nothing scopes the outline removal to the pointer, so either the "
-        "mouse case draws a ring it does not need or the keyboard case has "
-        "none at all")
+    box = re.search(r"\.composer:focus-within\{([^}]*)\}", css)
+    assert box, "the composer no longer says it has the keyboard"
+    flat = box.group(1).replace(" ", "")
+    assert "box-shadow:" in flat and "0001pxvar(--fg-4)" in flat and "border-color:var(--fg-4)" in flat, (
+        "the composer's focus indicator is not a 2px ring at the documented "
+        "3.9:1 ink: %s" % " ".join(box.group(1).split()))
+
+    #: and the field draws nothing of its own, or the two stack.
+    own = [m for m in re.findall(r"#i[^{,]*\{([^}]*)\}", css)
+           if re.search(r"outline:(?!none)", m.replace(" ", ""))]
+    assert not own, (
+        "the field draws a ring of its own inside the box's, so a focused "
+        "composer is two nested rectangles: %s" % own)
+
 
 
 def test_clearing_the_conversation_leaves_the_page_able_to_explain_itself():

--- a/tests/test_the_page_tells_the_truth.py
+++ b/tests/test_the_page_tells_the_truth.py
@@ -46,12 +46,20 @@ def test_a_refused_delete_is_not_drawn_as_a_delete():
     being navigated away, and leaving the session and its browsers exactly where
     they were - with every visible signal saying it had worked.
 
-    Known-bad: stop reading the answer.
+    ⛔ AND IT SAYS SO IN THE PANEL, NOT IN THE TRANSCRIPT, which is what this
+    assertion used to name. The sentence went to the conversation - the thing
+    the open panel is lying on top of and has just put out of play - so it
+    landed where the person who pressed the button could not read it. The
+    property is unchanged and the place it is said moved, so the literal moved
+    with it rather than the gate being dropped.
+
+    Known-bad: stop reading the answer, or say it into the transcript again.
     """
     body = CODE[CODE.index("async function forgetChat"):]
     body = body[:body.index("\n}")]
     assert "forgotten" in body, "the answer to the delete is never read"
-    assert "orphan(" in body, "a refused delete says nothing to the person who asked"
+    assert "railsay(" in body, (
+        "a refused delete says nothing where the person who asked can read it")
 
 
 def test_every_event_the_server_can_send_is_drawn():
@@ -429,17 +437,26 @@ def test_a_deleted_conversation_stops_the_page_asking_about_it():
     """The other half of the same defect: the server refuses now, and the page
     has to stop rather than retry a 410 four times a second in three loops.
 
-    Known-bad: leave `looking` reading only `document.hidden`, or drop the
-    `vanish` guard so the page keeps a live composer over a dead session.
+    ⛔ AND THE FLAG IS NOT WRITTEN BY HAND ANY MORE, which is why this names a
+    call instead of an assignment. The browser pane has a SECOND reason to be
+    out of play - the sessions panel lying on top of it - and the two are set
+    from different files, so whichever let go last won: closing the panel over
+    a deleted conversation brought the pane back fully lit on a page where
+    nothing is live. A box is held while any reason holds it.
+
+    Known-bad: leave `looking` reading only `document.hidden`; drop the
+    `vanish` guard so the page keeps a live composer over a dead session; or
+    write `box.inert = true` here again, which passes every assertion in this
+    file and loses the hold the moment a panel is closed.
     """
     assert "!document.hidden && !vanished" in CODE, (
         "the four loops go on polling a conversation that does not exist")
     body = CODE[CODE.index("function vanish()"):]
     body = body[:body.index("\n}")]
     assert "es.close()" in body, "the event stream is left open on a dead session"
-    assert "box.inert = true" in body, (
+    assert "outOfPlay(box, 'deleted', true)" in body, (
         "the composer still answers the keyboard for a conversation that cannot "
-        "receive anything")
+        "receive anything, or it is held by a flag anybody else can clear")
     assert "orphan(" in body, "the page says nothing about why it went quiet"
 
 
@@ -852,30 +869,34 @@ def test_a_reopened_conversation_keeps_the_answer_of_every_turn():
         "the sentence that came with the tool calls came back as an answer")
 
 
-def test_the_session_drawer_never_covers_the_input():
-    """⛔ THE DRAWER COVERED HALF THE ONLY INPUT ON THE PAGE, and the gate
-    written for the drawer could not see it.
+def test_the_sessions_panel_puts_the_page_behind_it_out_of_play():
+    """⛔ IT COVERED HALF THE CONVERSATION AND LEFT IT LOOKING READABLE.
 
-    That gate asserts that nothing outside the rail reacts to the rail being
-    open, which is true and was the defect of the day before. It is a scan over
-    selectors, so it knows nothing about where a box ends up: the rail ran the
-    full height of the window and lay over the composer. Measured 2026-09-11 in
-    a real browser: 256px of the 530px input, and `elementFromPoint` on the
-    corner of the textarea answered `chats`. Half of the only way to talk to
-    the agent was dead, with nothing saying so.
+    Measured 2026-09-12 in a real browser at eight widths, drawer open: 240px
+    off the front of every line at every desktop width - 48% of the measure at
+    1440px, 61% at 960px, 29 rows buried at once and one of them whole. The
+    owner read it off his own screen before any gate did: lines beginning
+    `.com/it/ navigated to`, with the verb and the step number underneath the
+    panel.
 
-    The rule that used to prevent it padded the transcript out of the way, and
-    that rewrapped every paragraph as the panel appeared - which is what it was
-    removed for. So the coupling runs the other way now: the CHAT still knows
-    nothing, and the PANEL knows where the input begins.
+    The gate that stood here asserted that the drawer stopped SHORT of the
+    composer, which was the defect of the day before and is now a question that
+    cannot be asked: with the page behind it inert, the panel may cover the
+    input, because the input is out of play anyway. So the property moved. It
+    is no longer where the panel stops, it is what it holds while it is up.
 
-    Measured and not declared, because the textarea grows with what is typed:
-    a constant would be right until somebody wrote a third line.
+    Three things are executed rather than read, because the text cannot answer
+    any of them: that opening holds both panes and closing releases them, that
+    the keyboard goes in and comes back, and that a hold SOMEBODY ELSE is
+    keeping survives this panel letting go of its own. The last one is why
+    `outOfPlay` exists at all - a conversation deleted in another tab holds the
+    browser pane, and a plain `inert = false` from here would bring that pane
+    back fully lit on a page where nothing is live.
 
-    Known-bad: anchor the rail to the bottom of the window again, or publish a
-    composer's HEIGHT instead of the distance to it: the same number only
-    while the composer sits at the bottom of the window, and below 720px the
-    panes stack and it does not.
+    Known-bad, all three run: write `box.inert = open` in place of the call to
+    `outOfPlay` and the deleted pane revives; drop the `hadFocus` check and the
+    keyboard is left standing on the document; drop the focus into the panel
+    and it never arrives.
     """
     import json
     import shutil
@@ -883,25 +904,67 @@ def test_the_session_drawer_never_covers_the_input():
 
     import pytest
 
-    #: the panel has to stop at the variable, not at the window.
-    style = CODE[CODE.index("#rail {"):]
-    style = style[:style.index("}") + 1]
-    assert "bottom:var(--rail-bottom" in style.replace(" ", ""), (
-        "the drawer is anchored to the bottom of the window again, so it lies "
-        "over the composer: %r" % " ".join(style.split()))
-
     node = shutil.which("node")
     if not node:
-        pytest.skip("needs node to EXECUTE the publisher")
+        pytest.skip("needs node to EXECUTE the panel rather than read it")
 
-    src = CODE[CODE.index("function publishRailFloor("):]
-    src = src[:src.index(chr(10) + "}") + 2]
-    done = subprocess.run([node, "-e", src + chr(10) + "let set = {};\nglobalThis.window = {innerHeight: 900};\nglobalThis.innerHeight = 900;\nglobalThis.addEventListener = () => {};\nglobalThis.$ = id => id === 'f'\n  ? {getBoundingClientRect: () => ({top: 783.2, height: 83.4})}\n  : null;\nglobalThis.document = {documentElement: {style: {\n  setProperty(k, v){ set[k] = v; }}}};\nglobalThis.ResizeObserver = undefined;\npublishRailFloor();\nprocess.stdout.write(JSON.stringify({set}));"],
-                          capture_output=True, text=True,
-                          encoding="utf-8", timeout=30)
+    #: `outOfPlay` and its map, from the file that owns them.
+    owner = CODE[CODE.index("const heldBy = new WeakMap();"):]
+    owner = owner[:owner.index(chr(10) + "}") + 2]
+    #: the key, the panel's own line and `showRail`, up to its first caller.
+    panel = CODE[CODE.index("const RAILKEY"):]
+    panel = panel[:panel.index("$('railtab').onclick")]
+
+    harness = [
+        "const made = {};",
+        "const box = id => (made[id] = {id, hidden:false, inert:false,",
+        "  attrs:{}, kids:[],",
+        "  setAttribute(k, v){ this.attrs[k] = v; },",
+        "  getAttribute(k){ return this.attrs[k]; },",
+        "  contains(n){ return n === this || this.kids.indexOf(n) >= 0; },",
+        "  focus(){ globalThis.document.activeElement = this; }});",
+        "['rail','railtab','left','right','newchat','chats','f'].forEach(box);",
+        "made.rail.kids = [made.newchat, made.chats];",
+        "made.left.kids = [made.f];",
+        "globalThis.$ = id => made[id];",
+        "globalThis.document = {activeElement: made.railtab};",
+        "globalThis.drawChats = () => {};",
+        "globalThis.addEventListener = () => {};",
+        "globalThis.localStorage = {seen:{},",
+        "  setItem(k, v){ this.seen[k] = v; }, getItem(k){ return this.seen[k]; }};",
+        "const shot = () => ({left: made.left.inert, right: made.right.inert,",
+        "  hidden: made.rail.hidden, focus: document.activeElement.id,",
+        "  expanded: made.railtab.getAttribute('aria-expanded'),",
+        "  remembered: localStorage.getItem('aihawk.rail')});",
+        "showRail(true);  const opened = shot();",
+        "showRail(false); const closed = shot();",
+        "/* somebody else is holding the browser pane: opening and closing this",
+        "   panel over it must not hand that pane back. */",
+        "outOfPlay(made.right, 'deleted', true);",
+        "showRail(true); showRail(false);",
+        "process.stdout.write(JSON.stringify({opened, closed,",
+        "                                     survives: made.right.inert}));",
+    ]
+
+    done = subprocess.run(
+        [node, "-e", owner + chr(10) + panel + chr(10) + chr(10).join(harness)],
+        capture_output=True, text=True, encoding="utf-8", timeout=30)
     assert done.returncode == 0, done.stderr
-    got = json.loads(done.stdout)["set"]
+    got = json.loads(done.stdout)
 
-    assert got.get("--rail-bottom") == "117px", (
-        "the floor the panel stops at is not the distance to the composer, "
-        "so it is right until the panes stack and the input moves: %r" % got)
+    assert got["opened"] == {"left": True, "right": True, "hidden": False,
+                             "focus": "newchat", "expanded": "true",
+                             "remembered": "1"}, (
+        "opening the panel does not take the page behind it out of play, or "
+        "does not take the keyboard with it: %r" % (got["opened"],))
+
+    assert got["closed"] == {"left": False, "right": False, "hidden": True,
+                             "focus": "railtab", "expanded": "false",
+                             "remembered": "0"}, (
+        "closing the panel leaves the page held, or leaves the keyboard "
+        "standing on the document: %r" % (got["closed"],))
+
+    assert got["survives"] is True, (
+        "closing the panel released a hold it never took: a conversation "
+        "deleted elsewhere had the browser pane out of play, and this brought "
+        "it back fully lit on a page where nothing is live")

--- a/tests/test_the_page_tells_the_truth.py
+++ b/tests/test_the_page_tells_the_truth.py
@@ -1206,15 +1206,25 @@ def test_the_browser_state_is_only_announced_when_it_changes():
         pytest.skip("needs node to EXECUTE say()")
 
     end = "stateEl.title = why || ''; }"
-    src = CODE[CODE.index("function say(s, why){"):]
+    #: from the variable the guard keeps, not from the function: what has
+    #: been DRAWN is the thing being remembered, and slicing below it was
+    #: how the harness first reported a defect that was its own.
+    src = CODE[CODE.index("let shown = null;"):]
     src = src[:src.index(end) + len(end)]
 
     harness = [
         "let writes = 0;",
-        "globalThis.right = {dataset: new Proxy({}, {set(t, k, v){",
+        "/* the markup declares the first state before any script runs, which is",
+        "   where the first version of this guard went wrong: it read the DOM,",
+        "   saw its own starting value, and swallowed the call that normalises",
+        "   the page. */",
+        "globalThis.right = {dataset: new Proxy({state: 'idle'}, {set(t, k, v){",
         "  writes++; t[k] = v; return true; }})};",
         "globalThis.stateEl = {textContent:'', title:'',",
         "                      classList:{toggle(){}}};",
+        "/* the state the markup already declares: the call must still draw */",
+        "say('idle');",
+        "const normalised = writes;",
         "/* the pump, a hundred passes of a browser that has not changed */",
         "for (let k = 0; k < 100; k++) say('live');",
         "const steady = writes;",
@@ -1222,7 +1232,7 @@ def test_the_browser_state_is_only_announced_when_it_changes():
         "const afterChange = writes;",
         "/* and the same state with a different reason is a change too */",
         "say('offline', 'reconnecting');",
-        "process.stdout.write(JSON.stringify({steady, afterChange,",
+        "process.stdout.write(JSON.stringify({normalised, steady, afterChange,",
         "                                     afterReason: writes}));",
     ]
 
@@ -1232,14 +1242,19 @@ def test_the_browser_state_is_only_announced_when_it_changes():
     assert done.returncode == 0, done.stderr
     got = json.loads(done.stdout)
 
-    assert got["steady"] == 1, (
+    assert got["normalised"] == 1, (
+        "the first call is swallowed because the markup already declares that "
+        "state, so the page is never normalised: the word IDLE stays in bright "
+        "capitals in the corner of an empty room, which is what this guard "
+        "shipped with for one commit")
+    assert got["steady"] == 2, (
         "a hundred passes of an unchanged browser wrote the live region %d "
         "times, which a screen reader reads out %d times"
-        % (got["steady"], got["steady"]))
-    assert got["afterChange"] == 2, (
+        % (got["steady"] - 1, got["steady"] - 1))
+    assert got["afterChange"] == 3, (
         "the guard swallowed a real change, which is the one thing it must "
         "never do: %r" % (got,))
-    assert got["afterReason"] == 3, (
+    assert got["afterReason"] == 4, (
         "the same state with a different reason was swallowed, so the word "
         "explaining WHY it went offline never arrives: %r" % (got,))
 
@@ -1326,3 +1341,76 @@ def test_clearing_the_conversation_leaves_the_page_able_to_explain_itself():
         "clearing the conversation leaves a pane with nothing in it, on a "
         "product whose whole first-run explanation was what it just deleted: "
         "%r" % (got["left"],))
+
+
+def test_pressing_stop_when_nothing_is_running_says_so():
+    """⛔ THE PANIC BUTTON ANSWERED `stopped:false` AND THE PAGE SAID NOTHING.
+
+    The server replies that there was nothing to stop whenever the page's idea
+    of the run is stale: a restarted server, a second tab that already stopped
+    it, a few seconds of lag. The press did nothing, said nothing, and left the
+    button offering to stop a run that had already ended - so the only reading
+    available to the person is that the product ignores its own stop.
+
+    And there was one request written twice, here and on the key, with the same
+    failure sentence: the half added to either one reached whichever path the
+    reader happened to be looking at. The key presses the button now.
+
+    `busyNow` is deliberately not written by this path. The event stream is its
+    one writer, and a second writer is how two places start disagreeing about
+    whether the agent is working.
+
+    Known-bad, three: stop reading the body; write the sentence for a successful
+    stop as well, which turns the ordinary case into noise; give the key its own
+    copy of the request again.
+    """
+    import json
+    import shutil
+    import subprocess
+
+    import pytest
+
+    #: one request, one sentence about it failing.
+    assert CODE.count("'/chat/stop'") == 1, (
+        "the stop is written %d times, so the next thing added to it reaches "
+        "one path and not the other" % CODE.count("'/chat/stop'"))
+
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("needs node to EXECUTE the stop")
+
+    src = CODE[CODE.index("halt.onclick = async"):]
+    src = src[:src.index("};") + 2]
+
+    harness = [
+        "let said = [];",
+        "globalThis.orphan = (kind, text) => said.push(kind + ': ' + text);",
+        "globalThis.halt = {};",
+        "globalThis.answer = {stopped: false};",
+        "globalThis.ask = async () => ({json: async () => answer});",
+        "HERE",
+        "(async () => {",
+        "  await halt.onclick();",
+        "  const nothing = said.slice();",
+        "  said = []; answer = {stopped: true};",
+        "  await halt.onclick();",
+        "  process.stdout.write(JSON.stringify({nothing, ordinary: said}));",
+        "})();",
+    ]
+    js = chr(10).join(harness).replace("HERE", src)
+
+    done = subprocess.run([node, "-e", js], capture_output=True, text=True,
+                          encoding="utf-8", timeout=30)
+    assert done.returncode == 0, done.stderr
+    got = json.loads(done.stdout)
+
+    assert len(got["nothing"]) == 1 and "nothing running to stop" in got["nothing"][0], (
+        "pressing stop on a run that had already ended says nothing at all, so "
+        "the press is indistinguishable from one that never arrived: %r"
+        % (got["nothing"],))
+    assert not got["nothing"][0].startswith("err"), (
+        "a stale page is reported to the person as an error, which is the same "
+        "defect as calling their own Stop a failure: %r" % (got["nothing"],))
+    assert got["ordinary"] == [], (
+        "an ordinary stop writes a line into the transcript, which is noise on "
+        "the path that works: %r" % (got["ordinary"],))

--- a/tests/test_the_page_tells_the_truth.py
+++ b/tests/test_the_page_tells_the_truth.py
@@ -968,3 +968,190 @@ def test_the_sessions_panel_puts_the_page_behind_it_out_of_play():
         "closing the panel released a hold it never took: a conversation "
         "deleted elsewhere had the browser pane out of play, and this brought "
         "it back fully lit on a page where nothing is live")
+
+
+def test_a_step_nobody_landed_stops_claiming_to_be_running():
+    """⛔ PRESS STOP WITH A CLICK IN FLIGHT AND THAT ROW BREATHED FOR EVER.
+
+    No result ever arrives for a step that was cancelled, and `land` is the only
+    thing that settles a row, so it kept `data-state="run"` - the breathing dot,
+    the present-tense verb - for the life of the page. A line in a log asserting
+    that something is happening, hours after it stopped.
+
+    The same pass found the other half: a row that FAILED was marked by colour
+    alone, `--err` mixed at 8% against the row, which is 1.12:1, and it carried
+    the same present-tense verb as a row still in flight. Scrolling back through
+    a ten minute run to find what went wrong, there was nothing to look for.
+
+    So the outcome is a word, and the past tense is kept for the one case that
+    earned it. Executed through the dispatcher, because the fact under test is
+    that the END OF A TURN settles a step nobody landed - a unit test of `close`
+    could not see a caller that never calls it.
+
+    Known-bad, three: drop the `if(live) close(...)` from the `busy 0` branch,
+    and the row stays in the running state; give a failed or stopped step the
+    past tense, and the log asserts the thing happened; drop the word and the
+    outcome is a tint again.
+    """
+    import json
+    import shutil
+    import subprocess
+
+    import pytest
+
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("needs node to EXECUTE the dispatcher")
+
+    def whole(start, end):
+        src = CODE[CODE.index(start):]
+        return src[:src.index(end) + len(end)]
+
+    harness = [
+        "globalThis.VERB = {browser_click: ['Clicking', 'Clicked']};",
+        "globalThis.el = (tag, cls, t) => ({tag, cls, t});",
+        "const made = () => {",
+        "  const lab = {b:{textContent:'Clicking'}, words:[],",
+        "    /* only the outcome word: `land` also appends the inline result */",
+        "    append(...xs){ for (const x of xs)",
+        "      if (x && x.cls === 'mark') this.words.push(x.t); }};",
+        "  const row = {querySelector: s => s === '.lab b' ? lab.b : lab,",
+        "               lastElementChild:{textContent:''}};",
+        "  return {dataset:{name:'browser_click', state:'run'},",
+        "          firstElementChild: row, appendChild(){}, lab};",
+        "};",
+        "globalThis.timer = 0; globalThis.t0 = 0; globalThis.turn = null;",
+        "globalThis.queued = null; globalThis.LONG = 48;",
+        "globalThis.busyNow = true;",
+        "for (const name of ['clearInterval','flush','waiting','waited','put',",
+        "                    'drawChats','paint','settleOnce','newTurn','step',",
+        "                    'orphan','setQueued','send','rich'])",
+        "  globalThis[name] = () => {};",
+        "globalThis.performance = {now: () => 0};",
+        "globalThis.dur = () => '0ms';",
+        "",
+        "/* a turn that ends with a step still open: Stop, or a run that died */",
+        "const open = made(); globalThis.live = open;",
+        "onEvent({data: JSON.stringify({kind:'busy', text:'0'})});",
+        "const stopped = {state: open.dataset.state,",
+        "                 verb: open.lab.b.textContent, words: open.lab.words};",
+        "",
+        "/* and a step the server refused */",
+        "const bad = made(); globalThis.live = bad;",
+        "land('err', 'timeout', false);",
+        "const failed = {state: bad.dataset.state,",
+        "                verb: bad.lab.b.textContent, words: bad.lab.words};",
+        "",
+        "/* and one that actually worked */",
+        "const good = made(); globalThis.live = good;",
+        "land('result', 'ok', false);",
+        "const worked = {state: good.dataset.state,",
+        "                verb: good.lab.b.textContent, words: good.lab.words};",
+        "process.stdout.write(JSON.stringify({stopped, failed, worked}));",
+    ]
+
+    js = (whole("function close(", chr(10) + "}") + chr(10)
+          + whole("function land(", chr(10) + "}") + chr(10)
+          + whole("const onEvent =", chr(10) + "};") + chr(10)
+          + chr(10).join(harness))
+    done = subprocess.run([node, "-e", js], capture_output=True, text=True,
+                          encoding="utf-8", timeout=30)
+    assert done.returncode == 0, done.stderr
+    got = json.loads(done.stdout)
+
+    assert got["stopped"]["state"] == "off", (
+        "the end of a turn leaves a step in the running state, so its dot goes "
+        "on breathing for the life of the page: %r" % (got["stopped"],))
+    assert got["stopped"]["verb"] == "Clicking", (
+        "a step that never finished is written in the past tense, which asserts "
+        "the thing happened: %r" % (got["stopped"],))
+    assert "stopped" in got["stopped"]["words"], (
+        "nothing but a colour says the step did not finish: %r"
+        % (got["stopped"],))
+
+    assert got["failed"]["state"] == "err" and got["failed"]["verb"] == "Clicking", (
+        "a failed step is written as though it had happened: %r" % (got["failed"],))
+    assert "failed" in got["failed"]["words"], (
+        "a failed step is marked by colour only, at 1.12:1, and reads with the "
+        "same verb as a step still running: %r" % (got["failed"],))
+
+    assert got["worked"]["state"] == "ok" and got["worked"]["verb"] == "Clicked", (
+        "a step that worked lost its past tense: %r" % (got["worked"],))
+    assert got["worked"]["words"] == [], (
+        "an ordinary result is annotated with an outcome word, which is noise "
+        "on the rows that make up most of a run: %r" % (got["worked"],))
+
+
+def test_the_queued_sentence_is_on_screen_and_survives_a_click():
+    """⛔ A SECOND ENTER DESTROYED THE FIRST SENTENCE, SILENTLY.
+
+    The chip read `1 message queued` - a literal in the markup - so the words
+    waiting to be sent were never drawn anywhere. Type a follow-up while the
+    agent works, think of a better wording, press Enter: the first one is gone,
+    with nothing on screen that ever showed it and no way back.
+
+    The same control destroyed work in the other direction. Clicking the chip to
+    see what was queued assigned over the composer, so a draft in the box was
+    overwritten by the queued text - from the one control whose whole purpose is
+    to give typed words back.
+
+    Executed, because both facts are about what `paint` and the click handler
+    DO: a scan can see the literal leave the markup and cannot see what replaces
+    it, which is how the string ended up in two places to begin with.
+
+    Known-bad, two: leave the count in the markup and do not write the sentence;
+    assign over `i.value` again and the draft is eaten.
+    """
+    import json
+    import shutil
+    import subprocess
+
+    import pytest
+
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("needs node to EXECUTE the composer")
+
+    paint = CODE[CODE.index("function paint(){"):]
+    paint = paint[:paint.index(chr(10) + "}") + 2]
+    click = CODE[CODE.index("chip.onclick = "):]
+    click = click[:click.index("; };") + 4]
+
+    harness = [
+        "const what = {textContent: ''};",
+        "globalThis.chip = {hidden: true, querySelector: () => what,",
+        "                   focus(){}};",
+        "globalThis.i = {value: '', placeholder: '',",
+        "                dispatchEvent(){}, focus(){}};",
+        "globalThis.go = {disabled:false, setAttribute(){}};",
+        "globalThis.halt = {hidden:true}; globalThis.fresh = {disabled:false};",
+        "globalThis.Event = function(){};",
+        "globalThis.queued = 'go to the second page and read the heading';",
+        "globalThis.busyNow = true;",
+        "globalThis.setQueued = (v) => { globalThis.queued = v; };",
+        "paint();",
+        "const shown = what.textContent;",
+        "/* a draft in the box, and the chip pressed to look at what is queued */",
+        "i.value = 'and stop before sending anything';",
+        "chip.onclick();",
+        "process.stdout.write(JSON.stringify({shown, box: i.value}));",
+    ]
+
+    #: the stubs first, then the code that binds to them, then the actions:
+    #: `chip.onclick = ...` runs the moment the script is evaluated.
+    at = harness.index("paint();")
+    js = (chr(10).join(harness[:at]) + chr(10) + paint + chr(10) + click
+          + chr(10) + chr(10).join(harness[at:]))
+    done = subprocess.run([node, "-e", js], capture_output=True, text=True,
+                          encoding="utf-8", timeout=30)
+    assert done.returncode == 0, done.stderr
+    got = json.loads(done.stdout)
+
+    assert got["shown"] == "go to the second page and read the heading", (
+        "the chip does not show the sentence it is holding, so replacing it is "
+        "invisible and what was lost cannot even be read: %r" % (got["shown"],))
+    assert "and stop before sending anything" in got["box"], (
+        "clicking the chip ate the draft in the box: %r" % (got["box"],))
+    assert "go to the second page" in got["box"], (
+        "clicking the chip did not give the queued sentence back: %r"
+        % (got["box"],))

--- a/tests/test_the_page_tells_the_truth.py
+++ b/tests/test_the_page_tells_the_truth.py
@@ -1028,6 +1028,9 @@ def test_a_step_nobody_landed_stops_claiming_to_be_running():
         "globalThis.el = (tag, cls, t) => ({tag, cls, t});",
         "const made = () => {",
         "  const lab = {b:{textContent:'Clicking'}, words:[],",
+        "    /* the row's own label, which `echoes` reads to decide whether the",
+        "       inline result says anything new */",
+        "    querySelector(sel){ return sel === 'b' ? this.b : null; },",
         "    /* only the outcome word: `land` also appends the inline result */",
         "    append(...xs){ for (const x of xs)",
         "      if (x && x.cls === 'mark') this.words.push(x.t); }};",
@@ -1067,7 +1070,8 @@ def test_a_step_nobody_landed_stops_claiming_to_be_running():
         "process.stdout.write(JSON.stringify({stopped, failed, worked}));",
     ]
 
-    js = (whole("function close(", chr(10) + "}") + chr(10)
+    js = (whole("function echoes(", chr(10) + "}") + chr(10)
+          + whole("function close(", chr(10) + "}") + chr(10)
           + whole("function land(", chr(10) + "}") + chr(10)
           + whole("const onEvent =", chr(10) + "};") + chr(10)
           + chr(10).join(harness))

--- a/tests/test_the_page_tells_the_truth.py
+++ b/tests/test_the_page_tells_the_truth.py
@@ -1429,3 +1429,73 @@ def test_pressing_stop_when_nothing_is_running_says_so():
     assert got["ordinary"] == [], (
         "an ordinary stop writes a line into the transcript, which is noise on "
         "the path that works: %r" % (got["ordinary"],))
+
+
+def test_a_result_that_only_repeats_the_row_is_not_drawn_twice():
+    """⛔ THE MOST FREQUENT LINE IN THE PRODUCT SAID THE SAME WORDS TWICE. A
+    click answers `clicked <target>` and the row already reads `Clicked
+    <target>`, so a run of eighteen clicks was eighteen rows of the same four
+    words repeated across the line - in the owner's own screenshot, `clicked
+    [aria-label='continue']` twice on one row. An echo is not information, and
+    the owner had already asked for the noise to go.
+
+    Executed through `land`, because the decision reads the settled row - the
+    past-tense verb the row now carries and the target beside it - and a scan
+    cannot see what a row says after it has been settled.
+
+    Known-bad, two: drop the guard and the echo is back; compare against the
+    tool name instead of the row and a result that adds a status is hidden too.
+    """
+    import json
+    import shutil
+    import subprocess
+
+    import pytest
+
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("needs node to EXECUTE land")
+
+    def whole(start, end):
+        src = CODE[CODE.index(start):]
+        return src[:src.index(end) + len(end)]
+
+    harness = [
+        "globalThis.VERB = {browser_click: ['Clicking','Clicked'],",
+        "                   browser_navigate: ['Navigating','Navigated']};",
+        "globalThis.el = (tag, cls, t) => ({tag, cls, t});",
+        "const made = (name, target) => {",
+        "  const lab = {b:{textContent:''}, code:{textContent: target}, shown:[],",
+        "    querySelector(sel){ return sel === 'b' ? this.b : sel === 'code' ? this.code : null; },",
+        "    append(...xs){ for (const x of xs) if (x && x.cls === 'inline') this.shown.push(x.t); }};",
+        "  const row = {querySelector: s => s === '.lab b' ? lab.b : lab,",
+        "               tabIndex: 0, lastElementChild:{textContent:''}};",
+        "  return {dataset:{name, state:'run'}, firstElementChild: row, appendChild(){}, lab};",
+        "};",
+        "globalThis.timer = 0; globalThis.t0 = 0; globalThis.LONG = 48;",
+        "for (const name of ['clearInterval','orphan']) globalThis[name] = () => {};",
+        "globalThis.performance = {now: () => 0}; globalThis.dur = () => '0ms';",
+        "const out = {};",
+        "let d = made('browser_click', 'a:nth-of-type(1)'); globalThis.live = d;",
+        "land('result', 'clicked a:nth-of-type(1)', false); out.echo = d.lab.shown;",
+        "d = made('browser_click', '#buy'); globalThis.live = d;",
+        "land('result', 'Clicked #buy.', false); out.echoDressed = d.lab.shown;",
+        "d = made('browser_navigate', 'https://x'); globalThis.live = d;",
+        "land('result', 'navigated to https://x/ (HTTP 200)', false); out.news = d.lab.shown;",
+        "process.stdout.write(JSON.stringify(out));",
+    ]
+    js = (whole("function echoes(", chr(10) + "}") + chr(10)
+          + whole("function close(", chr(10) + "}") + chr(10)
+          + whole("function land(", chr(10) + "}") + chr(10)
+          + chr(10).join(harness))
+    done = subprocess.run([node, "-e", js], capture_output=True, text=True,
+                          encoding="utf-8", timeout=30)
+    assert done.returncode == 0, done.stderr
+    got = json.loads(done.stdout)
+
+    assert got["echo"] == [] and got["echoDressed"] == [], (
+        "a result that only repeats the row is drawn beside it, so the most "
+        "frequent line in the product says the same words twice: %r" % (got,))
+    assert got["news"] == ["navigated to https://x/ (HTTP 200)"], (
+        "a result that says more than the row - here a status - was hidden: %r"
+        % (got,))

--- a/tests/test_the_session_column.py
+++ b/tests/test_the_session_column.py
@@ -860,3 +860,36 @@ def test_the_only_way_into_the_sessions_is_visible_when_the_keyboard_reaches_it(
         "the focus ring on the sessions button is not drawn inside it: %s"
         % " ".join(rule.group(1).split()))
 
+
+def test_the_top_row_is_one_line_across_the_whole_app():
+    """⛔ THE ICON SAT 4.5px ABOVE THE LINE EVERYTHING ELSE SHARES. The drawer
+    title, the model chip and the address bar all centre on the same pixel; the
+    one control on the spine was pushed down by an 11px top padding and landed
+    just off it. Nobody names that miss and everybody reads it as unfinished,
+    and it is on the app's most visible seam. Measured after the fix in a real
+    browser at 1440px: icon, chip and title all on 27.5.
+
+    Centred by a grid row exactly one header tall, NOT by a margin computed from
+    the icon's size: that size is declared in the markup, and a rule that
+    repeated it here would let a redrawn icon un-centre itself silently while
+    both files still looked right.
+
+    Known-bad, two: put a top padding back on the strip; centre it with a margin
+    that names the icon's height.
+    """
+    import re
+
+    css = re.sub(r"/\*.*?\*/", "",
+                 PAGE[PAGE.index("<style>"):PAGE.index("</style>")], flags=re.S)
+    rule = css[css.index("#railtab{"):]
+    rule = " ".join(rule[:rule.index("}")].split())
+    assert "grid-template-rows:calc(var(--topbar)" in rule.replace(" ", ""), (
+        "the strip no longer centres its icon in a row one header tall: %s" % rule)
+    assert not re.search(r"(padding|margin)[^;]*[1-9]", rule), (
+        "the icon is positioned by a number again, so it is centred until "
+        "somebody changes the header or the icon: %s" % rule)
+    assert "24" not in rule, (
+        "the icon's drawn size is repeated in the stylesheet, so the markup and "
+        "this rule now both know it and only one of them will be updated: %s"
+        % rule)
+

--- a/tests/test_the_session_column.py
+++ b/tests/test_the_session_column.py
@@ -829,3 +829,34 @@ def test_the_panel_closes_the_three_ways_a_person_tries():
         "theSpineStillCloses": True,
     }, ("the panel cannot be dismissed the way a person expects, or it swallows "
         "a key that is not its own: %r" % (got,))
+
+
+def test_the_only_way_into_the_sessions_is_visible_when_the_keyboard_reaches_it():
+    """⛔ ITS FOCUS RING WAS CLIPPED ON THREE SIDES AND THE SLIVER LEFT WAS THE
+    COLOUR OF THE LINE ALREADY THERE.
+
+    The strip is flush with the window on the left, the top and the bottom, so
+    the page's focus outline was drawn outside the viewport on all three: the
+    only visible segment was a 2px amber line about 2.5px from the permanent
+    amber hairline the strip already carries. Two similar marks side by side, on
+    the single keyboard route into the whole sessions feature.
+
+    An element-local exception to a global rule, which is the one kind of
+    exception worth having: the offset goes negative so the ring is drawn
+    INSIDE the strip, where there is room for it.
+
+    Known-bad: drop the offset and the ring goes back outside the window.
+    """
+    import re
+
+    css = re.sub(r"/\*.*?\*/", "",
+                 PAGE[PAGE.index("<style>"):PAGE.index("</style>")], flags=re.S)
+    rule = re.search(r"#railtab:focus-visible\{([^}]*)\}", css)
+    assert rule, (
+        "nothing pulls the focus ring inside the strip, so it is drawn outside "
+        "the window on three sides and what is left is a line beside a line")
+    offset = re.search(r"outline-offset:\s*(-?[\d.]+)px", rule.group(1))
+    assert offset and float(offset.group(1)) < 0, (
+        "the focus ring on the sessions button is not drawn inside it: %s"
+        % " ".join(rule.group(1).split()))
+

--- a/tests/test_the_session_column.py
+++ b/tests/test_the_session_column.py
@@ -684,3 +684,148 @@ def test_the_spine_is_part_of_the_frame_and_is_the_only_way_in():
     assert not hidden, (
         "%d rule(s) hide the sessions column or the only way into it: %s"
         % (len(hidden), hidden))
+
+
+def test_a_long_name_ends_in_an_ellipsis_instead_of_stopping_mid_word():
+    """⛔ THE RULE ASKED FOR THE ELLIPSIS AND THE DISPLAY MODE SWITCHED IT OFF.
+
+    `text-overflow` does nothing on a flex container: the text inside becomes an
+    anonymous flex item, and there is no line box for the ellipsis to hang off
+    the end of. So `.chat .nm` declared `text-overflow:ellipsis` next to
+    `display:flex` and a name that did not fit was simply cut through, mid-word,
+    with no mark. Measured on the running page 2026-09-12: a name overflowing
+    its box by 10px, `text-overflow` computing to `ellipsis` and doing nothing.
+    On screen it does not read as a long name, it reads as a broken row.
+
+    The gate is on the CLASS and not on the one selector, which is what this
+    project does with defects it has seen once: any rule that asks for the
+    ellipsis while laying its contents out as flex is the same mistake wearing a
+    different name.
+
+    Known-bad: put `display:flex` back into `.chat .nm`.
+    """
+    import re
+
+    css = re.sub(r"/\*.*?\*/", "",
+                 PAGE[PAGE.index("<style>"):PAGE.index("</style>")], flags=re.S)
+    both = []
+    for sel, decl in re.findall(r"([^{}]+)\{([^{}]*)\}", css):
+        flat = decl.replace(" ", "")
+        if "text-overflow:ellipsis" in flat and re.search(r"display:(inline-)?flex",
+                                                          flat):
+            both.append(sel.strip())
+    assert not both, (
+        "%d rule(s) ask for an ellipsis and lay their contents out as flex, "
+        "which switches it off - the text is cut mid-word instead: %s"
+        % (len(both), both))
+
+    #: and the rule that needs one still asks for it
+    nm = css[css.index(".chat .nm{"):]
+    assert "text-overflow:ellipsis" in nm[:nm.index("}")].replace(" ", ""), (
+        "the name in a session row no longer asks for an ellipsis at all")
+
+
+def test_the_panel_closes_the_three_ways_a_person_tries():
+    """⛔ IT COULD ONLY BE CLOSED BY THE 48px ICON THAT OPENED IT, and the key
+    everybody presses to dismiss an overlay STOPPED THE AGENT instead.
+
+    Measured on the running page 2026-09-12: Escape left the panel open and
+    reached the composer's handler, a click on the conversation behind it did
+    nothing, and choosing a conversation carried the panel across the navigation
+    so the page you had just asked for arrived already covered.
+
+    That is what made covering unacceptable rather than merely bold. A panel
+    that lies over the page and puts it out of play has to be one gesture away
+    from gone, and there are three gestures: the key, the click outside, and
+    picking the thing you opened it for.
+
+    Executed, because none of it can be read off the text: the handlers are
+    registered in capture on `document`, and what matters is the ORDER they run
+    in and which events they swallow. Escape while the panel is CLOSED must not
+    be swallowed - that key belongs to the composer, where it stops a run.
+
+    The spine case is the subtle one. `pointerdown` and `click` both fire on a
+    real press, so without the second guard the panel closes on the press and
+    the button's own handler reopens it on the click: the one control that opens
+    it could never close it.
+
+    Known-bad, four, all run: drop the `stopPropagation`, drop the `hidden`
+    check so a closed panel swallows Escape, drop the `railtab` guard in the
+    pointer handler, drop the `showRail(false)` on choosing a conversation.
+    """
+    import json
+    import re
+    import shutil
+    import subprocess
+
+    import pytest
+
+    node = shutil.which("node")
+    if not node:
+        pytest.skip("needs node to EXECUTE the handlers rather than read them")
+
+    code = re.sub(r"/\*.*?\*/|<!--.*?-->", "", PAGE, flags=re.S)
+    owner = code[code.index("const heldBy = new WeakMap();"):]
+    owner = owner[:owner.index(chr(10) + "}") + 2]
+    panel = code[code.index("const RAILKEY"):]
+    panel = panel[:panel.index("async function renameChat(")]
+
+    harness = [
+        "const made = {};",
+        "const box = id => (made[id] = {id, hidden:false, inert:false,",
+        "  attrs:{}, kids:[],",
+        "  setAttribute(k, v){ this.attrs[k] = v; },",
+        "  getAttribute(k){ return this.attrs[k]; },",
+        "  contains(n){ return n === this || this.kids.indexOf(n) >= 0; },",
+        "  focus(){ globalThis.document.activeElement = this; }});",
+        "['rail','railtab','left','right','newchat','chats','f','railsay']",
+        "  .forEach(box);",
+        "made.rail.kids = [made.newchat, made.chats, made.railsay];",
+        "made.left.kids = [made.f];",
+        "globalThis.$ = id => made[id];",
+        "globalThis.document = {activeElement: made.railtab};",
+        "globalThis.drawChats = () => {};",
+        "globalThis.localStorage = {seen:{},",
+        "  setItem(k, v){ this.seen[k] = v; }, getItem(k){ return this.seen[k]; }};",
+        "const heard = [];",
+        "globalThis.addEventListener = (type, fn) => heard.push({type, fn});",
+        "HERE",
+        "let swallowed = 0;",
+        "const esc = () => ({key:'Escape', stopPropagation(){ swallowed++; }});",
+        "const fire = (type, ev) => { for(const l of heard)",
+        "                               if(l.type === type) l.fn(ev); };",
+        "const press = () => made.railtab.onclick();",
+        "const out = {closedOnLoad: made.rail.hidden};",
+        "fire('keydown', esc());",
+        "out.leavesEscapeAloneWhenClosed = swallowed === 0;",
+        "press(); out.opens = !made.rail.hidden;",
+        "fire('keydown', esc());",
+        "out.escapeCloses = made.rail.hidden;",
+        "out.swallowedWhileOpen = swallowed === 1;",
+        "press(); fire('pointerdown', {target: made.f});",
+        "out.aPressOutsideCloses = made.rail.hidden;",
+        "press(); fire('pointerdown', {target: made.newchat});",
+        "out.aPressInsideDoesNot = !made.rail.hidden;",
+        "/* a real press on the spine: pointerdown, then the button's own click */",
+        "fire('pointerdown', {target: made.railtab}); press();",
+        "out.theSpineStillCloses = made.rail.hidden;",
+        "process.stdout.write(JSON.stringify(out));",
+    ]
+    js = chr(10).join(harness).replace("HERE", owner + chr(10) + panel)
+
+    done = subprocess.run([node, "-e", js], capture_output=True, text=True,
+                          encoding="utf-8", timeout=30)
+    assert done.returncode == 0, done.stderr
+    got = json.loads(done.stdout)
+
+    assert got == {
+        "closedOnLoad": True,
+        "leavesEscapeAloneWhenClosed": True,
+        "opens": True,
+        "escapeCloses": True,
+        "swallowedWhileOpen": True,
+        "aPressOutsideCloses": True,
+        "aPressInsideDoesNot": True,
+        "theSpineStillCloses": True,
+    }, ("the panel cannot be dismissed the way a person expects, or it swallows "
+        "a key that is not its own: %r" % (got,))

--- a/tests/test_the_split_between_the_panes.py
+++ b/tests/test_the_split_between_the_panes.py
@@ -214,7 +214,7 @@ def test_the_numbers_the_split_is_made_of_live_in_one_place():
     """
     body = PAGE[PAGE.index(FIRST):PAGE.index(LAST)]
     code = re.sub(r"/\*.*?\*/", "", body, flags=re.S)
-    typed = re.findall(r"(4[0-9]{2}|530|9)", code)
+    typed = re.findall(r"\b(4[0-9]{2}|530|9)\b", code)
     assert not typed, (
         "the drag code types the layout's numbers again instead of reading "
         "them, so the stylesheet and the control can disagree: %s" % typed)

--- a/tests/test_the_split_between_the_panes.py
+++ b/tests/test_the_split_between_the_panes.py
@@ -16,6 +16,7 @@ that compute it are lifted out and run, the same way the renderer is.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 
@@ -43,13 +44,34 @@ const LEFT = {
 const SPLIT = {attrs: {}, setAttribute(k, v){ this.attrs[k] = v; }};
 const $ = id => (id === 'left' ? LEFT : SPLIT);
 const window = {innerWidth: 1920};
+/* ⛔ THE LIMITS COME FROM THE STYLESHEET NOW, so the harness has to serve
+   them: the floor, the picture's minimum, and the two strips that sit OUTSIDE
+   the split. That is the whole point of what is being tested - the ceiling
+   used to subtract the picture's minimum from the WHOLE window and promise
+   57px it could not give - and a shim inventing its own numbers would be
+   testing the shim. They are read from the page's own token block. */
+const document = {documentElement: {}};
+const TOKENS = %s;
+const getComputedStyle = () => ({getPropertyValue: n => TOKENS[n] || ''});
 """
+
+
+#: One reader for the numbers, used by the shim and by the arithmetic in the
+#: assertions: a gate that retypes them is a second place to be wrong.
+def PX(name):
+    return float(re.search(name + r":\s*([\d.]+)px", PAGE).group(1))
+
+
+#: The four numbers the split is made of, read from the page that declares
+#: them rather than repeated here, which is the defect this change removes.
+TOKENS = {name: re.search(name + r":\s*([\d.]+px)", PAGE).group(1)
+          for name in ("--pane-min", "--stage-min", "--spine", "--split")}
 
 
 def clamp(asked, width=1920, remember=True):
     """What the page would set the conversation to, asked for `asked` pixels."""
     body = PAGE[PAGE.index(FIRST):PAGE.index(LAST)]
-    js = (SHIM + body
+    js = ((SHIM % json.dumps(TOKENS)) + body
           + "\nwindow.innerWidth = %d;" % width
           + "\nsplitTo(%s, %s);" % (json.dumps(asked), "true" if remember else "false")
           + "\nprocess.stdout.write(JSON.stringify({width: LEFT.style.width,"
@@ -84,10 +106,20 @@ def test_the_browser_pane_cannot_be_dragged_to_nothing_either():
     whole window leaves no picture at all, and the page still parses, the
     handler still exists, and nothing is red anywhere.
 
-    Known-bad: drop the `Math.min(max, ...)`.
+    ⛔ AND THE CEILING WAS 57px OPTIMISTIC, which is what these numbers used
+    to encode: they subtracted the picture's minimum from the WHOLE window,
+    while the spine and the separator sit outside the split. Dragged to the
+    end the browser pane got 423px where the control announced 480, and the
+    separator reported a ceiling it could not reach. The arithmetic here is
+    built from the same tokens the page reads, so it cannot drift from it
+    again.
+
+    Known-bad, two: drop the `Math.min(max, ...)`; compute the ceiling from
+    the window without taking off the two strips beside the split.
     """
-    assert clamp(5000)["px"] == 1920 - 480
-    assert clamp(1900)["px"] == 1440
+    room = lambda w: w - PX("--stage-min") - PX("--spine") - PX("--split")
+    assert clamp(5000)["px"] == room(1920)
+    assert clamp(1900)["px"] == room(1920)
 
 
 def test_a_width_saved_on_a_big_monitor_is_clamped_on_a_laptop():
@@ -96,8 +128,10 @@ def test_a_width_saved_on_a_big_monitor_is_clamped_on_a_laptop():
 
     Known-bad: compute `max` from a constant.
     """
-    assert clamp(1440, width=1280)["px"] == 1280 - 480
-    assert clamp(1440, width=1920)["px"] == 1440
+    room = lambda w: w - PX("--stage-min") - PX("--spine") - PX("--split")
+    assert clamp(1440, width=1280)["px"] == room(1280)
+    #: the same number on a wide window is inside the range, so it survives
+    assert clamp(1200, width=1920)["px"] == 1200
 
 
 def test_the_floor_wins_when_the_window_is_too_small_for_both():
@@ -125,7 +159,10 @@ def test_the_separator_says_what_it_is_and_where_it_is():
     assert 'role="separator"' in PAGE
     assert 'aria-orientation="vertical"' in PAGE
     assert 'tabindex="0"' in PAGE
-    assert clamp(700)["attrs"]["aria-valuemax"] == "1440"
+    #: announced from the same arithmetic the control obeys, or the range a
+    #: screen reader reads out is a range the drag will not honour
+    assert clamp(700)["attrs"]["aria-valuemax"] == str(int(
+        1920 - PX("--stage-min") - PX("--spine") - PX("--split")))
     assert "ArrowLeft" in PAGE and "ArrowRight" in PAGE, (
         "the arrow keys do not move it, so it can only be dragged")
 
@@ -156,3 +193,33 @@ def test_pressing_the_separator_leaves_it_focused():
             "the pointerdown handler cancels the default action, which is what "
             "focuses the element, and never focuses it itself: the separator "
             "can be dragged and then not moved with the arrow keys")
+
+
+def test_the_numbers_the_split_is_made_of_live_in_one_place():
+    """⛔ THE SAME FOUR NUMBERS WERE WRITTEN IN FIVE PLACES AND ONE OF THEM
+    WAS WRONG. 420 was in the pane's clamp, in the drag code and in the
+    markup's `aria-valuemin`; 9 was in the separator's rule and again in the
+    ceiling that forgot it; 480 was in the drag code only, subtracted from the
+    whole window rather than from the room the two panes share - so the
+    control announced a ceiling 57px above the one it would honour, and the
+    browser pane bottomed out at 423px where it promised 480.
+
+    Tokens, read by the stylesheet and by the code and announced from the same
+    read. What this holds is the property, not the values: no pixel literal in
+    the drag code, and the floor a screen reader is told matches the floor the
+    drag obeys.
+
+    Known-bad, two: type a number back into the drag code; announce a floor
+    from anywhere but the same read.
+    """
+    body = PAGE[PAGE.index(FIRST):PAGE.index(LAST)]
+    code = re.sub(r"/\*.*?\*/", "", body, flags=re.S)
+    typed = re.findall(r"(4[0-9]{2}|530|9)", code)
+    assert not typed, (
+        "the drag code types the layout's numbers again instead of reading "
+        "them, so the stylesheet and the control can disagree: %s" % typed)
+
+    got = clamp(700)["attrs"]
+    assert got["aria-valuemin"] == str(int(PX("--pane-min"))), (
+        "the floor announced to a screen reader is not the floor the drag "
+        "obeys: %r" % (got,))

--- a/tests/test_the_stage_of_screens.py
+++ b/tests/test_the_stage_of_screens.py
@@ -191,15 +191,42 @@ def test_the_template_follows_the_screens_that_exist():
 def test_the_state_word_says_nothing_when_it_would_repeat_the_tab():
     """The Live/Frozen tabs are a control that shows its own state, and the word
     beside them said `live` while Live was selected: one fact printed twice, the
-    second time in the place the eye goes for news. `idle`, `busy` and `error`
+    second time in the place the eye goes for news. `busy`, `offline` and `error`
     are news and still appear, and the dot goes on carrying live and frozen,
     which is what a dot is for.
 
-    Known-bad: print every state, which is what it did.
+    ⛔ `idle` JOINED THE QUIET THREE, AND IT WAS ALREADY QUIET THE WRONG WAY.
+    A rule in the browser stylesheet clipped the WHOLE state box to one pixel
+    whenever the pane was empty, which is right for `idle` - capitals, the
+    brightest thing on a bar describing an empty room - and wrong for every
+    other word that box can hold. Drop the stream on a first run and `offline`
+    was written into a clipped box: a 7px dot changed colour and nobody got the
+    word. Two places decided whether a word is worth showing; the one that knows
+    WHICH word decides now, and the rule is gone.
+
+    Known-bad, two: print every state, which is what it did; or add `offline` or
+    `error` to this list, which hides the two words that exist to be read.
     """
     code = re.sub(r"/\*.*?\*/", "", PAGE, flags=re.S)
-    assert "stateEl.classList.toggle('sr', s === 'live' || s === 'frozen')" in code, (
-        "the state word is shown even when it only repeats the selected switch")
+    quiet = re.search(r"stateEl\.classList\.toggle\('sr',([^)]*)\)", code)
+    assert quiet, "nothing decides whether the state word is worth showing"
+    said = quiet.group(1)
+    assert set(re.findall(r"'([a-z]+)'", said)) == {"live", "frozen", "idle"}, (
+        "the states the word stays quiet for are %s: live and frozen repeat the "
+        "switch beside them and idle names an empty room, and anything else in "
+        "that list is a word somebody needs" % sorted(re.findall(r"'([a-z]+)'", said)))
+    # ⛔ AND THE MARKUP STARTS THE WAY `say` WOULD DRAW IT. Nothing calls
+    # `say('idle')` on a first load - the state only moves when a browser does -
+    # so with the clipping rule gone the word came back on screen in capitals,
+    # in the corner of an empty room. Found by opening the page after the rule
+    # was deleted, not by any assertion here.
+    state = re.search(r'<span id="state"[^>]*class="([^"]*)"', PAGE)
+    assert state and "sr" in state.group(1).split(), (
+        "the state box starts on screen carrying the one word that is never "
+        "worth showing: %s" % (state.group(1) if state else "no span"))
+    assert '#right[data-empty="1"] #state' not in code, (
+        "the empty room clips the state box again, so the word that says the "
+        "stream died lands in a box one pixel wide")
     # ⛔ AND IT GOES OFF-SCREEN, NOT AWAY. `hidden` is display:none, and a live
     # region mutated inside a display:none subtree announces nothing - so the one
     # transition that matters, live to error, was silent for a screen reader

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -339,8 +339,14 @@ async def test_the_stop_control_is_its_own_button_and_follows_the_run():
     assert "halt.hidden = !busyNow;" in page, \
         "the stop button is no longer tied to the run alone"
 
-    assert 'data-mode' not in page, \
-        "the send button has a mode again, which is how stop went missing before"
+    # The send button publishes a MODE again - send, queue, replace - and that
+    # is not the regression this line was written against: stop used to be one
+    # of those modes and vanished with it. What must hold is that stop is never
+    # among them, and that the dedicated button above still exists.
+    mode = page[page.index('const mode = '):]
+    mode = mode[:mode.index(';')]
+    assert 'stop' not in mode, \
+        'stop is a mode of the send button again, which is how it went missing before'
 
 
 async def test_the_live_view_never_causes_a_browser_to_start():

--- a/tests/test_web_service.py
+++ b/tests/test_web_service.py
@@ -219,8 +219,15 @@ async def test_stop_cancels_a_run_in_flight_and_says_so():
             kinds.append(await asyncio.wait_for(q.get(), 1))
         except asyncio.TimeoutError:
             break
-    texts = [e["text"] for e in kinds if e["kind"] == "err"]
-    assert texts == ["stopped"], f"expected one 'stopped', got {kinds}"
+    # ⛔ AND IT IS NOT AN ERROR, WHICH IS WHAT THIS USED TO ASSERT. The person
+    # pressed the button: a deliberate, correct action was answered with a red
+    # box, announced to a screen reader as "error stopped", and any step in
+    # flight was flipped to the failed state. A `note` draws as an ordinary
+    # line, and the gate keeps the half that matters - it is SAID, once.
+    assert not [e for e in kinds if e["kind"] == "err"], (
+        f"stopping is reported to the person as a failure: {kinds}")
+    texts = [e["text"] for e in kinds if e["kind"] == "note"]
+    assert texts == ["Stopped."], f"expected one 'Stopped.', got {kinds}"
     # and the lock is released, or the next instruction would hang forever
     assert not svc._busy.locked()
 


### PR DESCRIPTION
A UX pass over the interface, driven by an audit of six dimensions - spatial model, typography, interaction, accessibility, visual hierarchy, first run and failure states - with every finding verified against the code before it was acted on, and every change checked in a real browser afterwards.

**The owner's complaint first.** The sessions panel covered half the conversation and left it looking readable: measured 240px off the front of every line at every desktop width, 48% of the measure at 1440px, 61% at 960. It is a modal now - the page behind it goes inert and dims, Escape closes it, a click outside closes it, choosing a conversation closes it - and `inert` has one owner because two reasons can hold the same pane.

**The transcript stops saying things that are not true.** A step nobody landed breathed for ever; Stop was reported as an error; a failed step was marked by colour alone with the same verb as one still running; tool output was cut in silence for the watcher and the model; a dead stream left the clock counting; the queued sentence was never on screen and a second Enter destroyed it; the most frequent row said the same four words twice.

**Nobody is locked out by how they use it.** The live region was rewritten 25 times a second; a reconnect read the whole conversation aloud; the one input had no focus ring, then two; every finished step was a tab stop that opened nothing; screens and chips were named by their contents.

**Every control says what it does.** Enter looks different when it will queue; Clear explains itself instead of going dead; the first-run example fills the box; a failed load of the session list is told from an empty one; one rule says "cannot be used"; pressed is one rung above hovered; the panel's icon sits on the line everything else shares.

**Found only by screenshots**, and recorded as such: a comment inside a start tag that printed attributes down the seam between the panes; two backspace bytes that had blinded two gates; two nested focus rectangles on the composer. Each has a gate now, including one that reads the bytes of every tracked file and one that reads the served page with an HTML parser.

Measured and rejected, so nobody re-derives it: widening the conversation when the browser pane is empty (it already opens at 70 characters a line), and centring the two panes (ragged bands at both edges).

579 passed. Fifty-one known-bad mutations run against the new and rewritten gates, fifty-one killed. One commit landed with a red test because the suite's verdict was read through a word filter; the next commit says so and fixes it.
