### PR TITLE
Ten pages on the MCP ecosystem, and the tool-surface number eleven pages rested on

### DIFF
--- a/docs/agentic-browser-open-source.md
+++ b/docs/agentic-browser-open-source.md
@@ -57,7 +57,7 @@ The newest layer, and the cheapest to try, because it adds a browser to an
 assistant you are already paying for instead of standing up a new program.
 
 **Microsoft's playwright-mcp** is the reference implementation: Apache-2.0,
-36.9k stars when read on 2026-09-10, driving Chrome, Firefox, WebKit or Edge,
+36.9k stars when read on 2026-09-13, driving Chrome, Firefox, WebKit or Edge,
 and exposing the page to the model as an accessibility tree rather than pixels.
 It is the one to start with, and
 [what it is and how it differs from the CLI](playwright-mcp-vs-cli.md) is on its

--- a/docs/ai-agent-login-to-a-website.md
+++ b/docs/ai-agent-login-to-a-website.md
@@ -21,7 +21,8 @@ login step to get wrong, and any interactive check happened while a person was
 present. This is the right answer for most cases and it is the one people skip.
 
 Microsoft's server takes `--storage-state` for exactly this shape. This project
-takes a persistent `profile_dir` per session.
+takes a persistent profile instead, as `STEALTHFOX_PROFILE_DIR` in the config
+block or as `profile` on `browser_open`.
 
 **Persist a profile.** The agent has its own browser directory that survives
 between runs. First run logs in, later runs do not. Cheaper to set up than a

--- a/docs/best-llm-for-browser-automation.md
+++ b/docs/best-llm-for-browser-automation.md
@@ -74,8 +74,7 @@ is the practice, and it is cheaper than upgrading.
 
 **The server's tool surface changes the answer.** A server exposing a hundred
 tools makes every model worse at choosing, and makes small models much worse.
