### PR TITLE
The two listings publish themselves from the tag, and a test keeps their version honest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -198,3 +198,97 @@ jobs:
           fi
           gh release create "$TAG" --title "${TAG#v}" --notes-file notes.md
           echo "::notice::created the release page for $TAG"
+
+  # The Official MCP Registry lists this server from `server.json`, and the
+  # entry names a version, so a release that does not also publish here leaves
+  # the registry describing the previous one. 0.43.0 was published by hand on
+  # 2026-09-12; from the next tag this job does it.
+  #
+  # It runs when `upload` succeeded AND when the index already had the version,
+  # so a `workflow_dispatch` exercises the whole path (install, OIDC login,
+  # probe, verify) against the version on the index without publishing anything
+  # twice: the registry refuses a duplicate version, so the probe asks first and
+  # an entry that is already there is a logged no-op, the same rule `upload`
+  # applies to the index. It does NOT run when `gate` failed: then `upload` is
+  # skipped and the index has nothing to verify, and the registry checks the
+  # package on the index before accepting the entry.
+  #
+  # Its own job, and after `upload`: the OIDC token that speaks for this
+  # repository at the registry has no business in the job that holds the PyPI
+  # trust, and the registry needs the package to be on the index first. The
+  # index answers minutes before its mirrors do, and the registry reads the
+  # index, so the wait below asks the index for the package's description
+  # rather than trusting that `upload` returned.
+  registry:
+    needs: [already-published, upload]
+    if: >-
+      always() && needs.already-published.result == 'success' &&
+      (needs.upload.result == 'success' || needs.already-published.outputs.present == 'yes')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      id-token: write          # OIDC for the registry; no token in a secret anywhere
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: server.json names the version being built
+        shell: bash
+        run: |
+          set -euo pipefail
+          HAVE="${{ needs.already-published.outputs.version }}"
+          SJ="$(jq -r '.version' server.json)"
+          PKG="$(jq -r '.packages[0].version' server.json)"
+          if [ "$SJ" != "$HAVE" ] || [ "$PKG" != "$HAVE" ]; then
+            echo "server.json says $SJ (package entry $PKG) and pyproject.toml says $HAVE" >&2
+            exit 1
+          fi
+          echo "NAME=$(jq -r '.name' server.json)" >> "$GITHUB_ENV"
+          echo "VERSION=$HAVE" >> "$GITHUB_ENV"
+      - name: the index serves this version with the ownership token
+        shell: bash
+        # The registry validates the package by reading the description PyPI
+        # serves. Right after `upload` the index can answer 404 for a while, so
+        # this waits for the version AND for the token inside its description,
+        # which is the exact thing the registry will look for.
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 40); do
+            BODY="$(curl -s "https://pypi.org/pypi/aihawk/$VERSION/json" || true)"
+            if printf '%s' "$BODY" | jq -e --arg n "$NAME" '.info.description | contains("mcp-name: " + $n)' > /dev/null 2>&1; then
+              echo "index serves $VERSION with the token for $NAME"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo "after 10 minutes the index does not serve $VERSION with 'mcp-name: $NAME' in its description" >&2
+          exit 1
+      - name: install mcp-publisher
+        run: |
+          curl -sL "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher --help > /dev/null
+      - name: authenticate to the registry
+        run: ./mcp-publisher login github-oidc
+      - name: publish, unless the registry already has this version
+        shell: bash
+        run: |
+          set -euo pipefail
+          ENC="$(printf '%s' "$NAME" | jq -sRr @uri)"
+          CODE="$(curl -s -o /dev/null -w '%{http_code}' "https://registry.modelcontextprotocol.io/v0.1/servers/$ENC/versions/$VERSION")"
+          case "$CODE" in
+            200) echo "::notice::$NAME $VERSION is already on the registry. No-op, not a failure." ;;
+            404) ./mcp-publisher validate
+                 ./mcp-publisher publish ;;
+            *)   echo "the registry answered $CODE for $NAME $VERSION, which is neither present nor absent. Refusing rather than guessing." >&2
+                 exit 1 ;;
+          esac
+      - name: the registry serves it
+        shell: bash
+        run: |
+          set -euo pipefail
+          ENC="$(printf '%s' "$NAME" | jq -sRr @uri)"
+          GOT="$(curl -sf "https://registry.modelcontextprotocol.io/v0.1/servers/$ENC/versions/$VERSION" | jq -r '.server.version')"
+          if [ "$GOT" != "$VERSION" ]; then
+            echo "the registry serves version '$GOT' for $NAME, expected $VERSION" >&2
+            exit 1
+          fi
+          echo "registry: $NAME $VERSION"

