### PR TITLE
The model closes support because it finally reads the rule that says to (0.42.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.41.0"
+version = "0.42.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/aihawk/agent.py
+++ b/src/aihawk/agent.py
@@ -22,8 +22,10 @@ SYSTEM_PROMPT = (
     "browser ONLY through the provided tools. Inspect pages with "
     "browser_read_text / browser_snapshot / browser_read_html before acting on "
     "them. A person may be watching the browser while you work, so prefer one "
-    "clear action at a time over long chains. When the task is done, reply with "
-    "the answer and do NOT call any more tools. Report only what the page "
+    "clear action at a time over long chains. When the task is done: first close "
+    "the support browser with browser_close if you opened it and nothing more "
+    "needs it, then reply with the answer, and call no more tools after that. "
+    "Report only what the page "
     "actually shows. Say plainly what failed and what you could not check: the "
     "person reading is deciding what to do next. Write the way a competent "
     "colleague talks: the answer first, then what supports it. Do not announce "
@@ -40,6 +42,33 @@ SYSTEM_PROMPT = (
 #: and wrong as a status marker at the head of every line", and the answers came
 #: back with a tick at the head of every line. A rule with an exception in it is
 #: a rule the model satisfies by finding the exception.
+
+#: ⛔ THE END-OF-TURN SENTENCE USED TO FORBID THE CALL THAT CLOSES `support`.
+#: It said "reply with the answer and do NOT call any more tools", and the
+#: only text that said to close the helper was the server's instructions,
+#: which the loop never sent. Measured 2026-09-12 with the real model on a
+#: task that needs both browsers: six runs out of six left `support` open,
+#: and in the owner's own sessions one conversation of 247 steps used it 29
+#: times and never closed it. The order is now part of the sentence about
+#: ending, because that is the moment the model was told to stop.
+
+
+def system_message(instructions: str = "") -> dict:
+    """The one system message, from this build's prompt plus what the server
+    says about itself.
+
+    ⛔ ONE FUNCTION, THREE WRITERS. The message was assembled in the
+    constructor, in the brain's restore and nowhere else, and the server's
+    instructions - the only text that defines what `support` is for and that
+    whoever opens it closes it - were in neither. They travel with the link
+    and are refreshed at the start of every run, so a restored transcript and
+    a new one carry the same current instructions.
+    """
+    text = SYSTEM_PROMPT
+    if instructions:
+        text += chr(10) + chr(10) + instructions.strip()
+    return {"role": "system", "content": text}
+
 
 Say = Callable[[str, str], Awaitable[None]]
 
@@ -148,7 +177,7 @@ class Conversation:
         self.client = client
         self.model = model
         self.max_tokens = max_tokens
-        self.messages: List[dict] = [{"role": "system", "content": SYSTEM_PROMPT}]
+        self.messages: List[dict] = [system_message()]
         self.tool_defs: Optional[List[dict]] = None
         self.usage = {"prompt": 0, "completion": 0, "calls": 0, "last_prompt": 0}
 
@@ -168,7 +197,7 @@ class Conversation:
         self.usage["last_prompt"] = last
 
     async def run(self, task: str, call_tool, tools, *, say: Say = _silent,
-                  describe=None) -> str:
+                  describe=None, instructions: str = "") -> str:
         """Run one instruction to an answer.
 
         `call_tool(name, args)` performs a tool call and returns the MCP result;
@@ -178,6 +207,10 @@ class Conversation:
         """
         if self.tool_defs is None:
             self.tool_defs = mcp_tools_to_openai(tools)
+        # Refreshed every run rather than set once: the instructions belong to
+        # the server the link is talking to now, and a transcript restored from
+        # disk arrived with a system message this process did not write.
+        self.messages[0] = system_message(instructions)
         self.messages.append({"role": "user", "content": task})
 
         # No turn ceiling. There was one, and what it did in practice was end

--- a/src/aihawk/brain.py
+++ b/src/aihawk/brain.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 from typing import Awaitable, Callable
 
 from . import actions_help
-from .agent import SYSTEM_PROMPT, Conversation
+from .agent import Conversation, system_message
 from .link import Link
 
 Say = Callable[[str, str], Awaitable[None]]
@@ -89,7 +89,7 @@ class OpenRouterBrain(Brain):
         """
         if messages:
             self._convo.messages = (
-                [{"role": "system", "content": SYSTEM_PROMPT}]
+                [system_message()]
                 + [m for m in messages if m.get("role") != "system"])
         if usage:
             self._convo.usage.update(usage)
@@ -109,4 +109,5 @@ class OpenRouterBrain(Brain):
         # cancellation the stop button raises or something the interface's own
         # handler already reports.
         await self._convo.run(text, link.call, link.tools,
+                              instructions=getattr(link, "instructions", ""),
                               say=say, describe=actions_help.summarise)

--- a/src/aihawk/link.py
+++ b/src/aihawk/link.py
@@ -58,6 +58,12 @@ class Link:
         self._ctx: Any = None
         self._sess_ctx: Optional[ClientSession] = None
         self._tools: Optional[list] = None
+        #: What the server says about itself at `initialize`. It is the one
+        #: place the two-browser contract is written - what `support` is for,
+        #: and that whoever opens it closes it - and until 2026-09-12 nothing
+        #: read it: the loop sent the system prompt and the tool descriptions
+        #: and the server's own instructions went nowhere.
+        self._instructions: str = ""
         # One instruction at a time. Two tool calls racing on one browser is not
         # a transport problem, it is two hands on the same mouse.
         self._lock = asyncio.Lock()
@@ -72,7 +78,8 @@ class Link:
         read, write = await self._ctx.__aenter__()
         self._sess_ctx = ClientSession(read, write)
         self._session = await self._sess_ctx.__aenter__()
-        await self._session.initialize()
+        started = await self._session.initialize()
+        self._instructions = getattr(started, "instructions", None) or ""
         self._tools = (await self._session.list_tools()).tools
         return self
 
@@ -90,6 +97,11 @@ class Link:
     @property
     def tools(self):
         return self._tools or []
+
+    @property
+    def instructions(self) -> str:
+        """The server's own instructions, verbatim, or an empty string."""
+        return self._instructions
 
     @property
     def session(self) -> ClientSession:

--- a/src/aihawk/mcp/server.py
+++ b/src/aihawk/mcp/server.py
@@ -188,9 +188,10 @@ close another: browser_navigate opens the page and every other tool acts on
 it. When you need a second page, that is what `support` is. Going somewhere
 else and coming back is a navigation, not a second window.
 
-Open it with browser_open when you need it and close it with browser_close when
-you are done: it costs a real browser, it is not saved, and it goes away when
-this server does. There is no third browser and no way to get one from here -
+Open it with browser_open when the task needs it, and close it with
+browser_close as soon as the task no longer needs it, before you give your
+answer: it costs a real browser, it is not saved, and it goes away when this
+server does. There is no third browser and no way to get one from here -
 `main` and `support` are the whole of what this gives you."""
 
 
@@ -599,40 +600,34 @@ async def browser_open(browser: Browser | None = None, seed: int | None = None,
                        proxy: str | None = None, profile: str | None = None) -> str:
     """Open `main` or `support`, or reopen one as somebody else.
 
-    `main` is your own identity - its page, cookies, fingerprint, the logins - and
-    `support` is a helper beside it for what must not touch that identity: a
-    temporary mailbox to receive a verification, a lookup, a page you want to
-    read without the site connecting it to the account. They share nothing.
-    The helper is not saved: it lives for the task and dies with this server.
+    `main` is your own identity: its page, cookies, fingerprint, logins.
+    `support` is a helper beside it for what must not touch that identity - a
+    temporary mailbox for a verification, a lookup the site must not connect to
+    the account. They share nothing. `support` is yours to manage: open it when
+    the task needs a second identity, and close it with browser_close as soon
+    as the task no longer needs it, before you answer. It is not saved.
 
     Called on a browser that is already up, this REOPENS it with the settings
-    given, and what it held is gone - so this is also how you become somebody
-    else: a fresh stranger, the same person as last time by seed, or a saved
-    profile that is already logged in somewhere.
+    given, and what it held is gone.
 
-    seed     the browser's identity. Same seed, same fingerprint, every time.
-             Leave it out and one is drawn, and the answer tells you which, so
-             you can ask for it again later.
-    profile  a directory that keeps cookies and logins between opens. A
-             profile also KEEPS ITS SEED: the first open on a new one stores
-             the identity inside it, and every open after reuses it, so a
-             login does not come back wearing different hardware. Pass "" to
-             insist on no profile at all. A relative path is resolved against
-             the server's own directory, so the answer reports the full path
-             used.
-    proxy    where the traffic goes out, as `http://user:pass@host:port` or
-             `socks5://host:port`. Pass "" to insist on going out from this
-             machine's own address. Left out for `support`, it goes out
-             through the same exit `main` already has; give it a value only
-             if you mean `support` to look different. A profile does NOT pin
-             its exit the way it pins its seed: timezone, locale and
-             geography come from the exit, so the same login arriving from
-             another country is as visible as one arriving on different
-             hardware.
-
-    Opening one takes several seconds and costs real memory. browser_close
-    frees it.
+    seed     the identity; same seed, same fingerprint. Left out, one is drawn.
+    profile  a directory keeping cookies, logins and the seed between opens;
+             "" means none.
+    proxy    the exit, `http://user:pass@host:port` or `socks5://host:port`;
+             "" means this machine's own address; left out for `support`, it
+             shares the exit `main` has.
     """
+    # ⛔ THE DESCRIPTION ABOVE IS WHAT THE MODEL READS, AND IT IS CUT AT 1024
+    # CHARACTERS BY THE API. The version before this one was 1996: the model
+    # saw it end mid-word inside the paragraph about profiles, and the sentence
+    # that told it to close the helper was past the cut. A gate in the server
+    # tests now holds every tool's description under the limit. What was cut
+    # from here, kept for a reader of the source: a profile also keeps its
+    # seed, so a login does not come back wearing different hardware; a profile
+    # does NOT pin its exit - timezone, locale and geography come from the
+    # exit, so the same login arriving from another country is as visible as
+    # one arriving on different hardware; and `support` takes a proxy of its
+    # own only when it is meant to look different from `main`.
     role = browser or DEFAULT_BROWSER_ID
 
     if role not in (DEFAULT_BROWSER_ID, SUPPORT_BROWSER_ID):
@@ -997,24 +992,23 @@ async def browser_click_at(x: float, y: float, hold_seconds: float = 0.0,
                            browser: Browser | None = None) -> Image:
     """Click (or press-and-hold) a raw viewport coordinate instead of a
     selector - for targets a selector cannot reliably reach: a slider track, a
-    canvas-drawn captcha, or a precise point inside a wider element. Moves the
+    canvas-drawn captcha, a precise point inside a wider element. Moves the
     pointer there first (no teleport), then down, then up, holding first if
     hold_seconds is set. Returns a screenshot taken right after release.
 
-    hold_seconds needs invisible-playwright 0.9.0 or newer to mean anything. In
-    every earlier version the wait it is built on returned instantly, so the
-    press and the release happened in the same frame and the hold never
-    happened - on the one tool that exists for sliders and press-and-hold
-    challenges. The floor in pyproject.toml is set accordingly.
-
     Coordinates are relative to the VIEWPORT, not to the page, so the ones in a
-    snapshot go stale the moment anything scrolls: a click, a keypress, a lazy
-    image loading in above the fold. Nothing raises when that happens - the
-    click simply lands on whatever is at that spot now. Take a fresh snapshot
-    after anything that could have moved the page, and prefer browser_click with
-    the element's `selector` whenever it has one.
+    snapshot go stale the moment anything scrolls. Nothing raises when that
+    happens: the click lands on whatever is at that spot now. Take a fresh
+    snapshot after anything that could have moved the page, and prefer
+    browser_click with the element's `selector` whenever it has one.
 
     `browser` is `main` unless you say `support`, and they share nothing."""
+    # hold_seconds needs invisible-playwright 0.9.0 or newer to mean anything:
+    # in every earlier version the wait it is built on returned instantly, so
+    # the press and the release happened in the same frame and the hold never
+    # happened, on the one tool that exists for sliders and press-and-hold
+    # challenges. The floor in pyproject.toml is set accordingly. Said here and
+    # not in the description above, which the API cuts at 1024 characters.
     png = await actions.click_at(
         await ready(browser),
         x, y, hold_seconds)

--- a/tests/mcp_server/test_every_description_reaches_the_model.py
+++ b/tests/mcp_server/test_every_description_reaches_the_model.py
@@ -1,0 +1,61 @@
+"""Every tool description is read by the model in full, and the one about
+`support` says who closes it.
+
+The loop hands the API each tool's description cut at 1024 characters, because
+a longer one is rejected rather than trimmed. `browser_open` was 1996: the model
+read it ending mid-word inside the paragraph about profiles, and the sentence
+that told it to close the helper was past the cut. Measured 2026-09-12 with the
+real model, six runs of a task that needs both browsers, `support` left open in
+six. No browser is started here: the descriptions are read from the server the
+same way the loop reads them.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from aihawk.agent import mcp_tools_to_openai
+from aihawk.mcp import server
+
+#: The API's ceiling, and the loop's cut. Written once here and once in the
+#: loop, and this file is the one that says why.
+LIMIT = 1024
+
+
+def descriptions():
+    tools = asyncio.run(server.mcp.list_tools())
+    assert len(tools) >= 16, "found %d tools, so this is not looking at the server" % len(tools)
+    return {t.name: (t.description or "") for t in tools}
+
+
+def test_no_description_is_longer_than_the_model_can_read():
+    """Known-bad: give any tool a description over the limit - the loop cuts
+    it and nothing says so."""
+    over = {n: len(d) for n, d in descriptions().items() if len(d) > LIMIT}
+    assert not over, (
+        "these descriptions are cut before the model reads them, and whatever "
+        "is past the cut is a rule the model has never been told: %s" % over)
+
+
+def test_the_loop_sends_what_the_server_wrote():
+    """The cut in the loop is the fact the gate above defends; this holds that
+    the two agree, so the limit cannot quietly move in one place."""
+    tools = asyncio.run(server.mcp.list_tools())
+    sent = {d["function"]["name"]: d["function"]["description"]
+            for d in mcp_tools_to_openai(tools)}
+    for name, description in descriptions().items():
+        assert sent[name] == description, (
+            "the model reads a different description of %s than the server "
+            "wrote" % name)
+
+
+def test_the_tool_that_opens_support_says_who_closes_it():
+    """⛔ THE ONLY SENTENCE ABOUT CLOSING WAS PAST THE CUT. Now it is in the
+    first paragraph, where a model that reads nothing else still meets it.
+
+    Known-bad: move the sentence below the parameters again, or drop it.
+    """
+    text = descriptions()["browser_open"]
+    first = text[:LIMIT // 2]
+    assert "browser_close" in first and "support" in first, (
+        "the description of browser_open does not say, early, that support is "
+        "closed with browser_close: %r" % text[:200])

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -62,6 +62,7 @@ from openai.types.chat.chat_completion_message_function_tool_call import (
 
 from aihawk import agent as agent_module
 from aihawk.agent import (
+    system_message,
     SYSTEM_PROMPT,
     Conversation,
     _result_text,
@@ -1115,3 +1116,91 @@ def test_a_reopened_conversation_gets_THIS_build_instructions():
     assert brain.messages[0]["role"] == "system", "the prompt has to lead"
     assert [m["content"] for m in brain.messages[1:]] == [
         "open the listings", "three roles"], "the transcript itself was altered"
+
+
+async def test_the_server_instructions_reach_the_model():
+    """⛔ THE SERVER'S INSTRUCTIONS WENT NOWHERE. They are the one place the
+    two-browser contract is written - what `support` is for, and that whoever
+    opens it closes it - and the loop sent the system prompt and the tool
+    descriptions and nothing else. Measured 2026-09-12: six runs of a task that
+    needs both browsers, `support` left open in six.
+
+    They travel with the link and are put into the system message at the start
+    of every run, by the one function that builds it, so a transcript restored
+    from disk and a fresh one carry the same current instructions.
+
+    Known-bad, three: drop the argument; build the system message in the
+    constructor only, so a restored transcript keeps the old one; put the
+    instructions in a second system message instead of the one.
+    """
+    mcp = ScriptedMCP(tools=tools_result(tool("browser_open")), results={})
+    model = ScriptedModel([assistant_answer("done"), assistant_answer("done")])
+    convo = Conversation(model, "m")
+    tools = (await mcp.list_tools()).tools
+    await convo.run("go", mcp.call_tool, tools, instructions="There are two browsers.")
+
+    system = [m for m in model.requests[0]["messages"] if m["role"] == "system"]
+    assert len(system) == 1, "the instructions travel as a second system message"
+    assert system[0]["content"].startswith(SYSTEM_PROMPT), "the prompt is no longer first"
+    assert system[0]["content"].endswith("There are two browsers."), (
+        "the server's instructions do not reach the model: %r" % system[0]["content"][-80:])
+    assert convo.messages[0] == system_message("There are two browsers.")
+
+    #: and a run with a different server replaces them rather than stacking
+    await convo.run("again", mcp.call_tool, tools, instructions="Only one browser.")
+    system = [m for m in model.requests[1]["messages"] if m["role"] == "system"]
+    assert len(system) == 1 and system[0]["content"].endswith("Only one browser."), (
+        "the instructions of a previous run are still in the message")
+
+
+def test_the_end_of_the_turn_closes_the_helper_before_the_answer():
+    """⛔ THE SENTENCE ABOUT ENDING FORBADE THE CALL THAT CLOSES `support`. It
+    said `reply with the answer and do NOT call any more tools`, which is the
+    moment the model was told to stop - so the close never came, in every run
+    measured and in the owner's own 247-step session. The order is in the
+    sentence now, and without loophole vocabulary: an exception is what a model
+    reaches for.
+
+    Known-bad: put the old sentence back, or phrase the close as an exception.
+    """
+    low = SYSTEM_PROMPT.lower()
+    ending = next(s for s in low.split(". ") if "task is done" in s)
+    assert "support" in ending and "browser_close" in ending, (
+        "the end-of-turn sentence does not say to close support: %r" % ending)
+    assert ending.index("browser_close") < ending.index("answer"), (
+        "the close comes after the answer in the sentence, which is after the "
+        "model has stopped calling tools: %r" % ending)
+    for loophole in ("except", "unless", "only exception"):
+        assert loophole not in ending, (
+            "the close is phrased as an exception (%r), which is what a model "
+            "reaches for: %r" % (loophole, ending))
+
+
+async def test_the_brain_hands_the_link_instructions_to_the_loop():
+    """The loop can carry the instructions and the interface can still forget
+    to pass them: the brain is the one caller in the product, and this drives
+    it with a link that has some.
+
+    Known-bad: drop `instructions=` from the brain's call.
+    """
+    from aihawk.brain import OpenRouterBrain
+
+    class LinkWithInstructions:
+        instructions = "Two browsers, main and support."
+
+        def __init__(self, mcp):
+            self.tools = tools_result(tool("browser_open")).tools
+            self.call = mcp.call_tool
+
+    mcp = ScriptedMCP(tools=tools_result(tool("browser_open")), results={})
+    model = ScriptedModel([assistant_answer("done")])
+
+    async def say(kind, text):
+        pass
+
+    await OpenRouterBrain(model, "m").handle("go", LinkWithInstructions(mcp), say)
+    system = [m for m in model.requests[0]["messages"] if m["role"] == "system"]
+    assert len(system) == 1 and system[0]["content"].endswith("Two browsers, main and support."), (
+        "the interface's brain does not hand the server's instructions to the "
+        "loop: %r" % system[0]["content"][-80:])
+


### PR DESCRIPTION
The owner watched the helper browser get opened, used and never closed. Measured
before touching anything, with the real model on a task that needs both
browsers: six runs out of six left `support` open at the end, and in the owner's
own sessions one conversation of 247 steps used it 29 times and never closed it.

Three origins, none of them the model:

- The server's instructions never reached it. They are the one place the
  two-browser contract is written - what `support` is for, and that whoever
  opens it closes it - and the loop sent the system prompt and the tool
  descriptions and nothing else. The link keeps what the server says at
  `initialize`, and one function builds the system message from this build's
  prompt plus those instructions, refreshed at the start of every run, so a
  restored transcript and a fresh one carry the same current text. It was
  assembled by hand in two places and had the instructions in neither.

- The end-of-turn sentence forbade the very call that closes the helper: "reply
  with the answer and do NOT call any more tools", at the exact moment the
  close should happen. The order is in the sentence now - close `support` if
  you opened it and nothing more needs it, then answer, then no more tools -
  without exception vocabulary, because an exception is what a model reaches
  for.

- The API cuts every tool description at 1024 characters, and `browser_open`
  was 1996: the model read it ending mid-word inside the paragraph about
  profiles, and the one sentence about closing was past the cut.
  `browser_click_at` was over too. Both fit now, the contract comes first, and
  what was cut moved into comments for a reader of the source.

Measured after, same bench, same task, same model, six runs: `support` closed
before the answer in six, left open at the end in none. Every sequence ends
with browser_close support.

Gates: every description under the limit and identical to what the loop sends,
executed against the real server; `browser_open` names `browser_close` in its
first half; the loop puts the instructions in the one system message and
replaces them run to run; the brain hands the link's instructions to the loop;
the end-of-turn sentence closes before it answers and carries no loophole.