### PR TITLE
Half that page served a query with no measured demand, and the half serving 1,900 a month got 204 words

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -13,6 +13,11 @@ dropdowns, keys, screenshots, a live view of the window, and a JavaScript
 reader, on a Firefox whose fingerprint is set inside the engine rather than
 bolted onto the page.
 
+If you are still deciding whether you want a server at all rather than a
+library call, the price is the thing to weigh and it is a recurring one:
+[MCP against a plain API](model-context-protocol-vs-api-vs-rag.md) has this
+server's per-turn bill measured.
+
 The engine is [`invisible-playwright`](https://github.com/feder-cr/invisible_playwright),
 a Firefox patched at the C++ source. The server ships inside the `aihawk`
 package and is what `aihawk` runs with no subcommand: `uvx aihawk` is what a

--- a/docs/model-context-protocol-vs-api-vs-rag.md
+++ b/docs/model-context-protocol-vs-api-vs-rag.md
@@ -1,16 +1,20 @@
 ---
-title: "MCP vs an API, and MCP vs RAG: three different layers"
-description: "MCP is not a competitor to either. It is a standard way to expose capabilities to a model, usually on top of an API, and it solves a different problem from retrieval."
+title: "MCP vs an API: the decision, and what the wrapper costs"
+description: "MCP is not a competitor to an API: it is a model-facing layer on top of one. What it buys, the per-turn bill measured on our own server, and when to skip it."
 parent: "Alternatives and Comparisons"
 nav_order: 36
 ---
 
-# MCP vs an API, and MCP vs RAG: three different layers
+# MCP vs an API
 
-Both comparisons get asked constantly and both are category errors, in
-different directions. **MCP usually sits on top of an API rather than replacing
-one, and it does something RAG does not do at all.** Worth ten minutes because
-picking the wrong layer is expensive to undo.
+**MCP is not an alternative to an API. It is usually a thin layer on top of the
+API you already have, aimed at a model instead of at a developer.** So the real
+question is never which to use; it is whether the layer is worth its price, and
+the price is a number almost nobody publishes.
+
+This page answers that first, with ours measured. RAG comes after, because it
+is the other comparison people pair with this one and it is a category error in
+a different direction: RAG does something MCP does not do at all.
 
 ## MCP vs an API
 
@@ -33,8 +37,40 @@ What MCP adds on top of the API, and why the wrapper is not pointless:
 - **A place for oversight.** Approval prompts, permission settings and activity
   logs sit at this layer rather than in each API client.
 
-**When you do not need it:** if your own code is calling your own API, MCP adds
-nothing. The layer earns its keep when a model is choosing.
+### What the wrapper costs, measured
+
+Every comparison of these two skips the price, so here is ours. **A tool is not
+free to declare: its name, its description and the JSON schema for its
+arguments are sent to the model on every turn**, for the life of every session.
+Not once at registration. Every turn.
+
+Enumerated from this project's own browser server on 2026-09-13 and counted
+with a tokenizer rather than a characters-per-token rule of thumb: **16 tools,
+9,145 characters of description, 3,192 tokens on every single turn.** A
+forty-turn session spends around 128,000 tokens restating what the tools are,
+before a page has been read.
+
+Call the same API from your own code and that number is zero. Call it through
+provider-native function calling, where you send the schemas yourself, and you
+pay the same per-turn bill but keep control of exactly which ones and when.
+[How many MCP tools is too many](how-many-mcp-tools-is-too-many.md) is that
+arithmetic in full.
+
+### The decision, in two questions
+
+**Does a model need to choose whether to call this?** If your own code decides,
+you want the API and nothing else. A protocol whose product is discoverability
+is pure overhead when nothing is discovering.
+
+**Does somebody else's assistant need to find it?** This is the one MCP answers
+and function calling does not. An MCP server can be registered by a client you
+did not write, in an application you have never seen. If both ends are yours,
+you are paying a per-turn bill for a registry with one entry in it, and
+[MCP alternatives](model-context-protocol-alternatives.md) works through what
+to use instead.
+
+Two yeses and the wrapper is worth writing. One yes and it is usually a
+function call with extra steps.
 
 ## MCP vs RAG
 
@@ -66,7 +102,8 @@ find something and then do something about it, which is the common real case.
 ## The one-line versions
 
 - MCP vs an API: not competitors. MCP is usually a model-facing layer over an
-  API.
+  API, and it bills you per turn for the discovery it adds - 3,192 tokens on
+  ours, every turn, forever.
 - MCP vs RAG: not competitors. RAG retrieves at scale; MCP acts, and attaches
   known context.
 - If nothing in your system is a model choosing what to do next, you probably


### PR DESCRIPTION
Measured after #1308 shipped: **`mcp vs api` is 1,900 searches a month and campo libero** - no official documentation and no content-marketing domain on the page - which makes it the strongest cell in the whole corpus. `mcp vs rag` reports **no volume at all**.

The page split its attention almost evenly between the two, 204 words against 190. It was written before either number existed, which is the defect: the topic was chosen well and the balance was chosen blind.

**The API half now carries what a reader asking that question needs, and what nobody else publishes: what the wrapper costs.** A tool is not free to declare. Its name, its description and the JSON schema for its arguments go to the model on *every turn*, for the life of every session, not once at registration. On this server, enumerated from the tool registry and counted with a tokenizer: 16 tools, 9,145 characters of description, **3,192 tokens every turn**. A forty-turn session spends about 128,000 tokens restating what the tools are before a page has been read. Call the same API from your own code and that number is zero.

Then the decision, in two questions, because a reader comparing these is deciding rather than browsing: does a model need to choose whether to call this, and does somebody else's assistant need to find it. Two yeses and the wrapper earns its keep; one yes and it is a function call with extra steps.

The RAG half is unchanged and stays, clearly secondary - it is a real question people pair with this one, and the page's thesis is that both are category errors in different directions.

Also: the title and H1 now lead with the measured query, and one inbound link from `mcp-server.md`, which ranks first for "mcp server" and is the nearest traffic to this question.

488 words on the API comparison against 190 on RAG. Title 55 characters, description 157, in-body link density 3.6 per thousand words - all inside the pipeline's windows. Content gates and selftest clean, english-only clean, wiki builds to 93 pages, name and disclosure scans re-run by hand over 52 added lines.

The seventh content check added in #1310 verified the two figures in this page against the live server rather than taking my word for them.