--- a/mcpb/.mcpbignore
+++ b/mcpb/.mcpbignore
@@ -1,0 +1,6 @@
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+*.egg-info/
+uv.lock

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,35 @@
+{
+  "manifest_version": "0.4",
+  "name": "aihawk",
+  "display_name": "AIHawk",
+  "version": "0.43.0",
+  "description": "AI browser agent: browses, clicks, types, and reads real web pages from plain-English instructions.",
+  "long_description": "AIHawk gives an MCP client a real browser to drive. The tools navigate, click, type, read and screenshot pages the way a person would, on a patched Firefox engine.\n\nThe engine is downloaded once, outside this bundle, with `uvx invisible-playwright fetch`. Until that has run, every browser tool reports that the engine is missing.",
+  "author": {
+    "name": "feder-cr",
+    "url": "https://github.com/feder-cr"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/feder-cr/AIHawk.git"
+  },
+  "homepage": "https://github.com/feder-cr/AIHawk",
+  "documentation": "https://github.com/feder-cr/AIHawk/wiki",
+  "support": "https://github.com/feder-cr/AIHawk/issues",
+  "server": {
+    "type": "python",
+    "entry_point": "src/server.py",
+    "mcp_config": {
+      "command": "uv",
+      "args": ["run", "--directory", "${__dirname}", "src/server.py"]
+    }
+  },
+  "compatibility": {
+    "platforms": ["win32", "linux"],
+    "runtimes": {
+      "python": ">=3.11"
+    }
+  },
+  "keywords": ["browser", "browser-agent", "web-automation", "playwright", "firefox", "computer-use"],
+  "license": "MIT"
+}

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -1,0 +1,12 @@
+# The MCP bundle's own project: it exists so that the host's `uv run` installs
+# the published package instead of a copy of the tree. The pin is exact and it
+# is the same number as the bundle's manifest and the package's pyproject; a
+# test in the suite refuses a release where the three disagree.
+[project]
+name = "aihawk-mcpb"
+version = "0.43.0"
+description = "MCP bundle that runs the published aihawk package"
+requires-python = ">=3.11"
+dependencies = [
+    "aihawk==0.43.0",
+]

--- a/mcpb/src/server.py
+++ b/mcpb/src/server.py
@@ -1,0 +1,35 @@
+"""Entry point of the MCP bundle: the server over stdio.
+
+Two hosts run this file two ways. One honours `mcp_config` and runs
+`uv run --directory <bundle> src/server.py`, so the bundle's pyproject has
+already installed the pinned package and the import below succeeds. The other
+runs `python src/server.py` on its own, with nothing installed, and for that
+one the import fails and the process becomes `uvx aihawk==<pin>` instead, with
+the same stdio and the same arguments. The pin is read from the pyproject next
+to this file rather than written here, so the bundle carries the number once.
+
+With no arguments this is `aihawk` with no subcommand, which is the MCP server.
+"""
+
+import os
+import pathlib
+import sys
+import tomllib
+
+try:
+    from aihawk.cli import main
+except ImportError:
+    main = None
+
+
+def _pinned_requirement() -> str:
+    pyproject = pathlib.Path(__file__).resolve().parents[1] / "pyproject.toml"
+    deps = tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"]["dependencies"]
+    return next(d for d in deps if d.startswith("aihawk=="))
+
+
+if __name__ == "__main__":
+    if main is not None:
+        main()
+    else:
+        os.execvp("uvx", ["uvx", _pinned_requirement(), *sys.argv[1:]])

