### PR TITLE
A tool the model remembers and this server lacks gets a map, not a shrug (0.44.0)

### DIFF
--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "aihawk",
   "display_name": "AIHawk",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "AI browser agent: browses, clicks, types, and reads real web pages from plain-English instructions.",
   "long_description": "AIHawk gives an MCP client a real browser to drive. The tools navigate, click, type, read and screenshot pages the way a person would, on a patched Firefox engine.\n\nThe engine is downloaded once, outside this bundle, with `uvx invisible-playwright fetch`. Until that has run, every browser tool reports that the engine is missing.",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -4,9 +4,9 @@
 # test in the suite refuses a release where the three disagree.
 [project]
 name = "aihawk-mcpb"
-version = "0.43.0"
+version = "0.44.0"
 description = "MCP bundle that runs the published aihawk package"
 requires-python = ">=3.11"
 dependencies = [
-    "aihawk==0.43.0",
+    "aihawk==0.44.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.43.0"
+version = "0.44.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/feder-cr/AIHawk",
     "source": "github"
   },
-  "version": "0.43.0",
+  "version": "0.44.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "aihawk",
-      "version": "0.43.0",
+      "version": "0.44.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/aihawk/agent.py
+++ b/src/aihawk/agent.py
@@ -154,6 +154,19 @@ def shorten(text: str, limit: int, where: str) -> str:
         text[:limit], len(text) - limit, where)
 
 
+def unknown_tool(name: str, known) -> str:
+    """What the model is told when it calls a tool this server does not have.
+
+    Written for the mistake actually made rather than for a typo in general:
+    the names it reaches for are the old session tools, and what they used to
+    do - find or start a session - is a thing that no longer needs doing.
+    """
+    return ("There is no tool called %s here. The two browsers, main and support, "
+            "are already there: nothing has to be listed, started or chosen before "
+            "acting, and every tool takes `browser` to say which one. Go straight to "
+            "the task with one of: %s." % (name, ", ".join(known)))
+
+
 class Conversation:
     """One transcript, and the loop that grows it.
 
@@ -207,6 +220,7 @@ class Conversation:
         """
         if self.tool_defs is None:
             self.tool_defs = mcp_tools_to_openai(tools)
+            self.known = [d["function"]["name"] for d in self.tool_defs]
         # Refreshed every run rather than set once: the instructions belong to
         # the server the link is talking to now, and a transcript restored from
         # disk arrived with a system message this process did not write.
@@ -275,6 +289,23 @@ class Conversation:
 
                 await say("tool", f"{name} {describe(name, args)}".strip()
                           if describe else name)
+                # ⛔ A TOOL THE MODEL REMEMBERS AND THIS SERVER DOES NOT HAVE.
+                # Earlier public versions of this server had session_list,
+                # session_start and session_status, and a model trained on
+                # that repository reaches for them: measured 2026-09-13 with
+                # the real model, `session_list` as the FIRST call in six runs
+                # out of twelve, on a page that never mentions the word. The
+                # server answered `Unknown tool: session_list` and nothing
+                # else, so the model guessed again. The loop knows the real
+                # list, so it answers here - no round trip - and says what
+                # the model was looking for: nothing has to be listed or
+                # started, the two browsers are already there.
+                if name not in self.known:
+                    text = unknown_tool(name, self.known)
+                    await say("err", text)
+                    self.messages.append({"role": "tool", "tool_call_id": call.id,
+                                          "content": text})
+                    continue
                 try:
                     text, failed = _result_text(await call_tool(name, args))
                 except Exception as exc:

--- a/src/aihawk/mcp/server.py
+++ b/src/aihawk/mcp/server.py
@@ -129,7 +129,11 @@ atexit.register(_close_sessions_at_exit)
 # went from "click the select" straight to running `s.value='beta'` as script,
 # skipping the two rungs in between - coordinates, and a screenshot - because
 # nothing had told it they were rungs.
-INSTRUCTIONS = """Drive the page the way a person would. Everything here goes
+INSTRUCTIONS = """Two browsers, `main` and `support`, are already there. There is
+nothing to list, start or choose before acting: go straight to the task with
+browser_navigate on `main`, or browser_snapshot to see what it is already on.
+
+Drive the page the way a person would. Everything here goes
 through the real pointer and the real keyboard.
 
 Try things in this order. It matters, because a page can tell the difference.

