### PR TITLE
The Official MCP Registry can verify this package, and 0.43.0 is what carries it

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,8 @@ not read.
 [MIT](https://github.com/feder-cr/AIHawk/blob/main/LICENSE). Everything
 distributed before 2 September 2026 was released under AGPL-3.0 and stays under
 it.
+
+<!-- The Official MCP Registry verifies ownership of a PyPI package by finding
+     this token in the published description, which is this file. It must match
+     the `name` in server.json exactly. -->
+<!-- mcp-name: io.github.feder-cr/aihawk -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.42.0"
+version = "0.43.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
The registry proves you own a PyPI package by finding an mcp-name token in the published description, which for this project is README.md. Without it, publishing io.github.feder-cr/aihawk is refused with "Registry validation failed for package".

The token has to be on the index, not just in the tree, so it needs a release to reach anything: hence the bump to 0.43.0.

Checked on the built wheel rather than assumed, the token is in aihawk-0.43.0.dist-info/METADATA, which is the description PyPI serves and the registry reads. Locally: 585 passed, content gate clean, english-only clean.