--- a/server.json
+++ b/server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.feder-cr/aihawk",
+  "title": "AIHawk",
+  "description": "AI browser agent: browses, clicks, types, and reads real web pages from plain-English instructions.",
+  "repository": {
+    "url": "https://github.com/feder-cr/AIHawk",
+    "source": "github"
+  },
+  "version": "0.43.0",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "aihawk",
+      "version": "0.43.0",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/tests/test_publishing_surfaces.py
+++ b/tests/test_publishing_surfaces.py
@@ -1,0 +1,145 @@
+"""The two listings this package publishes to describe the version that ships.
+
+Two files in this repository are read by somebody else's machine, not by ours:
+
+  1. `server.json` at the root is what `mcp-publisher` sends to the Official
+     MCP Registry, and the registry checks the PyPI package it names for a
+     `mcp-name: <server name>` token in the published description, which is
+     README.md. A version in server.json that is not the version on the index
+     is refused by the registry; a missing token is refused too, with
+     "Registry validation failed for package".
+  2. `mcpb/` is the source of the MCP bundle that Smithery distributes for
+     local execution. Its manifest carries a version, and its pyproject pins
+     the published package exactly, so a bundle at 0.43.0 installs aihawk
+     0.43.0 and nothing else.
+
+That is four copies of one number (pyproject, server.json, manifest, the pin)
+and one token that must match a name. Each pair was written by hand on
+2026-09-12 and they agreed; nothing made them agree. The registry job in
+publish.yml runs on the tag, which is after the bump, and would only find out
+at the end of a release. This test finds out on the pull request.
+
+Every check is a function over strings and dicts, and a second test feeds them
+known-bad input: a check that has only ever said "consistent" is not a check.
+"""
+from __future__ import annotations
+
+import copy
+import json
+import pathlib
+import re
+import tomllib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+REGISTRY_NAME = "io.github.feder-cr/aihawk"
+
+
+def _load():
+    pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    return {
+        "package_name": pyproject["project"]["name"],
+        "version": pyproject["project"]["version"],
+        "readme": (ROOT / "README.md").read_text(encoding="utf-8"),
+        "server": json.loads((ROOT / "server.json").read_text(encoding="utf-8")),
+        "manifest": json.loads((ROOT / "mcpb" / "manifest.json").read_text(encoding="utf-8")),
+        "bundle_pyproject": tomllib.loads((ROOT / "mcpb" / "pyproject.toml").read_text(encoding="utf-8")),
+    }
+
+
+def registry_findings(package_name, version, readme, server):
+    """Why the registry would refuse server.json, or nothing."""
+    out = []
+    if server.get("name") != REGISTRY_NAME:
+        out.append("server.json names %r, the namespace is %r" % (server.get("name"), REGISTRY_NAME))
+    if server.get("version") != version:
+        out.append("server.json is %r, pyproject is %r" % (server.get("version"), version))
+    packages = server.get("packages") or []
+    if len(packages) != 1:
+        out.append("expected one package entry, found %d" % len(packages))
+    else:
+        pkg = packages[0]
+        if pkg.get("registryType") != "pypi":
+            out.append("the package is not a pypi entry")
+        if pkg.get("identifier") != package_name:
+            out.append("the package identifier is %r, the project is %r" % (pkg.get("identifier"), package_name))
+        if pkg.get("version") != version:
+            out.append("the package entry says %r, pyproject is %r" % (pkg.get("version"), version))
+        if (pkg.get("transport") or {}).get("type") != "stdio":
+            out.append("the transport is not stdio")
+    # The token must be followed by a boundary: whitespace, a tag, or the
+    # comment close. Glued to a period it does not match on the registry side.
+    if not re.search(r"mcp-name:\s*" + re.escape(REGISTRY_NAME) + r"(?=\s|-->|<)", readme):
+        out.append("README.md carries no `mcp-name: %s` token" % REGISTRY_NAME)
+    return out
+
+
+def bundle_findings(package_name, version, manifest, bundle_pyproject):
+    """Why the bundle would ship the wrong package, or nothing."""
+    out = []
+    if manifest.get("version") != version:
+        out.append("manifest is %r, pyproject is %r" % (manifest.get("version"), version))
+    if manifest.get("name") != package_name:
+        out.append("manifest name is %r, the project is %r" % (manifest.get("name"), package_name))
+    if "tools" in manifest:
+        # smithery-ai/cli#787: a manifest that declares tools is refused by
+        # Smithery's registry with a 400, because MCPB tool entries carry no
+        # inputSchema and the CLI forwards them as MCP tools that require one.
+        out.append("manifest declares tools, which Smithery refuses")
+    server = manifest.get("server") or {}
+    # "python", not "uv": Smithery's CLI recognises python, node and binary
+    # only (measured 2026-09-12: a uv-type manifest is refused with "Could not
+    # determine bundle runtime"). The entry point copes with either host.
+    if server.get("type") != "python":
+        out.append("server type is %r, Smithery accepts python" % server.get("type"))
+    entry = server.get("entry_point")
+    if not entry or not (ROOT / "mcpb" / entry).is_file():
+        out.append("entry_point %r is not a file in mcpb/" % entry)
+    deps = (bundle_pyproject.get("project") or {}).get("dependencies") or []
+    want = "%s==%s" % (package_name, version)
+    if deps != [want]:
+        out.append("bundle dependencies are %r, expected [%r]" % (deps, want))
+    if (bundle_pyproject.get("project") or {}).get("version") != version:
+        out.append("bundle pyproject is %r, pyproject is %r" % (bundle_pyproject["project"].get("version"), version))
+    return out
+
+
+def test_the_registry_entry_describes_the_package_that_ships():
+    d = _load()
+    assert registry_findings(d["package_name"], d["version"], d["readme"], d["server"]) == []
+
+
+def test_the_bundle_installs_the_version_that_ships():
+    d = _load()
+    assert bundle_findings(d["package_name"], d["version"], d["manifest"], d["bundle_pyproject"]) == []
+
+
+def test_the_checks_refuse_known_bad_input():
+    d = _load()
+    good = registry_findings(d["package_name"], d["version"], d["readme"], d["server"])
+    assert good == [], good
+
+    s = copy.deepcopy(d["server"]); s["version"] = "0.0.1"
+    assert registry_findings(d["package_name"], d["version"], d["readme"], s)
+
+    s = copy.deepcopy(d["server"]); s["packages"][0]["identifier"] = "somebody-else"
+    assert registry_findings(d["package_name"], d["version"], d["readme"], s)
+
+    stripped = d["readme"].replace("mcp-name: " + REGISTRY_NAME, "mcp-name: io.github.someone/else")
+    assert registry_findings(d["package_name"], d["version"], stripped, d["server"])
+
+    glued = d["readme"].replace("mcp-name: " + REGISTRY_NAME + " -->", "mcp-name: " + REGISTRY_NAME + ".-->")
+    assert glued != d["readme"]
+    assert registry_findings(d["package_name"], d["version"], glued, d["server"])
+
+    m = copy.deepcopy(d["manifest"]); m["version"] = "0.0.1"
+    assert bundle_findings(d["package_name"], d["version"], m, d["bundle_pyproject"])
+
+    m = copy.deepcopy(d["manifest"]); m["tools"] = [{"name": "browser_click", "description": "x"}]
+    assert bundle_findings(d["package_name"], d["version"], m, d["bundle_pyproject"])
+
+    m = copy.deepcopy(d["manifest"]); m["server"]["entry_point"] = "src/missing.py"
+    assert bundle_findings(d["package_name"], d["version"], m, d["bundle_pyproject"])
+
+    p = copy.deepcopy(d["bundle_pyproject"]); p["project"]["dependencies"] = ["aihawk>=0.1"]
+    assert bundle_findings(d["package_name"], d["version"], d["manifest"], p)