--- a/tests/test_agent_loop.py
+++ b/tests/test_agent_loop.py
@@ -1204,3 +1204,60 @@ async def test_the_brain_hands_the_link_instructions_to_the_loop():
         "the interface's brain does not hand the server's instructions to the "
         "loop: %r" % system[0]["content"][-80:])
 
+
+async def test_a_tool_the_model_remembers_and_this_server_lacks_gets_a_map():
+    """⛔ THE MODEL ASKED FOR `session_list` IN SIX RUNS OUT OF TWELVE, on a
+    page that never says the word. Earlier public versions of this server had
+    the session tools, a model trained on that repository still reaches for
+    them, and the server answered `Unknown tool: session_list` - a shrug, after
+    a round trip, and the model guessed again.
+
+    The loop knows the real list, so it answers itself: no call reaches the
+    server, the model is told that nothing has to be listed or started, and it
+    is handed the names it can use. The person watching sees the step fail
+    with that sentence rather than a bare error.
+
+    Known-bad, three: let the call through to the server; answer without the
+    real names; answer without saying the browsers are already there.
+    """
+    mcp = ScriptedMCP(tools=tools_result(tool("browser_navigate"), tool("browser_open")),
+                      results={})
+    model = ScriptedModel([
+        assistant_tool_calls(("c1", "session_list", "{}")),
+        assistant_answer("nothing to list"),
+    ])
+    seen = []
+
+    async def say(kind, text):
+        seen.append((kind, text))
+
+    convo = Conversation(model, "m")
+    tools = (await mcp.list_tools()).tools
+    await convo.run("go", mcp.call_tool, tools, say=say)
+
+    assert mcp.calls == [], (
+        "the call for a tool that does not exist went to the server: %r" % (mcp.calls,))
+    told = [m for m in model.requests[1]["messages"] if m["role"] == "tool"][-1]["content"]
+    assert "session_list" in told and "browser_navigate" in told and "browser_open" in told, (
+        "the model is not handed the real names: %r" % told)
+    assert "already there" in told and "main" in told and "support" in told, (
+        "the model is not told that the browsers exist and nothing has to be "
+        "started: %r" % told)
+    assert ("err", told) in seen, (
+        "the person watching does not see the step fail with the sentence: %r" % (seen,))
+
+
+def test_the_instructions_open_by_saying_there_is_nothing_to_start():
+    """The other half of the same defect, one step earlier: before the model
+    can reach for an old session tool, the first paragraph it reads says the
+    browsers are already there and where to begin.
+
+    Known-bad: move the paragraph down, or drop the two names from it.
+    """
+    from aihawk.mcp.server import INSTRUCTIONS
+    first = INSTRUCTIONS.split(chr(10) + chr(10))[0].lower()
+    assert "main" in first and "support" in first and "already there" in first, (
+        "the instructions do not open by saying the two browsers exist: %r" % first)
+    assert "browser_navigate" in first, (
+        "the opening does not say where to begin: %r" % first)
+


### PR DESCRIPTION
Measured 2026-09-13 with the real model, twelve runs of a task that needs both
browsers: in six of them the FIRST call of the turn was `session_list`, a tool
this server has not had since 0.10.0. The word "session" appears nowhere in
what the model reads - not the system prompt, not the instructions, not the
sixteen descriptions - so it is not something the page suggests. Earlier public
versions of this server had session_list, session_start and session_status,
and a model trained on that repository reaches for them out of habit.

The habit cannot be edited. What happens when it meets this server can. The
answer was `Unknown tool: session_list`, after a round trip, and the model
guessed again. Two changes, both on our side:

- The loop knows the real list, so a call for a tool that is not on it never
  reaches the server. The model is told that the two browsers are already
  there, that nothing has to be listed, started or chosen, and which names it
  can use. The person watching sees the step fail with that sentence.

- The instructions open by saying the same thing, one step earlier: `main` and
  `support` exist, go straight to the task with browser_navigate. Before, the
  first paragraph was about the order in which to try clicking.

Measured after, same bench, six runs: `session_list` in none of them, and every
turn shorter - five calls instead of seven or eight, about 27 seconds instead
of 45 - because the model goes straight to browser_navigate instead of listing
and opening first. It still closes `support` in six of six.

Gates: the loop is driven with a scripted model that asks for `session_list` -
no call reaches the scripted server, the reply carries the real names and the
sentence about the browsers, the narration shows the failure; and the
instructions' first paragraph names both browsers and where to begin. Four
known-bads run, four killed. 590 passed.