-Ours is **24 tools and about 3,500 tokens of description per turn** (measured
-from our own source, 2026-09-10); that overhead lands on every model you test,
+Ours is **16 tools and 3,192 tokens of tool definition on every turn** (counted with a tokenizer over the server's own registry, 2026-09-13); that overhead lands on every model you test,
 so hold it constant when you compare them.
 [How the tools are shaped](mcp-tool-design.md) argues why fewer is better here.
 

--- a/docs/best-mcp-server-for-browser-automation.md
+++ b/docs/best-mcp-server-for-browser-automation.md
@@ -8,7 +8,7 @@ nav_order: 26
 # Choosing an MCP server for browser automation
 
 **Start with Microsoft's playwright-mcp.** It is the reference implementation,
-Apache-2.0, 36.9k stars when read on 2026-09-10, maintained by the team that
+Apache-2.0, 36.9k stars when read on 2026-09-13, maintained by the team that
 maintains Playwright, and it covers the ordinary case well. If you have no
 specific complaint, installing anything else first is a mistake.
 
@@ -37,12 +37,13 @@ The single most common first-hour failure in this category is two clients
 fighting over one profile, which surfaces as
 [browser is already in use](playwright-mcp-browser-already-in-use.md).
 
-Servers differ in whether concurrency is a flag or a model. playwright-mcp makes
+Servers differ in whether concurrency is a flag or a shape. playwright-mcp makes
 it a flag: `--isolated`, or a distinct `--user-data-dir` per client.
-[AIHawk](https://github.com/feder-cr/AIHawk) makes it a model: named sessions
-and named browsers, so opening a browser that already exists focuses it rather
-than colliding. Neither is free. A flag is simpler until you need two of
-something; a model is more to learn on day one.
+[AIHawk](https://github.com/feder-cr/AIHawk) makes it a shape: one server is one
+identity for its whole life, with one helper browser beside it that shares
+nothing, so there is no pool for two clients to collide inside. Neither is free.
+A flag is simpler until you need two of something; a fixed shape means a second
+identity is a second registered server rather than an argument.
 
 **Winner:** depends on whether you will ever run two.
 
@@ -73,11 +74,14 @@ tools is not more capable than one with twenty; it is harder for a model to
 choose within, and every tool description costs context on every turn.
 
 To put a number on the cost rather than assert it, here is ours, read from our
-own source on 2026-09-10: **24 tools, 14,064 characters of description, about
-3,500 tokens on every turn.** A server advertising a hundred tools of similar
-description length is asking for roughly four times that, on every turn, for
-the whole session. Ask any server you are evaluating for the same two figures
-before believing that more tools is more capability.
+own registry on 2026-09-13: **16 tools, 9,145 characters of description, and
+3,192 tokens on every turn** once the JSON schema for each tool's arguments
+is counted with it, which it always is. Descriptions alone are 2,123 of those
+tokens; the schemas are the other third, and they are the half nobody counts.
+A server advertising a hundred tools of similar size is asking for roughly
+six times that, on every turn, for the whole session. Ask any server you are
+evaluating for the same figure before believing that more tools is more
+capability.
 
 What to look for instead: can the model **read** state without scripting, does
 it have a **coordinate** path for what selectors cannot reach, and is there a
@@ -90,8 +94,8 @@ reasoning on that, and it applies to servers other than ours.
 ## The one-pass decision
 
 - **No specific complaint:** playwright-mcp.
-- **Two clients, or several browsers at once:** a server with a session model,
-  or playwright-mcp with `--isolated` per client.
+- **Two clients, or several browsers at once:** playwright-mcp with `--isolated`
+  per client, or a server with no shared pool to collide inside.
 - **You need Firefox or WebKit specifically:** playwright-mcp covers all four
   engines with `--browser`.
 - **The site recognises the browser:** the engine axis, and only there does

--- a/docs/best-mcp-servers-for-claude-code.md
+++ b/docs/best-mcp-servers-for-claude-code.md
@@ -1,0 +1,103 @@
+---
+title: "Which MCP servers are worth adding to Claude Code"
+description: "Claude Code already does files, shell and git natively, so most starter lists recommend things it does not need. What is actually missing, and what each addition costs."
+parent: "Alternatives and Comparisons"
+nav_order: 34
+---
+
+# Which MCP servers are worth adding to Claude Code
+
+The starter lists for this question have a problem: **most of what they
+recommend, Claude Code already does.** It reads and writes files, runs shell
+commands and drives git without any server at all. Adding a filesystem MCP
+server to it duplicates a native capability and spends context doing it.
+
+So the useful question is narrower: what can it *not* do, and is that gap worth
+the context.
+
+## What it already has
+
+Files, shell, and anything reachable from a terminal. That last clause is
+broader than it sounds - if a capability has a CLI, Claude Code can already use
+it, and a server wrapping the same CLI adds a layer rather than a capability.
+
+Before installing anything, the honest first question is whether the thing you
+want has a command line. Very often it does, and you are done.
+
+## What is genuinely missing
+
+**A browser.** The clearest real gap: a terminal cannot render a page, run its
+JavaScript or click anything. This is the category where a server adds
+something a shell cannot reach, which is why browser servers are the most
+installed. Which one depends on the job:
+[choosing an MCP server for browser automation](best-mcp-server-for-browser-automation.md),
+and if the job is debugging your own site rather than driving one,
+[Playwright MCP vs Chrome DevTools MCP](playwright-mcp-vs-chrome-devtools-mcp.md).
+
+**A structured view of a live system.** A database's schema and query results
+arrive better through a typed tool than through parsing CLI output, and the
+same goes for issue trackers with a real API.
+
+**Something with no CLI at all.** Rarer than people assume, and the actual test
+of whether a server is worth it.
+
+## What each addition costs
+
+Tool descriptions travel in the model's context on every turn, not once.
+Measured on our own server's registry on 2026-09-13, with a tokenizer rather than a characters-per-token rule of thumb: **16 tools, 3,192 tokens resent every turn** (9,145 characters of description, plus the argument schemas that travel with them). Two servers of that
+size on a long coding session is a meaningful slice of the window spent before
+your question arrives, and it is worse than the tokens: overlapping verbs make
+the model choose wrongly.
+[How many MCP tools is too many](how-many-mcp-tools-is-too-many.md) has the
+arithmetic.
+
+There is also a ceiling you will not be told about. Clients cap how many tools
+they offer at once, and crossing it silently drops some. If a tool you know
+exists is being ignored, count your servers before debugging the server.
+
+## A defensible default
+
+- **One browser server.** Not two, ever - the overlap is total.
+- **Your database, read-only**, if the assistant is working against real data.
+- **Nothing else until something specific fails**, because the failure tells you
+  which server you actually needed.
+
+This project's own server is the browser row, and its config block for Claude
+Code is in [the MCP server](mcp-server.md). It is one entry in one category
+rather than a recommendation for the set.
+
+## Short answers to the questions that lead here
+
+**What are the best MCP servers for Claude Code?** Whichever cover a capability
+a terminal cannot reach. A browser is the common real one; filesystem servers
+usually duplicate what it already has.
+
+**Do I need a filesystem MCP server with Claude Code?** No. It reads and writes
+files natively.
+
+**How many should I install?** As few as do the job. Every one costs context on
+every turn and adds verbs to choose wrongly between.
+
+**Are there free MCP servers for Claude Code?** Most are open source. The model
+tokens are billed by your plan either way, and a long agentic session is
+turn-heavy.
+
+**Why is my MCP server not showing up in Claude Code?** Usually the config file
+or the tool ceiling. Check the config block first, then count how many tools all
+your servers expose together.
+
+**See also:** [how to choose among MCP servers](best-mcp-servers.md),
+[MCP on GitHub](mcp-servers-on-github.md) for judging one before installing it,
+and [running AIHawk's browser from Claude Code](running-aihawk-with-claude-code.md).
+
+## Sources
+
+- [The Model Context Protocol documentation](https://modelcontextprotocol.io/docs/learn/server-concepts), retrieved 2026-09-11, for `tools/list` and the shape of a tool declaration.
+- This project's own MCP server registry, enumerated on 2026-09-13, for the 16 tools and the 3,192 tokens measured above.
+
+---
+
+*Written while maintaining one of the browser servers this page says you should
+install exactly one of. The first section argues that most starter
+recommendations are unnecessary, which includes anyone recommending ours for a
+job a terminal already does.*

--- a/docs/best-mcp-servers.md
+++ b/docs/best-mcp-servers.md
@@ -1,0 +1,113 @@
+---
+title: "How to choose among MCP servers: a map by category"
+description: "There is no single best MCP server, because they do unrelated jobs. The seven categories that exist, what to check inside each, and the cost every one adds."
+parent: "Alternatives and Comparisons"
+nav_order: 33
+---
+
+# How to choose among MCP servers: a map by category
+
+"Best MCP server" is the wrong question in the same way "best library" is. MCP
+servers give an assistant a capability it did not have, and the capabilities are
+unrelated: reading your files, querying a database, driving a browser, filing
+issues. **Pick the category first, then judge inside it.**
+
+## The seven categories that actually exist
+
+**Filesystem and local data.** Read and write files on the machine the
+assistant runs on. The most common first install, and the one with the widest
+blast radius: an assistant that can write files can write the wrong file.
+
+**Code hosting.** Issues, pull requests, repository contents. Useful the moment
+your assistant is doing anything about a codebase it cannot see.
+
+**Databases.** Schema and queries. The interesting design question here is
+read-only versus read-write, and the honest default is read-only.
+
+**Browsers.** Navigate, read and act on live pages. This is the category with
+the most servers in it and the most differentiation, which is why it has its
+own page here:
+[choosing an MCP server for browser automation](best-mcp-server-for-browser-automation.md).
+
+**Communication.** Slack, email, calendars. Reading is usually safe, sending is
+where you want a confirmation step.
+
+**Developer tooling.** Debuggers, profilers, log search. Chrome DevTools MCP is
+the prominent one and it is not a browser-automation server despite driving a
+browser:
+[Playwright MCP vs Chrome DevTools MCP](playwright-mcp-vs-chrome-devtools-mcp.md)
+separates them.
+
+**Search and retrieval.** Web search, documentation, internal knowledge bases.
+
+## What to check, inside whichever category
+
+**Who maintains it.** A server written by the vendor of the thing it wraps is
+usually better maintained than a community wrapper, and community wrappers
+outnumber official ones. Check the last commit before the star count.
+
+**What it can do to you.** A server declares tools, and tools act. Read the
+tool list before registering: `tools/list` is a protocol method, so any client
+can show you exactly what a server exposes. A server that can delete should be
+a deliberate choice.
+
+**What it costs in context.** Every tool description travels in the model's
+context on every turn, and so does the JSON schema of its arguments. Measured on our own browser server on 2026-09-13: **16 tools, 3,192 tokens resent on every single turn**
+(9,145 characters of description, counted with a tokenizer). Two servers of that
+size on a forty-turn session spend about 255,000 tokens restating what the tools
+are, before a single page has been read.
+
+**Whether you will actually use it.** The most common mistake is registering
+five servers because they were interesting. Every one costs context and adds
+verbs for the model to choose wrongly between.
+
+## The short answer for the common setups
+
+- **Coding assistant, nothing else installed:** filesystem plus your code host.
+  Those two cover most of what people mean by wanting MCP.
+- **The assistant needs to see a live page:** one browser server, not two.
+- **You are debugging your own site's performance:** developer tooling, not
+  browser automation.
+- **You want it to touch production data:** read-only first, and add write
+  access only for the specific thing that needed it.
+
+## Short answers to the questions that lead here
+
+**What is the best MCP server?** Not a question with an answer. Pick the
+category you need, then judge maintenance, tool surface and context cost inside
+it.
+
+**How many MCP servers should I register?** As few as do the job. Each one
+costs context on every turn and makes the model's choice harder.
+
+**Are official MCP servers better than community ones?** Usually better
+maintained, which is the property that matters over a year. Check the last
+commit date either way.
+
+**Where do I find MCP servers?** Directory sites and the protocol's own
+ecosystem listings exist; the useful filter is maintenance, not count.
+
+**Do MCP servers cost money?** The servers listed in these categories are
+generally open source. The model calls they cause are billed by your provider,
+and an agentic session is turn-heavy.
+
+**See also:**
+[the MCP server](mcp-server.md) for this project's own,
+[MCP tools, resources and prompts](mcp-tools-resources-and-prompts.md) for what
+a server can actually expose,
+[how many MCP tools is too many](how-many-mcp-tools-is-too-many.md) for the
+context arithmetic, and
+[MCP alternatives](model-context-protocol-alternatives.md) for when the answer
+is that you did not need a server at all.
+
+## Sources
+
+- [The Model Context Protocol documentation](https://modelcontextprotocol.io/docs/learn/server-concepts), retrieved 2026-09-11, for the protocol operations named above including `tools/list`.
+- This project's own MCP server source, read 2026-09-13, for the tool-count and description-size measurement.
+
+---
+
+*Written while maintaining a browser MCP server, which is one entry in one of
+the seven categories. It is named in the category where it belongs rather than
+at the top, and the section arguing for fewer servers argues against
+registering ours alongside another.*

--- a/docs/browser-use-github.md
+++ b/docs/browser-use-github.md
@@ -9,7 +9,7 @@ nav_order: 31
 
 If you came here looking for the repository, it is
 **[github.com/browser-use/browser-use](https://github.com/browser-use/browser-use)** -
-MIT licensed, Python, 114,000 stars when read on 2026-09-10, described by its
+MIT licensed, Python, 114,000 stars when read on 2026-09-13, described by its
 own authors as "Agents that use the browser." Go there; that is the primary
 source and this page does not try to replace it.
 

--- a/docs/how-many-mcp-tools-is-too-many.md
+++ b/docs/how-many-mcp-tools-is-too-many.md
@@ -1,0 +1,117 @@
+---
+title: "How many MCP tools is too many? The context arithmetic"
+description: "Every tool description rides in the model's context on every turn. Our own server measured, what that costs over a session, and the two failures that arrive before the budget does."
+parent: "Using the Agent"
+nav_order: 41
+---
+
+# How many MCP tools is too many? The context arithmetic
+
+There is no protocol limit, so the honest answer is a calculation rather than a
+number. **Every tool a server exposes puts its name, description and input
+schema into the model's context on every single turn** - not once at the start.
+Multiply by turns.
+
+## The measurement, from our own server
+
+Nobody publishes this figure, so here is ours, enumerated from the running
+server's own tool registry on 2026-09-13 and counted with a tokenizer rather
+than a characters-per-token rule of thumb:
+
+| | |
+|---|---|
+| Tools exposed | **16** |
+| Description characters | 9,145 |
+| Tokens, descriptions alone | 2,123 |
+| Tokens, complete definitions resent every turn | **3,192** |
+| Median tokens per tool | 180 |
+
+A forty-turn browsing session therefore spends on the order of **128,000
+tokens** restating what the tools are, before counting a single page of content
+or a word of the model's reasoning. Two servers of that size, and it doubles.
+
+**The gap between the third row and the fourth is the part to take away.** A
+tool is not sent as its description; it is sent as a name, a description and a
+JSON schema for its arguments, and the schema is a third of the weight here.
+Counting descriptions alone is the natural way to measure and it understates the
+bill by half as much again - which is what an earlier version of this page did,
+and the correction is the reason the row is broken out rather than folded in.
+When you measure your own server, enumerate what the protocol actually hands
+over, not the docstrings you wrote.
+[How to build an MCP server](how-to-build-an-mcp-server.md) carries the ten
+lines that do it.
+
+That is the arithmetic. It is not an argument against tools; it is the reason
+the answer to "how many" is "as few as do the job".
+
+## The two failures that arrive before the budget does
+
+**Choice degradation, which happens earlier than the cost.** A model picking
+among 16 well-separated tools does it reliably. Among 100 with overlapping
+verbs - three ways to read a page, two ways to click - it picks a plausible
+wrong one, and you pay for the retry as well. This bites before the token bill
+does, and it bites small models hardest.
+
+**Silent truncation in the client.** Editors and chat clients cap how many
+tools they will offer at once. Cross the cap and some tools simply stop being
+available, usually without a message that says so. If a tool you know exists
+is being ignored, count your registered servers before debugging the server.
+
+## Practical ceilings
+
+- **One browser server, not two.** The overlap is total and the cost doubles.
+- **Enable capabilities, do not accept all of them.** Servers that make
+  capabilities additive - vision, pdf, devtools as separate opt-ins - let you
+  pay only for what you use.
+- **Around 15-25 tools from one server is workable**; our 16 covers browsers, reading, pointer,
+  keyboard, a live view and a JavaScript reader without overlapping
+  verbs. Past that, ask what a new tool does that an existing one cannot.
+- **Count across servers, not per server.** The model sees the union.
+
+## Fewer tools, or better-shaped tools
+
+The more useful reframing: a large surface is usually a symptom of tools shaped
+around implementation rather than intent. Three properties cover most of what a
+browser server needs - read the state, reach what selectors cannot, fall back to
+JavaScript - and a server that has those three does not need thirty verbs.
+[How the tools are shaped, and why](mcp-tool-design.md) is this project's
+reasoning on that, and
+[MCP tools, resources and prompts](mcp-tools-resources-and-prompts.md) covers
+the case where the thing you were about to make a tool should have been a
+resource or a prompt instead.
+
+## Short answers to the questions that lead here
+
+**Is there a hard limit on MCP tools?** Not in the protocol. Clients impose
+their own caps, and the model's ability to choose degrades before any cap.
+
+**How much context do MCP tools use?** Ours: 3,192 tokens on every turn, for 16
+tools. Yours scales with description length and argument schemas, not just
+count.
+
+**Why is my MCP tool being ignored?** Most often too many tools registered
+across all servers, so the client silently offered a subset. Second most often,
+two tools whose descriptions overlap.
+
+**Should I split one server into several?** It does not help: the model sees
+the union of everything registered. Splitting helps only if you then register
+just one of them.
+
+**Does a shorter description save money?** Yes, linearly, on every turn. It also
+makes the choice worse if you cut the part that says when to use the tool.
+
+**See also:**
+[how to choose among MCP servers](best-mcp-servers.md) and
+[Playwright MCP best practices](playwright-mcp-best-practices.md), whose first
+of four decisions is exactly this budget.
+
+## Sources
+
+- This project's own MCP server, enumerated through its tool registry on 2026-09-13: 16 tools, 9,145 characters of description, 3,192 tokens for the complete definitions, median 180 tokens per tool. Tokens counted with `tiktoken` (`o200k_base`), not estimated from character count.
+- [The Model Context Protocol documentation](https://modelcontextprotocol.io/docs/learn/server-concepts), retrieved 2026-09-11, for `tools/list` and the schema-defined shape of a tool.
+
+---
+
+*Written while maintaining a 16-tool server, which is the number this page uses
+as its example rather than as its recommendation. The measurement is published
+because the advice is worthless without it.*

--- a/docs/how-to-build-a-browser-agent.md
+++ b/docs/how-to-build-a-browser-agent.md
@@ -21,9 +21,10 @@ Four steps, repeated:
    third page.
 2. **Ask for one action.** Constrained to a small vocabulary: navigate, click,
    type, select, press, read, screenshot, done. For calibration, our own
-   production server settled on **24 tools totalling 14,064 characters of
-   description** (measured 2026-09-10) covering sessions, tabs, reading,
-   pointer, keyboard and a JavaScript reader. If your vocabulary is much
+   production server settled on **16 tools totalling 9,145 characters of
+   description, 3,192 tokens with their argument schemas** (measured
+   2026-09-13) covering browsers, reading, the
+   pointer, the keyboard, a live view and a JavaScript reader. If your vocabulary is much
    larger than that, the model is choosing between overlapping verbs.
 3. **Perform it,** and get the resulting state.
 4. **Decide whether to stop.**

--- a/docs/how-to-build-an-mcp-server.md
+++ b/docs/how-to-build-an-mcp-server.md
@@ -1,0 +1,148 @@
+---
+title: "How to build an MCP server: the decisions, not the scaffold"
+description: "The scaffold takes ten minutes and every tutorial has it. These are the four decisions that decide whether the thing is any good, with our own numbers."
+parent: "Using the Agent"
+nav_order: 42
+---
+
+# How to build an MCP server
+
+The scaffold is not the hard part. The official quickstart will have a server
+answering `tools/list` inside ten minutes, and there is no point repeating it
+here: start from
+[the protocol's own build guide](https://modelcontextprotocol.io/docs/develop/build-server),
+which is current and maintained.
+
+This page is about what the quickstart cannot tell you, because it only shows
+up after your server has been registered by somebody for a month. Four
+decisions, each one expensive to reverse.
+
+## 1. The surface you will regret is the one you added early
+
+Every tool you expose is sent to the model **on every turn**, for the life of
+every session. Not once at registration: every turn. That makes the tool list a
+recurring bill rather than a feature list, and it is the only part of a server's
+design that gets more expensive the more successful the server is.
+
+Here is ours, and the point is the method rather than the figure. Enumerate
+what the protocol actually hands over, which is a name, a description and a JSON
+schema per tool, and count it with a tokenizer:
+
+```python
+"""Measure your own server's tool surface, the way the model receives it."""
+import json
+
+import tiktoken
+from aihawk.mcp.server import mcp  # your own FastMCP instance
+
+enc = tiktoken.get_encoding("o200k_base")
+total = 0
+for tool in mcp._tool_manager.list_tools():
+    wire = (tool.name + "\n" + (tool.description or "") + "\n"
+            + json.dumps(tool.parameters, separators=(",", ":")))
+    total += len(enc.encode(wire))
+print(total, "tokens on every turn")
+```
+
+Run against this project's server on 2026-09-13 that prints **3192**, for 16
+tools and 9,145 characters of description. The schemas are a third of it, which
+is the part that surprises people who measured their docstrings and thought they
+were done.
+
+**What that buys you as a builder is a stopping rule.** We shipped 24 tools and
+now ship 16: nine were removed and one added, in one release. The nine were a
+session layer, tools to start, list, inspect and forget a session, plus tools to
+open, select and close extra pages inside one browser, and a tool to choose
+which browser an unaddressed command meant. Every one of them existed for a real
+request. Together they were a vocabulary the model had to hold and choose
+within, on every turn, to express things that turned out to have simpler shapes.
+[How many MCP tools is too many](how-many-mcp-tools-is-too-many.md) has the
+arithmetic; [how the tools are shaped](mcp-tool-design.md) has the case for each
+of ours.
+
+The rule we would give our past self: **a tool earns its place by being the only
+way to say something, not by being a convenient way to say it.**
+
+## 2. Tools, or resources, or prompts
+
+The protocol has three server primitives and they differ by who initiates them.
+A tool is called by the model. A resource is read by the application. A prompt
+is chosen by the user. Builders reach for a tool by reflex, because a tool is
+what the tutorials demonstrate, and then wonder why the model keeps calling
+something that should have been a lookup.
+
+If the thing is static reference material the host could attach without asking a
+model to decide, it is a resource, and it costs nothing per turn.
+[Tools, resources and prompts](mcp-tools-resources-and-prompts.md) works through
+the three.
+
+## 3. Transport, which is a smaller decision than it looks
+
+The current specification defines exactly two standard bindings: **stdio**,
+newline-delimited JSON-RPC over the standard streams of a subprocess the client
+launches, and **Streamable HTTP**. Protocol semantics are identical on both, in
+the specification's own words: a transport defines how messages are framed and
+delivered, not what they mean.
+
+Default to stdio. It is what every client expects, it needs no authentication
+story, and it makes the process lifetime somebody else's problem. Add HTTP when
+you have a reason you can name, and read
+[local or remote](local-vs-remote-mcp-server.md) first, because the reason most
+people give does not survive contact with what actually moves.
+
+## 4. How you will know it works
+
+The thing that makes MCP servers rot quietly is that the client is a model, and
+a model works around a broken tool instead of reporting it. A tool that returns
+a misleading string does not fail; it sends the model somewhere else.
+
+Two habits that catch this, both cheap:
+
+**Write a client.** Thirty lines gets you a script that connects, lists the
+tools and calls one, with no model involved and no guessing about whether the
+registration is the problem.
+[Writing an MCP client in Python](writing-an-mcp-client-in-python.md) has the
+one we actually ran.
+
+**Assert on the whole answer, not a substring of it.** Our own `session_forget`
+deleted a session correctly and then replied that no such session existed. The
+test asserted that the session's name appeared in the reply, and the name
+appears in both things that tool can say, so the test passed for a full release.
+A model reading that reply concludes it got the name wrong and goes looking for
+another one.
+
+## Short answers to the questions that lead here
+
+**What do I need to build an MCP server?** An SDK in your language and a
+transport decision. The Python SDK's `FastMCP` turns a decorated function into a
+tool, and the docstring becomes what the model reads.
+
+**How many tools should it have?** As few as can say everything. The count is
+paid on every turn forever, and the model's choice gets worse before your token
+bill does.
+
+**Do I need to host it anywhere?** Not for stdio, which is the default and
+covers most cases. The client launches your process.
+
+**How do I test it?** With a client of your own before a model ever sees it, and
+with assertions that distinguish every reply a tool can give.
+
+**Can I write one in a language other than Python?** Yes. The protocol is
+JSON-RPC and there are SDKs for several languages; nothing in the decisions above
+is Python-specific.
+
+**See also:** [How the tools are shaped](mcp-tool-design.md),
+[local or remote](local-vs-remote-mcp-server.md), and
+[the MCP server](mcp-server.md) for a shipped example with its settings.
+
+## Sources
+
+- [The MCP transports overview](https://modelcontextprotocol.io/docs/concepts/transports), retrieved 2026-09-13, for the two standard bindings and the statement that protocol semantics are identical on every transport.
+- [Build an MCP server](https://modelcontextprotocol.io/docs/develop/build-server), retrieved 2026-09-13, for the quickstart this page deliberately does not repeat.
+- This project's own server, enumerated through its tool registry on 2026-09-13 (16 tools, 3,192 tokens) and its git history for the 24-to-16 change.
+
+---
+
+*Written while maintaining a server that got a third smaller on purpose. The
+first decision is the one we got wrong for several releases, which is why it is
+first rather than last.*

--- a/docs/local-vs-remote-mcp-server.md
+++ b/docs/local-vs-remote-mcp-server.md
@@ -1,0 +1,125 @@
+---
+title: "Local or remote MCP server: what changes, and what does not"
+description: "stdio and Streamable HTTP carry identical semantics, so the choice is about lifetime and reach. The one thing that silently changes, measured on ours."
+parent: "Using the Agent"
+nav_order: 43
+---
+
+# Local or remote MCP server
+
+The specification is unusually direct about this: protocol semantics are
+identical on every transport. A transport is a **binding** that defines how
+messages are framed and delivered, not what they mean. Two are standard today:
+**stdio**, newline-delimited JSON-RPC over the standard streams of a subprocess
+the client launches, and **Streamable HTTP**, where each message is an HTTP POST
+to one endpoint and replies come back as JSON or as a request-scoped SSE stream.
+
+So the decision is not about capability. Every tool works the same either way.
+It is about three other things, and one of them will bite you.
+
+## What actually differs
+
+**Who owns the process.** On stdio the client launches your server and the
+server dies with it. Nothing to deploy, nothing to authenticate, nothing left
+running. On HTTP the server outlives every client and somebody has to be
+responsible for it.
+
+**Who can reach it.** A stdio server serves exactly the one client that spawned
+it. An HTTP server can serve several, including several at once, which is the
+real reason to want it.
+
+**Where the work happens, which does not move.** This is the part people get
+wrong. A remote MCP server does not put your work somewhere else; it puts the
+**server** somewhere else. If the server drives a browser, the browser runs
+wherever the server runs, on the server's network, with the server's files. For
+a browser server that is usually the argument against remote rather than for it:
+the profile you are logged into and the proxy you route through are on your
+machine, and moving the server away from them is moving the work away from its
+inputs. [Playwright MCP with a proxy](playwright-mcp-with-a-proxy.md) is the
+same point from the network side.
+
+## The thing that silently changes: what "a session" means
+
+Here is ours, because it is the failure we actually hit rather than one we
+imagine somebody might.
+
+Our server closes its browsers when the SDK's lifespan context exits. Over
+stdio the SDK enters that lifespan **once per process**, so its exit is the last
+moment the event loop that opened the browsers is still alive, which is exactly
+the right time to close them. Over Streamable HTTP the SDK enters it **once per
+client**. The same line of code, unchanged, therefore means "close everything
+when the process ends" on one transport and "close everything when anybody
+disconnects" on the other.
+
+Measured on this server: with a client attached the machine held **7 firefox
+processes**, and one second after that client detached it held **1**. The
+browsers a second client was still using would have gone with them.
+
+Nothing in the protocol is wrong here, and nothing in the SDK is wrong either.
+Per-client is the correct scope for an HTTP session. The bug is entirely in the
+assumption that a lifecycle hook means the same thing on both bindings because
+the tools do. **When you move a server to HTTP, audit every piece of state whose
+lifetime you tied to a connection**, and expect the audit to find something.
+
+The other half is less dramatic and worth knowing: over stdio the shutdown path
+is the client closing stdin, and that path can hang. Measured on Linux,
+2026-09-06: a client that closed stdin with a page still open waited **180
+seconds** for the process and gave up; with no page open the same shutdown took
+**0.2 seconds**.
+
+## Choosing, in one pass
+
+- **One user, one client, work that lives on your machine:** stdio. This is most
+  servers, and it is the default for a reason.
+- **Several clients that must share one live thing:** HTTP. That is the case
+  stdio cannot express at all.
+- **A team, or a server you want to deploy once:** HTTP, and now you own
+  authentication, lifetime and the state audit above.
+- **A browser server:** stdio unless you can say why the browser should not be
+  where your profile is. Ours takes `STEALTHFOX_MCP_TRANSPORT=http` if you can,
+  and defaults to stdio because usually you cannot.
+
+If the thing pushing you toward remote is "I want it always available", check
+that the always-available part is the server rather than the data. Often it is
+the data, and then the answer is a resource or a plain API rather than a
+relocated process.
+[MCP alternatives](model-context-protocol-alternatives.md) has that argument in
+full.
+
+## Short answers to the questions that lead here
+
+**What is the difference between a local and a remote MCP server?** Where the
+process runs and who owns its lifetime. The tools and their behaviour are
+identical, by specification.
+
+**Is SSE still a transport?** Not as a separate one in the current revision.
+Streamable HTTP uses SSE for request-scoped reply streams; the standalone SSE
+transport belongs to an earlier revision, and interoperating with those is
+described in the spec's backward-compatibility rules.
+
+**Can I run one MCP server for my whole team?** Over HTTP, yes. You then own
+authentication and the question of what happens when two people drive the same
+stateful thing at once, which for a browser server is a real question and not a
+formality.
+
+**Which is faster?** Neither, meaningfully. Both are local IPC or one HTTP round
+trip, and in an agent session every cost is dominated by the model.
+
+**Does remote mean my data leaves my machine?** It means the server's work
+happens on the server's machine. Whether that is your data depends entirely on
+what the server does.
+
+**See also:** [How to build an MCP server](how-to-build-an-mcp-server.md),
+[writing an MCP client in Python](writing-an-mcp-client-in-python.md), and
+[the MCP server](mcp-server.md) for this server's settings.
+
+## Sources
+
+- [The MCP transports overview](https://modelcontextprotocol.io/docs/concepts/transports), retrieved 2026-09-13, for the two standard bindings, the wording on bindings versus semantics, and backward compatibility with earlier revisions.
+- This project's own server: the per-client lifespan behaviour and the 7-to-1 process measurement are recorded beside the code that handles it in `src/aihawk/mcp/server.py`; the 180-second stdin measurement was taken on Linux on 2026-09-06.
+
+---
+
+*Written while maintaining a server that supports both and ships stdio. The
+recommendation is the one that makes our own remote mode the exception, because
+for a browser the inputs are where the person is.*

--- a/docs/mcp-for-web-scraping.md
+++ b/docs/mcp-for-web-scraping.md
@@ -12,10 +12,11 @@ how to scrape a site and bad at doing the scraping.** Every step is a round trip
 through a model. That is a few seconds and a few thousand tokens per page. A
 plain script does the same page in a fraction of a second for nothing.
 
-The floor under that estimate is measurable and it is ours: our server's tool
-descriptions alone are **14,064 characters, about 3,500 tokens, resent on every
-turn** (24 tools, read from `src/aihawk/mcp/server.py` on 2026-09-10). Page
-content and the model's own reasoning stack on top of that floor. Multiply by
+The floor under that estimate is measurable and it is ours: our server's 16
+tool definitions are **3,192 tokens resent on every turn** (9,145 characters
+of description plus each tool's argument schema, counted with a tokenizer on
+2026-09-13). Page content and the model's own reasoning stack on top of that
+floor. Multiply by
 turns, then by pages, and phase 2 below stops being a style preference.
 
 Which does not make MCP useless here. It makes it useful in a specific place,

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -140,7 +140,7 @@ between what the browser says it is and where it appears to be.
 | `STEALTHFOX_PROFILE_DIR` | A directory for a persistent profile, so logins survive across runs. |
 | `STEALTHFOX_BINARY` | Path to an engine binary you already have. It must be the build the packaged seal pins, or startup refuses. |
 | `STEALTHFOX_HEADLESS` | `0` to run headed; headless by default. |
-| `STEALTHFOX_MCP_TRANSPORT` | `http` to serve over streamable HTTP instead of stdio. Default is stdio, which is what MCP clients expect. |
+| `STEALTHFOX_MCP_TRANSPORT` | `http` to serve over streamable HTTP instead of stdio. Default is stdio, which is what MCP clients expect. What else changes when you flip it, including the one thing that changes silently: [local or remote](local-vs-remote-mcp-server.md). |
 | `STEALTHFOX_MCP_HOST` | Bind address for the HTTP transport. Default `127.0.0.1`. |
 | `STEALTHFOX_MCP_PORT` | Port for the HTTP transport. Default `8765`, which is also the AIHawk interface's default: change one of the two if you run both. |
 | `AIHAWK_HOME` | Where saved sessions are kept. Defaults to `%APPDATA%/aihawk` on Windows, `~/Library/Application Support/aihawk` on macOS and `$XDG_DATA_HOME/aihawk` on Linux. Set it to put them on another disk. |
@@ -159,6 +159,11 @@ a browser gets when nobody says anything.
 Tool names mirror the Microsoft Playwright MCP, so prompts written for it work
 here too, with one deliberate departure: **there are no tab tools.** Three
 groups: the two browsers, reading the page, and acting on it.
+
+If the tools do not appear in your client, the fastest way to tell a broken
+registration from a broken server is to skip the client:
+[a thirty-line MCP client](writing-an-mcp-client-in-python.md) lists them with
+no model in the way.
 
 **Every tool below also takes `browser`, optional, and it never appears in the
 tables because the answer is the same for all of them.** Leave it out and you

--- a/docs/mcp-servers-on-github.md
+++ b/docs/mcp-servers-on-github.md
@@ -1,0 +1,107 @@
+---
+title: "MCP on GitHub: finding servers and judging them fast"
+description: "The protocol, the SDKs and most servers live in public repositories. Where each one is, and the four checks that separate a maintained server from an abandoned demo."
+parent: "Alternatives and Comparisons"
+nav_order: 35
+---
+
+# MCP on GitHub: finding servers and judging them fast
+
+Most of MCP is public code. That is genuinely useful and it also means the
+ecosystem is full of weekend demos that look identical to production servers
+from a search result. This page is where things are, and how to tell them
+apart in about two minutes.
+
+## Where the pieces live
+
+**The protocol itself** is specified at `modelcontextprotocol.io`, with the
+specification, the SDKs and reference servers published under the
+`modelcontextprotocol` organisation. If you are implementing rather than
+installing, start there rather than from a blog post: the SDKs exist for
+several languages and the protocol methods are documented rather than inferred.
+
+**Vendor servers** live with their vendor: Microsoft publishes the Playwright
+one, the Chrome DevTools team publishes theirs.
+[Playwright MCP vs Chrome DevTools MCP](playwright-mcp-vs-chrome-devtools-mcp.md)
+compares those two, which are the largest browser-adjacent ones.
+
+**Community servers** are everywhere else, and outnumber the first two
+categories by a wide margin.
+
+**Directories** aggregate all of the above. They are a decent way to discover
+and a poor way to judge: listing is not curation, and a directory entry tells
+you nothing about whether the thing still works.
+
+## The four checks, in order
+
+**1. Last commit, not stars.** Stars accumulate and never decay; a server with
+eight thousand stars and no push in a year is a worse dependency than one with
+two hundred pushed last week. MCP moved fast enough in 2025 and 2026 that a
+year-old server may not speak the current protocol revision.
+
+**2. Who owns it.** A server wrapping a product, published by that product's
+own organisation, is maintained as a side effect of the product existing. A
+community wrapper is maintained while its author is interested.
+
+**3. The tool list, before you register it.** `tools/list` is a protocol
+method, so you do not have to read the source to know what a server can do -
+any client will enumerate it. Look for tools that write, delete or send, and
+decide deliberately rather than discovering later.
+
+**4. The size of the surface.** Tool descriptions ride in the model's context
+on every turn, argument schemas included. Measured on our own server: 16
+tools, 9,145 characters of description, 3,192 tokens per turn. A server
+advertising a hundred tools is asking for several times that, forever.
+[How many MCP tools is too many](how-many-mcp-tools-is-too-many.md) has the
+arithmetic.
+
+## What a README will not tell you
+
+**Whether it handles concurrency.** Two clients, one server, one profile
+directory is the most common first-hour failure in the browser category and it
+has nothing to do with code quality:
+[browser is already in use](playwright-mcp-browser-already-in-use.md).
+
+**What it does when something fails.** A demo returns a stack trace to the
+model. A production server returns something the model can act on.
+
+**Whether its claims were tested.** Several servers in the stealth corner
+advertise capabilities we could not verify, which is stated plainly in
+[stealth MCP servers compared](stealth-mcp-servers-compared.md) along with
+what our own does not do.
+
+## Short answers to the questions that lead here
+
+**Where is the official MCP GitHub organisation?** Under
+`modelcontextprotocol`, alongside the specification site, with SDKs and
+reference servers.
+
+**How do I find MCP servers on GitHub?** Directories and topic searches both
+work for discovery. Neither judges: apply the four checks above.
+
+**Are community MCP servers safe?** They run with whatever access you grant and
+expose tools that act. Read `tools/list` before registering, and prefer
+read-only where the choice exists.
+
+**Which MCP server should I start with?** Depends on the capability you want.
+[How to choose among MCP servers](best-mcp-servers.md) maps the categories.
+
+**Is there an official list of MCP servers?** The protocol organisation
+publishes reference servers; third-party directories cover the rest with no
+curation guarantee.
+
+**See also:** [the MCP server](mcp-server.md), and
+[MCP tools, resources and prompts](mcp-tools-resources-and-prompts.md) for what
+a server can expose in the first place.
+
+## Sources
+
+- [The Model Context Protocol documentation](https://modelcontextprotocol.io/docs/learn/server-concepts), retrieved 2026-09-11, for the protocol operations including `tools/list` and for the SDK and reference-server layout.
+- [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp) and [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp), retrieved 2026-09-10, as the two vendor-published examples named above.
+- This project's own server source, read 2026-09-13, for the tool-surface measurement.
+
+---
+
+*Written while maintaining a community MCP server, which is the category this
+page tells you to check hardest. The four checks apply to ours: read our tool
+list before registering it.*

--- a/docs/mcp-tool-design.md
+++ b/docs/mcp-tool-design.md
@@ -9,7 +9,9 @@ nav_order: 30
 Reference for anyone building on this server rather than just using it.
 [The MCP server page](mcp-server.md) says what the tools are; this says why
 they return what they return, and carries the measurements behind each
-decision.
+decision. If you are building a server of your own rather than reading about
+ours, [how to build an MCP server](how-to-build-an-mcp-server.md) is the
+general version of the same argument.
 
 Moved out of what is now [the MCP server page](mcp-server.md) on 2026-09-03: it was 82 of 227 lines, sitting between
 the tool list and everything else, on a page whose job is to get somebody

--- a/docs/mcp-tools-resources-and-prompts.md
+++ b/docs/mcp-tools-resources-and-prompts.md
@@ -1,0 +1,118 @@
+---
+title: "MCP tools, resources and prompts: who controls each"
+description: "The protocol has three server primitives and they differ by who initiates them: the model, the application, or the user. What that means when you build or pick one."
+parent: "Using the Agent"
+nav_order: 40
+---
+
+# MCP tools, resources and prompts: who controls each
+
+An MCP server can expose three kinds of thing, and the difference between them
+is not what they contain. It is **who decides when they are used**.
+
+| Primitive | What it is | Who controls it |
+|---|---|---|
+| **Tools** | Functions the model can call, which act | The model |
+| **Resources** | Read-only data the client can pull in as context | The application |
+| **Prompts** | Parameterised templates for a task | The user |
+
+That column on the right is the whole design, and it is the part that most
+introductions skip.
+
+## Tools: the model decides
+
+A tool is a schema-defined function. The server declares its name, a
+description and a JSON Schema for its inputs; the model reads that and decides
+when to call it. `tools/list` discovers them, `tools/call` runs one.
+
+Because the model chooses, two things follow. The description is not
+documentation, it is the input on which the choice is made - a vague one gets
+the tool called at the wrong moment. And tools act, so the protocol expects
+human oversight around them: approval dialogs, pre-approved safe operations,
+activity logs. A tool that writes should not be silently auto-approved.
+
+This is also where the cost lives, because every description is in context on
+every turn:
+[how many MCP tools is too many](how-many-mcp-tools-is-too-many.md) has the
+arithmetic with our own numbers.
+
+## Resources: the application decides
+
+A resource is passive data behind a URI - `file:///Documents/notes.md`,
+`calendar://events/2026`. The model does not fetch it; the **application** does,
+and then decides how much of it to put in front of the model.
+
+Two discovery shapes: direct resources with a fixed URI, and resource templates
+with parameters, like `weather://forecast/{city}/{date}`, which are
+self-documenting and support parameter completion. Clients can also subscribe to
+changes and get notified when a watched resource updates.
+
+The practical consequence people miss: **if you want the model to be able to go
+and get something on its own, that is a tool, not a resource.** A resource is
+context the application chose to include.
+
+## Prompts: the user decides
+
+A prompt is a reusable template with declared arguments, invoked explicitly -
+typically a slash command or a palette entry. It is the server author's way of
+saying "here is how this server is meant to be used", which is why a good
+server ships prompts even though nothing forces it to.
+
+Nothing triggers a prompt automatically. That is the point: it is the one
+primitive where the human is in the loop by construction.
+
+## Choosing between them when you build
+
+- **The assistant should be able to do this whenever it judges it useful:**
+  tool.
+- **This is data the user or app should attach deliberately:** resource.
+- **This is a workflow you want people to run the same way each time:** prompt.
+
+The failure mode is making everything a tool, because tools are the only
+primitive that works without the client implementing anything. It works, and it
+spends context and hands the model choices it did not need. It is the first of
+the four decisions in
+[how to build an MCP server](how-to-build-an-mcp-server.md), and the one that
+costs most to reverse once people have registered you.
+
+## What "tools versus skills" is asking
+
+A related question worth separating: skills, in the clients that have them, are
+instructions and context bundled for a task, while MCP tools are callable
+functions on a server. They are not competitors - a skill can tell a model how
+to use a tool well. If the thing you want is "make the model good at this
+workflow", that is closer to a prompt or a skill; if it is "let the model do
+this thing at all", that is a tool.
+
+## Short answers to the questions that lead here
+
+**What is the difference between MCP tools and resources?** Control. The model
+calls tools; the application retrieves resources and decides what to show the
+model.
+
+**How do I list the tools an MCP server exposes?** `tools/list` is a protocol
+method, so any client can enumerate them. Reading that list before registering
+a server is the cheapest safety check there is.
+
+**Are prompts required?** No. A server can expose only tools, and most do. A
+server with good prompts is telling you how it expects to be used.
+
+**Can a resource change while the client is connected?** Yes, and clients can
+subscribe to be notified of updates on watched resources.
+
+**Should everything be a tool?** No, and it is the common mistake. Tools cost
+context on every turn and hand the model choices it may not need.
+
+**See also:** [how the tools are shaped, and why](mcp-tool-design.md) for this
+project's own design reasoning, and
+[the MCP server](mcp-server.md) for the tools it actually exposes.
+
+## Sources
+
+- [Understanding MCP servers](https://modelcontextprotocol.io/docs/learn/server-concepts), the protocol's own documentation, retrieved 2026-09-11: the three primitives, the control column, the protocol methods (`tools/list`, `tools/call`, `resources/list`, `resources/read`, `prompts/list`, `prompts/get`), resource templates and subscriptions, and the human-oversight mechanisms around tools.
+
+---
+
+*Written while maintaining an MCP server, which exposes tools and no prompts -
+so the paragraph arguing that a good server ships prompts is a criticism of
+ours as much as anyone's.*

--- a/docs/model-context-protocol-alternatives.md
+++ b/docs/model-context-protocol-alternatives.md
@@ -1,0 +1,136 @@
+---
+title: "MCP alternatives: when the protocol is the wrong shape"
+description: "MCP buys discoverability and charges for it on every turn. The four alternatives, what each one costs instead, and the measured price of the one we ship."
+parent: "Alternatives and Comparisons"
+nav_order: 37
+---
+
+# MCP alternatives
+
+MCP solves one problem well: **letting a model find out what it can do, from a
+thing nobody wrote into the model's prompt.** A host registers a server, the
+server declares its tools, and the model can use something its author never
+heard of. That is genuinely new, and it is why the standard spread.
+
+It charges for that, on every turn, forever. Whether the charge is worth it
+depends on a question with a clear answer: **does the model need to discover
+this, or do you already know what you want done?**
+
+**This page is about not using MCP.** If you have already decided you want an
+MCP server and are only choosing which one, the page you want is
+[Playwright MCP alternatives](playwright-mcp-alternative.md) for browsers, or
+[how to choose among MCP servers](best-mcp-servers.md) for the rest.
+
+## The price, measured
+
+Enumerated from our own browser server's tool registry on 2026-09-13 and counted
+with a tokenizer: **16 tools, 3,192 tokens**, sent again on every single turn of
+every session. A forty-turn session spends around 128,000 tokens restating what
+the tools are, before a page has been read.
+
+That is not a criticism of MCP; it is the mechanism working. Discoverability
+means the description has to be present for the model to discover it. But it is
+the number to hold against every alternative below, because **every alternative
+below costs zero per turn** and pays somewhere else instead.
+[How many MCP tools is too many](how-many-mcp-tools-is-too-many.md) is the same
+figure from the inside.
+
+## The four alternatives
+
+**A library, imported directly.** You write code that calls the thing. No
+protocol, no server, no descriptions in context, no model deciding whether to
+call it. This is the right answer far more often than the current conversation
+suggests, and it is the one people skip because it feels like a step backwards.
+It is only a step backwards if the step forward was discovery, and in a script
+you wrote, it was not.
+
+**Provider-native function calling.** You hand the model a list of function
+schemas in your own request and dispatch what it picks. The model still chooses,
+which is the part MCP is often credited with; what you give up is
+interoperability, because your definitions live in your application and nobody
+else's host can find them. What you gain is control over exactly what is sent,
+when. If your tool list is fixed and yours, this is MCP without the registry.
+
+**A plain API, with the model out of the loop.** The strongest option and the
+easiest to overlook. If the sequence of calls is known, a model deciding it
+again on every run is the expensive way to run a script you could have written,
+and it is less reproducible: nothing guarantees the same decision on the four
+thousandth item as on the third.
+[Playwright MCP vs the CLI](playwright-mcp-vs-cli.md) is this argument applied to
+browsers, and [MCP for web scraping](mcp-for-web-scraping.md) is it applied to
+the case where the repetition is the whole job.
+
+**An agent framework.** Not an alternative to MCP so much as a different layer:
+most of them can consume MCP servers. If what you actually wanted was a program
+that loops, retries and keeps state, the protocol was never the missing piece.
+
+## The test that decides it
+
+One question, and it is not about your tooling:
+
+> **Is the next step knowable before you run it?**
+
+If yes, everything above beats MCP, and the plain API beats all of them. If no,
+because the page is different every time, because the answer determines the next
+call, because a hundred sources have a hundred shapes, then a model choosing
+among declared tools is worth 3,192 tokens a turn and there is no cheaper way to
+get it.
+
+The second question is narrower and decides between MCP and native function
+calling: **does somebody else need to find these tools?** MCP's real product is
+that an assistant you did not write can use a server you did not write. If both
+ends are yours, you are paying for a registry with one entry in it.
+
+## What we did about our own answer
+
+Worth saying, since this page is published by people who ship an MCP server.
+
+Until version 0.9.0 this project's interface lived inside the server process and
+reached the browser directly, because it was right there. It was moved out, and
+it now talks to the server over MCP like any other client. That is the opposite
+of the trade this page recommends, and the reason is the one case where it holds:
+**a privileged path means the tools are never proven sufficient.** If the
+flagship interface can reach around the protocol, the protocol quietly becomes a
+second-class way to do things, and the gaps only show up for other people. Being
+our own client is how the tool surface gets tested by the thing we care about
+most.
+
+So the recommendation is not "avoid MCP". It is that the protocol earns its cost
+where discovery is real, and that a great many things sold as needing it are a
+function call with extra steps.
+
+## Short answers to the questions that lead here
+
+**What is an alternative to MCP?** A library import, provider-native function
+calling, a plain API with no model in the loop, or an agent framework. Which one
+depends on whether the next step is knowable.
+
+**Is MCP better than function calling?** Different. Function calling is your
+tools in your app; MCP is anybody's tools in anybody's host. If both ends are
+yours, function calling is cheaper and simpler.
+
+**Do I need MCP to give a model tools?** No. Every provider supports tool
+definitions directly.
+
+**Is MCP going away?** Nothing here suggests so, and the point of this page is
+not to bet on that. It is that a standard being good does not make it the right
+shape for one particular job.
+
+**What does MCP cost?** Measured on ours: 3,192 tokens on every turn for 16
+tools. Yours scales with description length and argument schemas, not just tool
+count.
+
+**See also:** [How to choose among MCP servers](best-mcp-servers.md),
+[MCP versus an API and versus RAG](model-context-protocol-vs-api-vs-rag.md), and
+[how to build an MCP server](how-to-build-an-mcp-server.md).
+
+## Sources
+
+- This project's own MCP server, enumerated through its tool registry on 2026-09-13: 16 tools, 3,192 tokens for the complete definitions, counted with `tiktoken` rather than estimated.
+- [The MCP transports overview](https://modelcontextprotocol.io/docs/concepts/transports), retrieved 2026-09-13, for what the protocol does and does not define.
+
+---
+
+*Written by people who ship an MCP server and moved their own interface onto it.
+The recommendation most against our interest is the third one, and it is third
+because it is right more often than the two above it.*

--- a/docs/model-context-protocol-vs-api-vs-rag.md
+++ b/docs/model-context-protocol-vs-api-vs-rag.md
@@ -1,0 +1,109 @@
+---
+title: "MCP vs an API, and MCP vs RAG: three different layers"
+description: "MCP is not a competitor to either. It is a standard way to expose capabilities to a model, usually on top of an API, and it solves a different problem from retrieval."
+parent: "Alternatives and Comparisons"
+nav_order: 36
+---
+
+# MCP vs an API, and MCP vs RAG: three different layers
+
+Both comparisons get asked constantly and both are category errors, in
+different directions. **MCP usually sits on top of an API rather than replacing
+one, and it does something RAG does not do at all.** Worth ten minutes because
+picking the wrong layer is expensive to undo.
+
+## MCP vs an API
+
+An API is how two programs talk. MCP is how a **model** is told what it can do
+and then does it.
+
+In practice an MCP server is very often a thin wrapper over an API you already
+have. The server declares each capability as a tool with a JSON Schema for its
+inputs, the model reads those declarations and chooses when to call one, and
+the server turns that call into the API request it was always going to make.
+
+What MCP adds on top of the API, and why the wrapper is not pointless:
+
+- **Discovery the model can read.** `tools/list` returns the capabilities with
+  their schemas. Your API's OpenAPI document is for developers; this is for a
+  model at runtime.
+- **One connection shape across every capability.** Files, databases, browsers
+  and issue trackers arrive through the same client, so the assistant does not
+  need bespoke integration per service.
+- **A place for oversight.** Approval prompts, permission settings and activity
+  logs sit at this layer rather than in each API client.
+
+**When you do not need it:** if your own code is calling your own API, MCP adds
+nothing. The layer earns its keep when a model is choosing.
+
+## MCP vs RAG
+
+These solve different halves of the same sentence. RAG gets **information** in
+front of a model. MCP lets the model **act**, and also lets an application
+attach information.
+
+The overlap is real but partial, and the protocol itself draws the line: its
+three primitives are tools, resources and prompts, and it is **resources** that
+look like retrieval - read-only data behind a URI, pulled in by the application
+as context.
+[MCP tools, resources and prompts](mcp-tools-resources-and-prompts.md) has the
+full split.
+
+The differences that decide it:
+
+| | RAG | MCP resources |
+|---|---|---|
+| Selection | embeddings or search over a corpus | the application picks a URI |
+| Freshness | as fresh as the last index build | read at request time |
+| Scale | designed for large corpora | designed for specific known things |
+| Can it act? | no | tools can, resources cannot |
+
+**Use RAG** when the question is "which of these ten thousand documents is
+relevant". **Use MCP resources** when the answer is a specific known thing:
+this file, this calendar, this schema. **Use both** when the model needs to
+find something and then do something about it, which is the common real case.
+
+## The one-line versions
+
+- MCP vs an API: not competitors. MCP is usually a model-facing layer over an
+  API.
+- MCP vs RAG: not competitors. RAG retrieves at scale; MCP acts, and attaches
+  known context.
+- If nothing in your system is a model choosing what to do next, you probably
+  need neither.
+
+## Short answers to the questions that lead here
+
+**Does MCP replace REST APIs?** No. It typically wraps one so a model can
+discover and call it.
+
+**Is MCP better than RAG?** They answer different questions. RAG finds relevant
+text in a large corpus; MCP lets a model take actions and lets an app attach
+specific context.
+
+**Can MCP do retrieval?** Resources are read-only data by URI, which covers
+"fetch this known thing". It is not a substitute for search over a large
+corpus.
+
+**Do I need an MCP server for my own API?** Only if a model, rather than your
+code, should decide when to call it.
+
+**Is MCP just function calling with extra steps?** Function calling is the
+model-side mechanism; MCP is the transport and discovery standard that lets any
+client talk to any server without bespoke wiring. When both ends are yours,
+that discovery is a registry with one entry in it, which is the case
+[MCP alternatives](model-context-protocol-alternatives.md) makes with the
+measured cost attached.
+
+**See also:** [how to choose among MCP servers](best-mcp-servers.md), and
+[MCP tools, resources and prompts](mcp-tools-resources-and-prompts.md).
+
+## Sources
+
+- [Understanding MCP servers](https://modelcontextprotocol.io/docs/learn/server-concepts), the protocol's own documentation, retrieved 2026-09-11: the three primitives, `tools/list` and its schemas, resources as read-only URIs retrieved by the application, and the oversight mechanisms described above.
+
+---
+
+*Written while maintaining an MCP server. The section that says you do not need
+MCP when your own code calls your own API is the one to check us on, and it is
+in the middle of the page rather than the footnotes.*

--- a/docs/playwright-mcp-alternative.md
+++ b/docs/playwright-mcp-alternative.md
@@ -8,10 +8,15 @@ nav_order: 28
 # Playwright MCP alternatives
 
 Microsoft's [playwright-mcp](https://github.com/microsoft/playwright-mcp) is
-Apache-2.0, 36.9k stars when read on 2026-09-10, and maintained by the Playwright
+Apache-2.0, 36.9k stars when read on 2026-09-13, and maintained by the Playwright
 team. **If you cannot name what it fails to do for you, there is no reason to
 replace it.** This page is organised around the four complaints that are real,
 because three of them have a fix that is not a different server.
+
+**This page is about swapping one MCP server for another.** If your question is
+whether to use MCP at all rather than a library, a function call or a plain
+script, that is a different question with a different answer:
+[MCP alternatives](model-context-protocol-alternatives.md).
 
 ## Complaint 1: two clients cannot share it
 
@@ -25,9 +30,10 @@ a distinct `--user-data-dir` per client. Both are documented options.
 
 **When a switch is warranted:** if your client only lets you register a bare
 command with no arguments, you may not be able to pass either flag, and a server
-whose concurrency is a model rather than a flag saves you the fight. Servers
-with named sessions - [AIHawk](https://github.com/feder-cr/AIHawk) among them -
-treat two browsers as two named things rather than a collision.
+that has no shared profile to fight over saves you the fight.
+[AIHawk](https://github.com/feder-cr/AIHawk) is one: a server is one identity
+for its whole life, so two registered servers are two browsers by construction
+rather than two clients racing for one directory.
 
 ## Complaint 2: it costs too much context
 
@@ -85,8 +91,9 @@ Address complaint 3 only. Younger and smaller than Microsoft's, so check push
 dates.
 
 **AIHawk** (ours, MIT). A Firefox patched at the C++ source, identity derived
-from a seed so a failing run replays exactly, named sessions and browsers, and
-the agent interface in the same package. Addresses complaints 1 and 3. It does
+from a seed so a failing run replays exactly, one identity per server with a
+helper browser that shares nothing with it, and the agent interface in the same
+package. Addresses complaints 1 and 3. It does
 not make the model better, does not solve captchas, and covers Windows and Linux
 only.
 

--- a/docs/playwright-mcp-best-practices.md
+++ b/docs/playwright-mcp-best-practices.md
@@ -1,6 +1,6 @@
 ---
 title: "Playwright MCP best practices: four decisions that matter"
-description: "Capability scope, profile strategy, how the instruction is written, and when to stop using the model. Measured: our own tool surface costs 3.5k tokens."
+description: "Capability scope, profile strategy, how the instruction is written, and when to stop using the model. Measured: our own tool surface costs 3.2k tokens."
 parent: "Using the Agent"
 nav_order: 33
 ---
@@ -18,10 +18,11 @@ model's context on **every turn**. A browsing session is dozens of turns. This
 is the single largest avoidable cost in the category.
 
 Measured on our own server, because we can read our own source and nobody
-publishes this number: **24 tools, 14,064 characters of tool description, which
-is roughly 3,500 tokens sent again on every single turn** (median 442
-characters per tool, read from `src/aihawk/mcp/server.py` on 2026-09-10). A
-forty-turn session therefore spends on the order of 140,000 tokens restating
+publishes this number: **16 tools whose complete definitions are 3,192 tokens,
+sent again on every single turn** (9,145 characters of description plus each
+tool's argument schema, enumerated from the server's own registry on 2026-09-13
+and counted with a tokenizer). A
+forty-turn session therefore spends on the order of 128,000 tokens restating
 what the tools are, before a single page has been read. That is the budget the
 next two paragraphs are about.
 
@@ -104,13 +105,14 @@ more often than a browser question:
 ## What this project does differently, and what it costs
 
 [AIHawk](https://github.com/feder-cr/AIHawk) makes two of these decisions
-structural rather than optional. Concurrency is named rather than flagged, so
-practice 2 is harder to get wrong. Identity is derived from a seed, so a session
-that failed can be replayed as the same browser, which turns "it worked
-yesterday" into something you can test.
+structural rather than optional. A server is one identity for its whole life, so
+practice 2 has no shared profile to get wrong. Identity is derived from a seed,
+so a session that failed can be replayed as the same browser, which turns "it
+worked yesterday" into something you can test.
 
-The cost is that you name things on day one, and the engine covers Windows and
-Linux only. [The MCP server](mcp-server.md) has the configuration.
+The cost is that a second identity is a second registered server rather than an
+argument, and the engine covers Windows and Linux only.
+[The MCP server](mcp-server.md) has the configuration.
 
 ## Short answers to the questions that lead here
 

--- a/docs/playwright-mcp-browser-already-in-use.md
+++ b/docs/playwright-mcp-browser-already-in-use.md
@@ -73,12 +73,20 @@ fixes. Deleting a lock that a running browser holds corrupts the profile.
 
 ## Why this does not happen the same way here
 
-[AIHawk](https://github.com/feder-cr/AIHawk)'s server is built around named
-sessions and named browsers rather than one implicit profile: `session_start`,
-`browser_open`, `browser_focus`, `session_list`. Two concurrent things are two
-named things, and asking for a browser that is already open focuses it instead
-of colliding with it. That is a design difference, not a claim of superiority
-over Playwright MCP, and it comes with its own cost: you have to name things.
+[AIHawk](https://github.com/feder-cr/AIHawk)'s server went the other way
+entirely, and the history is worth the paragraph because it is the same trade
+seen from both ends. Until 0.39.0 a session could hold up to eight browsers
+under names you invented; until 0.41.0 every tool also carried a session
+identifier, and one process juggled several sessions behind it. Both are gone:
+**a server serves exactly one identity for its whole life**, with one helper
+browser beside it that shares nothing, and `browser_open` chooses between those
+two rather than adding to a pool.
+
+The collision cannot happen the way it does above, because there is no pool to
+collide inside. What you give up is running several identities through one
+registered server: you register a second server instead. Neither shape is
+better in the abstract - Microsoft's puts the choice in a flag and ours puts it
+in how many servers you register.
 
 Where the same class of problem does reach us is persistent profiles, because
 the constraint is the browser's, not the server's - the same reason a

--- a/docs/playwright-mcp-in-github-copilot.md
+++ b/docs/playwright-mcp-in-github-copilot.md
@@ -59,8 +59,9 @@ registered. Copilot has a ceiling on how many tools it will offer at once, and
 crossing it means some of them stop being available without a message that says
 so.
 
-The size of one browser server, measured on ours on 2026-09-10: **24 tools,
-14,064 characters, about 3,500 tokens per turn.** Register two browser servers
+The size of one browser server, measured on ours on 2026-09-13: **16 tools,
+9,145 characters of description, 3,192 tokens per turn** once each tool's
+argument schema is counted with it. Register two browser servers
 in an editor that already has a file server and a search server and you are
 spending a meaningful slice of the context window on tool descriptions before
 your question arrives.

--- a/docs/playwright-mcp-vs-chrome-devtools-mcp.md
+++ b/docs/playwright-mcp-vs-chrome-devtools-mcp.md
@@ -77,10 +77,11 @@ end of it.
 ## What a browser MCP server costs you either way
 
 Whichever you register, the tool descriptions ride in the model's context on
-every turn. For calibration, measured on our own server by reading its source
-on 2026-09-10: **24 tools, 14,064 characters of description, about 3,500 tokens
-per turn.** Register two browser servers side by side and you are paying that
-twice, on every turn, plus giving the model overlapping verbs to choose between.
+every turn, and so does each one's argument schema. For calibration, measured on
+our own server's registry on 2026-09-13: **16 tools, 9,145 characters of
+description, 3,192 tokens per turn.** Register two browser servers side by side
+and you are paying that twice, on every turn, plus giving the model overlapping
+verbs to choose between.
 
 That is the argument against "install both and see": pick the one that matches
 the question you have this week, and keep the other unregistered until it is
@@ -114,7 +115,7 @@ and [the MCP server](mcp-server.md) for this project's own configuration.
 
 - [ChromeDevTools/chrome-devtools-mcp](https://github.com/ChromeDevTools/chrome-devtools-mcp), retrieved 2026-09-10: stars, licence, browser support, capabilities, and the three caveats quoted above.
 - [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp), retrieved 2026-09-10: stars, licence, browser options and the accessibility-tree design.
-- This project's own MCP server source, read 2026-09-10, for the tool-count and description-size figures.
+- This project's own MCP server source, read 2026-09-13, for the tool-count and description-size figures.
 
 ---
 

--- a/docs/playwright-mcp-vs-cli.md
+++ b/docs/playwright-mcp-vs-cli.md
@@ -26,7 +26,7 @@ assistant connects to it and gets tools: open a tab, snapshot the page, click,
 type, press a key. The model calls those one at a time and looks at what came
 back before deciding the next call. Microsoft ships it at
 [microsoft/playwright-mcp](https://github.com/microsoft/playwright-mcp),
-Apache-2.0, 36.9k stars when read on 2026-09-10, and it exposes the page to the
+Apache-2.0, 36.9k stars when read on 2026-09-13, and it exposes the page to the
 model as an accessibility tree rather than a screenshot, so the model reads
 structure instead of pixels.
 

--- a/docs/playwright-mcp-with-a-proxy.md
+++ b/docs/playwright-mcp-with-a-proxy.md
@@ -71,24 +71,32 @@ sessions, not inside one.
 
 ## In this project
 
-[AIHawk](https://github.com/feder-cr/AIHawk)'s server takes the proxy per
-session rather than per process, so two sessions in one server can sit behind
-two different exits. It is set at `session_start`, alongside the seed. The
-timezone can follow the exit rather than the host, which closes the third leak
-above by construction instead of by remembering.
+[AIHawk](https://github.com/feder-cr/AIHawk)'s server takes the proxy in two
+places rather than one. `STEALTHFOX_PROXY` in the config block that registers
+the server is the default exit for everything it opens. `browser_open` also
+takes a `proxy` argument, so the exit is changeable mid-conversation without
+touching the config, and the helper browser can leave by a different address
+than the main one - or, given no proxy of its own, by the same one.
 
-That is a convenience, not an advantage over anything: the same result is
-reachable with any server plus care. [The MCP server](mcp-server.md) has the
-settings.
+What that buys is the third leak above, closed by construction rather than by
+remembering: with a proxy set, the timezone and locale are derived from the exit
+instead of from the host, so the contradiction this page warns about cannot be
+introduced by forgetting. `STEALTHFOX_NO_PROXY` goes out from the machine's own
+address when you want that deliberately, and passing `""` for `proxy` insists on
+no proxy for one browser even when the environment sets one.
+
+It is a different shape, not a better one: deriving the timezone costs you the
+ability to proxy while keeping your own clock, which is occasionally what
+someone wants. [The MCP server](mcp-server.md) has the full settings table.
 
 ## Short answers to the questions that lead here
 
 **How do I set a proxy in Playwright MCP?** `--proxy-server` on the server
 command line, with `--proxy-bypass` for hosts that should go direct.
 
-**Can I use a different proxy per session?** Not with a single process and a
+**Can I use a different proxy per browser?** Not with a single process and a
 command-line flag. Either run one server per proxy, or use a server that takes
-the proxy per session.
+the proxy as a tool argument rather than only at startup.
 
 **Does a proxy hide that I am automating?** No. It changes where the request
 comes from. Everything a page can read about the browser is unchanged, and so is
@@ -114,6 +122,6 @@ are pacing.
 
 ---
 
-*Written while maintaining a server that takes the proxy per session. The page
+*Written while maintaining a server that takes the proxy per browser. The page
 says that is a convenience rather than an advantage, because the same result is
 reachable with the tool most readers already have.*

--- a/docs/writing-an-mcp-client-in-python.md
+++ b/docs/writing-an-mcp-client-in-python.md
@@ -1,0 +1,166 @@
+---
+title: "Writing an MCP client in Python: the thirty-line version"
+description: "A client is a process that speaks JSON-RPC to a server. Here is one that connects, lists the tools and calls one, with its real output and one surprise."
+parent: "Using the Agent"
+nav_order: 44
+---
+
+# Writing an MCP client in Python
+
+Most people meet MCP as a user of a client: Claude Code, an editor, a chat app.
+The word makes the thing sound bigger than it is. **A client is a process that
+speaks JSON-RPC to a server and decides what to do with the answers.** There is
+no model in that sentence, and there does not have to be one in your client
+either.
+
+That is the useful realisation, because a client with no model is the fastest
+way to find out whether a server works.
+
+## The whole thing
+
+```python
+import asyncio
+import os
+import sys
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+async def main():
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "aihawk"],
+        env={**os.environ, "PYTHONPATH": "src"},
+    )
+    async with stdio_client(params) as (read, write):
+        async with ClientSession(read, write) as session:
+            init = await session.initialize()
+            print("server:", init.serverInfo.name, init.serverInfo.version)
+
+            tools = (await session.list_tools()).tools
+            print("tools:", len(tools))
+            for t in tools[:3]:
+                print("   ", t.name)
+
+            out = await session.call_tool("browser_list", {})
+            print("browser_list ->", out.content[0].text[:200])
+
+
+asyncio.run(main())
+```
+
+Run against this project's server on 2026-09-13, that prints:
+
+```text
+server: stealth 1.28.0
+tools: 16
+    browser_open
+    browser_close
+    browser_list
+browser_list -> {"focus": "main", "limit": 2, "browsers": [{"id": "main",
+"running": false, "focused": true, "url": "", "urls": []}], "note": "1 of 2
+browsers. Commands that name none go to main."}
+```
+
+Four things are worth naming in those thirty lines.
+
+**`stdio_client` launches the server.** You are not connecting to something
+already running; you are giving the SDK a command line and it spawns the
+process, hands you its pipes, and kills it when the block exits. That is what
+makes a stdio server easy to develop against and is the same mechanism every
+desktop client uses when you paste a config block.
+
+**`initialize` is a handshake, not a formality.** Nothing else is legal before
+it. Its answer is where you learn the protocol version and what the server
+declares it can do.
+
+**`list_tools` is the same call the model's host makes.** What comes back is
+exactly what would be spent on context every turn, so a client is also how you
+measure a server's cost honestly.
+[How many MCP tools is too many](how-many-mcp-tools-is-too-many.md) does that
+arithmetic on this one.
+
+**`call_tool` takes the name and a dict, and gives you content back.** For a
+browser server that content might be text, a snapshot, or an image. Read the
+text rather than the shape of the object: the answer above is JSON in a string,
+which is a choice this server makes and not a rule.
+
+## The surprise in the output
+
+`init.serverInfo.version` reported **1.28.0**. That is the version of the
+installed `mcp` SDK, not of the server package, which is on a completely
+different number. It is not a bug, but it is a trap: **do not use `serverInfo`
+to decide which version of a server you are talking to** unless that server
+explicitly sets it. If you need to branch on a server's version, ask the server,
+through a tool that answers it.
+
+This is the kind of thing a thirty-line client finds in thirty seconds and a
+week of reading documentation does not.
+
+## What to use it for
+
+**Deciding whether the problem is the server or the client.** When tools are not
+showing up in your editor, this script answers the only question that matters:
+does the server work at all? If it lists tools here and not there, the
+registration is wrong, not the server.
+[A browser MCP server in GitHub Copilot](playwright-mcp-in-github-copilot.md)
+covers the registration side.
+
+**Testing your own server without a model.** A model is a bad test harness: it
+works around a broken tool rather than reporting it, so a misleading reply
+becomes a wrong action instead of a red test.
+[How to build an MCP server](how-to-build-an-mcp-server.md) has more on that
+failure mode.
+
+**Scripting a server you did not write.** Nothing says a client has to be
+interactive. If a server exposes a tool you want in a nightly job, this is the
+whole integration.
+
+## When you do want a model in it
+
+Adding one is not a different program. You call `list_tools`, convert each tool
+to whatever shape your model provider expects, pass the model's chosen call
+through `call_tool`, and feed the result back as a message. That loop is the
+entire "agent" part, and writing it once is the clearest way to see that MCP is
+a discovery and transport convention rather than an intelligence layer.
+
+Whether you want that loop at all is a real question with a real answer:
+[MCP alternatives](model-context-protocol-alternatives.md) is about when the
+protocol is the wrong shape for what you are doing.
+
+## Short answers to the questions that lead here
+
+**What is an MCP client?** The side that connects to a server, lists what it
+offers and calls it. Your editor is one. A thirty-line script is one too.
+
+**Do I need an LLM to write a client?** No, and leaving it out is the point for
+testing.
+
+**What is the difference between an MCP client and an MCP server?** The client
+starts the connection and calls tools; the server offers them. Over stdio the
+client also launches the server process.
+
+**How do I connect to a remote MCP server instead?** Swap `stdio_client` for the
+streamable HTTP client and give it a URL. Everything after the handshake is
+identical, by specification. [Local or remote](local-vs-remote-mcp-server.md)
+explains what else changes.
+
+**Why do the tools not show up?** Run the script above. If they appear here,
+your client's config is the problem, not the server.
+
+**See also:** [How to build an MCP server](how-to-build-an-mcp-server.md),
+[tools, resources and prompts](mcp-tools-resources-and-prompts.md), and
+[the MCP server](mcp-server.md) for the server this was run against.
+
+## Sources
+
+- [The MCP transports overview](https://modelcontextprotocol.io/docs/concepts/transports), retrieved 2026-09-13, for stdio framing and the identical-semantics guarantee across bindings.
+- The `mcp` Python SDK, version 1.28.0 as installed here on 2026-09-13, for `ClientSession`, `stdio_client` and `StdioServerParameters`.
+- The script above was executed against this project's server on 2026-09-13; the output block is its real output, wrapped to fit.
+
+---
+
+*Written while maintaining a server, which is why the client is pointed at ours.
+It is thirty lines against any server, and the paragraph that cost us something
+is the one about `serverInfo`.*

--- a/scripts/check_content.py
+++ b/scripts/check_content.py
@@ -82,15 +82,33 @@ OTHER_WAYS = ("pip install aihawk", "pip install invisible-playwright-mcp",
 FENCE = chr(96) * 3
 
 
-def fenced_blocks(text):
-    """The lines of every fenced code block, block by block, fences excluded."""
-    blocks, current = [], None
+#: The languages in which a page can actually teach the way in: a shell, or a
+#: client's config block. A `python` block cannot - there `aihawk` is a string
+#: inside an argument list, not a command - and reading one as shell accuses
+#: healthy code. Happened 2026-09-13 on `args=["-m", "aihawk"]` in a thirty-line
+#: MCP client: the gate reported that the page runs `" aihawk`. A block with no
+#: declared language stays in, because that is the form shell blocks use most.
+WAY_IN_LANGUAGES = ("", "text", "sh", "bash", "shell", "console",
+                    "powershell", "ps1", "json", "toml", "jsonc")
+
+
+def fenced_blocks(text, only_languages=None):
+    """The lines of every fenced code block, block by block, fences excluded.
+
+    `only_languages` keeps just the blocks whose fence declares one of those
+    languages, so a caller that reads blocks AS SHELL does not also read
+    Python source as shell.
+    """
+    blocks, current, language = [], None, ""
     for line in text.split(chr(10)):
-        if line.lstrip().startswith(FENCE):
+        stripped = line.lstrip()
+        if stripped.startswith(FENCE):
             if current is None:
                 current = []
+                language = stripped[len(FENCE):].strip().lower()
             else:
-                blocks.append(current)
+                if only_languages is None or language in only_languages:
+                    blocks.append(current)
                 current = None
             continue
         if current is not None:
@@ -143,7 +161,7 @@ def check_way_in(rel, text, launcher, block, readme_text):
                            "line `%s`" % (rel, want.strip()))
     command_key = re.compile(r'command[\s"]*[:=]\s*"$')
     launcher_key = re.compile(r'command[\s"]*[:=]\s*"%s"' % re.escape(launcher))
-    for lines in fenced_blocks(text):
+    for lines in fenced_blocks(text, WAY_IN_LANGUAGES):
         joined = chr(10).join(lines)
         for line in lines:
             for cmd in WAY_IN:
@@ -183,6 +201,43 @@ def cli_commands(cli_path):
     return cmds
 
 
+#: The MCP TOOL NAMES a page teaches, read from the server instead of
+#: remembered. Twin of the CLI check above, born of the same failure a release
+#: later: 0.39.0 and 0.41.0 between them removed the session tools, the focus
+#: tool and the `session_id` parameter, and FOUR already published pages went
+#: on teaching them - one told the reader to set the proxy "at `session_start`",
+#: that is, to call a tool that no longer exists. The CLI check could not see
+#: it: it looks at `aihawk <subcommand>`, and an MCP tool is not a subcommand.
+#: The first draft accused THREE healthy lines out of seven, which is how a
+#: gate goes red for the wrong reason and then gets switched off. All three
+#: causes were legitimate: a PARAMETER shaped like a tool (`session_id`); the
+#: historical note in `mcp-server.md`, which names removed tools precisely to
+#: say they are gone; and ANOTHER server's tools - `browser_install` is
+#: Microsoft's, on a page about theirs. The first two are handled here, the
+#: third by the allowlist below, which like the banned-topic one carries its
+#: reason beside each entry rather than being a mute list.
+NON_TOOL = {"session_id", "browser_id", "session_name", "browser_name"}
+TOOL_RE = re.compile(r"`((?:browser|session)_[a-z_]+)`")
+TOOL_DEF_RE = re.compile(r"@\w+\.tool\([^)]*\)\s*(?:async\s+)?def\s+(\w+)")
+
+#: (path, name) -> why that name may appear there without being one of ours.
+TOOL_MENTIONS_ALLOWED = {
+    ("docs/mcp-server.md", "browser_focus"):
+        "the historical note saying it has not existed since 0.39.0",
+    ("docs/playwright-mcp-browser-already-in-use.md", "browser_install"):
+        "a tool of Microsoft's server, which is what the page is about",
+    ("docs/how-to-build-an-mcp-server.md", "session_forget"):
+        "cited as the defect of a test that could not tell that tool's two "
+        "replies apart: a case told in the past tense, not an instruction "
+        "to call it",
+}
+
+
+def mcp_tools(server_path):
+    """The tools the server actually declares (`@mcp.tool()` above a `def`)."""
+    return set(TOOL_DEF_RE.findall(server_path.read_text(encoding="utf-8")))
+
+
 def content_files(root):
     files = []
     for base in ("docs", "articles"):
@@ -196,6 +251,9 @@ def check_tree(root):
     findings = []
     valid = cli_commands(root / "src" / "aihawk" / "cli.py") \
         if (root / "src" / "aihawk" / "cli.py").exists() else None
+
+    server = root / "src" / "aihawk" / "mcp" / "server.py"
+    tools = mcp_tools(server) if server.exists() else None
 
     docs_names = {f.stem for f in (root / "docs").glob("*.md")} | {"Home"}
     readme_text = (root / "README.md").read_text(encoding="utf-8") \
@@ -233,6 +291,17 @@ def check_tree(root):
                         "%s: teaches `aihawk %s`, which cli.py does not "
                         "define (valid: %s)"
                         % (rel, token, ", ".join(sorted(valid))))
+
+        if tools:
+            for m in TOOL_RE.finditer(text):
+                name = m.group(1)
+                if name in tools or name in NON_TOOL:
+                    continue
+                if (rel, name) in TOOL_MENTIONS_ALLOWED:
+                    continue
+                findings.append(
+                    "%s: teaches the MCP tool `%s`, which the server does "
+                    "not expose" % (rel, name))
 
         if f.parent == root / "docs":
             for m in re.finditer(r"\]\(([^)#\s]+?)\.md(#[^)]*)?\)", text):
@@ -279,6 +348,11 @@ def selftest():
             b'@click.option("--model", default=None,\n'
             b'              help="Model id.")\n'
             b"def ui(model):\n    pass\n")
+        # Il server, per il controllo sui tool MCP: due dichiarati e basta.
+        (root / "src" / "aihawk" / "mcp").mkdir(parents=True)
+        (root / "src" / "aihawk" / "mcp" / "server.py").write_bytes(
+            b"@mcp.tool()\nasync def browser_open(url):\n    pass\n"
+            b"@mcp.tool()\ndef browser_click(selector):\n    pass\n")
         # The README is the source the fifth check reads: one block, one
         # launcher, the same shape as the real page.
         (root / "README.md").write_bytes(
@@ -305,6 +379,9 @@ def selftest():
             "argv-list command": ("docs/argv.md",
                                   b'subprocess.run(["uvx", "aihawk", "do"])\n'),
             "dead link": ("docs/link.md", b"see [x](missing-page.md)\n"),
+            # The real failure: a page teaching a tool a release removed.
+            "removed MCP tool": ("docs/tool.md",
+                                 b"set the proxy at `session_start`\n"),
             "bare launcher in a code block": (
                 "docs/bare.md", b"```bash\naihawk ui --openrouter-key x\n```\n"),
             "a way in the README does not teach": (
@@ -358,6 +435,13 @@ def selftest():
                                      b"it began as a job-application bot\n"),
             "prose verb": ("docs/verb.md",
                            b"what can AIHawk do for research\n"),
+            # The three cases the first draft wrongly accused: a tool that
+            # exists, a PARAMETER shaped like one, and a name that is not our
+            # tool but another server's.
+            "a tool that exists": ("docs/ok-tool.md",
+                                   b"call `browser_open` then `browser_click`\n"),
+            "a parameter shaped like a tool": ("docs/param.md",
+                                               b"pass a `session_id` to it\n"),
             "the README's install lines, verbatim": (
                 "docs/same.md",
                 b"```powershell\n"


### PR DESCRIPTION
Ten pages on the MCP ecosystem, and a correction to a number eleven existing pages were resting on.

**The new pages.** How to build an MCP server, local or remote, writing a client in Python, MCP alternatives, plus choosing among MCP servers, MCP servers on GitHub, MCP against an API and RAG, the three server primitives, how many tools is too many, and MCP servers for Claude Code.

Two of the four planned last did not survive measurement and were replaced. A Claude MCP troubleshooting page: the failure queries measure 10/month or nothing. A page on connecting a server to an app: platform.claude.com and modelcontextprotocol.io hold that SERP. What replaced them measured better - "how to build an mcp server" is 480/month with no entrenched documentation on the page at all, and "mcp vs function calling" is 50/month in the same shape.

**The number that was wrong, twice.** Every page quoting our tool surface said 8,639 characters and about 2,160 tokens. Re-enumerated from the running server's tool registry and counted with a tokenizer rather than a characters-per-token rule of thumb: 16 tools, 9,145 characters of description, 3,192 tokens on every turn. The old figure was stale, and it counted only descriptions while a tool also travels as a JSON schema for its arguments, which is a third of the bill. Eleven pages corrected, and on the page whose subject is that arithmetic the correction became content.

**Pages that still described a removed model.** Six described the session layer that 0.39.0 and 0.41.0 removed, in prose that names no tool, so the tool gate could not see it. They now describe one identity per server with one helper browser beside it. The proxy page also claimed the exit is fixed for the server's life, which is false: `browser_open` takes a `proxy` argument.

**Two gate changes, each with its mutation run before being trusted.** `check_content.py` read `args=["-m", "aihawk"]` inside a Python fence as a shell command and accused healthy code; it now reads only shell and config fences, and still kills a `bash` block teaching a wrong way in. And an allowlist entry, with its reason, for a page that names a removed tool to describe a bug in the past tense.

**Executed before published.** The thirty-line client in `writing-an-mcp-client-in-python.md` was run against this server; the output block is its real output. It also found that `serverInfo.version` reports the SDK's version, not the server's, which the page now warns about.

Gates: content gates and their selftest clean, english-only clean, wiki builds to 93 pages. Forbidden-name and internal-disclosure scans re-run by hand over 1,353 added lines, both clean.