### PR DESCRIPTION
The Official MCP Registry got 0.43.0 by hand on 2026-09-12, from a server.json in a temporary directory, so the registry would keep describing that version forever. server.json now lives at the root, and a `registry` job in publish.yml sends it after `upload`: waits for the index to serve the version WITH the ownership token in its description, logs in with OIDC, asks the registry before publishing so a re-run is a no-op, then reads the entry back. It also runs when the index already had the version, so a workflow_dispatch exercises install, login, probe and verify without publishing twice.

mcpb/ is the source of the MCP bundle Smithery distributes for local execution: python-type manifest (their CLI does not know uv), pyproject pinning aihawk exactly, and an entry point that copes with both ways a host runs it (mcp_config with uv run, or bare python: on ImportError it becomes uvx aihawk==pin). Both arms were run. No tools in the manifest (smithery-ai/cli#787).

tests/test_publishing_surfaces.py keeps the four copies of the version and the mcp-name token consistent on every pull request, and refuses nine known-bad inputs first.

Locally: 588 passed, content gate clean, english clean, ruff clean, mcpb validate ok, mcp-publisher validate ok; the new job's run blocks were executed by hand against the live index and registry (token present, probe 200, verify 0.43.0). Not runnable here: jq syntax and the OIDC login, which a workflow_dispatch after merge will judge.