### PR TITLE
The ten new MCP pages linked each other and nothing else linked to them

### DIFF
--- a/docs/best-mcp-server-for-browser-automation.md
+++ b/docs/best-mcp-server-for-browser-automation.md
@@ -15,6 +15,11 @@ specific complaint, installing anything else first is a mistake.
 This page is for people with a specific complaint. Below are the four axes that
 actually separate these servers, and which one changes hands on each.
 
+Browser servers are one category among several, and the axes below are specific
+to this one: [how to choose among MCP servers](best-mcp-servers.md) is the map
+across categories, and [MCP servers on GitHub](mcp-servers-on-github.md) is how
+to judge one you found in a listing rather than in a comparison.
+
 ## Axis 1: how the model sees the page
 
 **Accessibility tree** or **pixels**. playwright-mcp defaults to the tree: the

--- a/docs/mcp-for-web-scraping.md
+++ b/docs/mcp-for-web-scraping.md
@@ -19,6 +19,11 @@ of description plus each tool's argument schema, counted with a tokenizer on
 floor. Multiply by
 turns, then by pages, and phase 2 below stops being a style preference.
 
+If the data is already in the HTML the server sends, the browser was never the
+question and neither was the protocol:
+[MCP against a plain API and against RAG](model-context-protocol-vs-api-vs-rag.md)
+is the comparison to read before this page's pattern, not after it.
+
 Which does not make MCP useless here. It makes it useful in a specific place,
 and the pattern below is what people converge on after they have paid for the
 naive version once.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -165,6 +165,11 @@ registration from a broken server is to skip the client:
 [a thirty-line MCP client](writing-an-mcp-client-in-python.md) lists them with
 no model in the way.
 
+This server exposes only tools, which is a choice rather than the only option:
+the protocol also has resources and prompts, and
+[who controls each](mcp-tools-resources-and-prompts.md) is why a browser fits
+the first and not the other two.
+
 **Every tool below also takes `browser`, optional, and it never appears in the
 tables because the answer is the same for all of them.** Leave it out and you
 get `main`, which is what a client that never mentions it has always got and

--- a/docs/playwright-mcp-in-github-copilot.md
+++ b/docs/playwright-mcp-in-github-copilot.md
@@ -66,7 +66,9 @@ in an editor that already has a file server and a search server and you are
 spending a meaningful slice of the context window on tool descriptions before
 your question arrives.
 
-Two habits keep this from biting:
+Two habits keep this from biting, and
+[MCP servers for Claude Code](best-mcp-servers-for-claude-code.md) applies the
+same budget to the other assistant most people have open:
 
 **Enable capabilities you use, not all of them.** `--caps` is additive on
 Microsoft's server. Vision, pdf and devtools off unless a page forces it.

--- a/docs/running-aihawk-with-claude-code.md
+++ b/docs/running-aihawk-with-claude-code.md
@@ -150,6 +150,14 @@ the last macOS build was `firefox-20`.
 is cached once and shared. The server process itself is per-client - each
 client starts its own - so a page open in one is not visible in the other.
 
+**What else should I register alongside it?** That is a question about your
+whole tool budget rather than about this server, because every registered
+server spends context on every turn:
+[MCP servers for Claude Code](best-mcp-servers-for-claude-code.md) goes
+through what is worth the slot, and
+[how many MCP tools is too many](how-many-mcp-tools-is-too-many.md) has the
+arithmetic measured on this one.
+
 ## Sources
 
 All retrieved 2026-09-03.

--- a/docs/stealth-mcp-servers-compared.md
+++ b/docs/stealth-mcp-servers-compared.md
@@ -110,7 +110,14 @@ the page from JavaScript after load; Patchright patches the driver. The engine
 wiki has the distinction in detail.
 
 **Which one is safest to depend on?** Judge by push date and issue tempo, not by
-star count. The survey figures above are dated for that reason.
+star count. The survey figures above are dated for that reason, and
+[MCP servers on GitHub](mcp-servers-on-github.md) is the same judgement applied
+to any listing rather than to this one category.
+
+**Is a stealth server even the category I want?** Only if the site recognising
+the browser is your actual complaint.
+[How to choose among MCP servers](best-mcp-servers.md) puts this category next
+to the others first, which is the cheaper question to answer.
 
 **See also:** [Choosing an MCP server for browser automation](best-mcp-server-for-browser-automation.md),
 [Playwright MCP alternatives](playwright-mcp-alternative.md), and


### PR DESCRIPTION
Counted after publishing #1308: the ten new pages carry five, six, seven inbound links, and almost all of them come from **inside the wave**. Four of the ten had exactly one link from the eighty-three pages that were already there, and `best-mcp-servers-for-claude-code` had **none at all** - reachable only from the sidebar.

An island gets no discovery and no equity from the corpus it was added to. It is the same defect already on record for the engine wiki (twenty-four pages with a full `See also` footer and empty prose), seen from the other side: there the links were in the wrong place on the page, here they point in the wrong direction across the corpus.

Six in-body links, each from a page whose readers would actually want the target:

- the Claude Code guide to the server budget, and to the tool arithmetic measured on this server
- the Copilot page to the same budget for the other assistant people have open
- the browser-server comparison to the category map, and to judging a server found in a listing
- the scraping page to the API-and-RAG comparison, placed before its own pattern rather than after
- the stealth survey to both of those
- the server reference to the three protocol primitives, saying why a browser fits tools and not the other two

Every page of the wave now has at least one inbound link from outside it. Content gates, selftest, english-only and the wiki build all clean; forbidden-name and internal-disclosure scans re-run by hand from the workbench, since a push from a worktree skips them silently.
