### PR TITLE
Manifests for the plugin directories, a hint on every tool, and where the data goes

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "aihawk",
+  "displayName": "AIHawk",
+  "version": "1.0.0",
+  "description": "AI browser agent: browses, clicks, types, and reads real web pages from plain-English instructions.",
+  "author": {
+    "name": "feder-cr",
+    "url": "https://github.com/feder-cr"
+  },
+  "homepage": "https://github.com/feder-cr/AIHawk/wiki/mcp-server",
+  "repository": "https://github.com/feder-cr/AIHawk",
+  "license": "MIT",
+  "keywords": ["browser", "browser-agent", "web-automation", "playwright", "firefox", "computer-use"],
+  "mcpServers": "./mcp.json"
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "aihawk",
+  "displayName": "AIHawk",
+  "description": "AI browser agent: browses, clicks, types, and reads real web pages from plain-English instructions.",
+  "author": {
+    "name": "feder-cr",
+    "url": "https://github.com/feder-cr"
+  },
+  "license": "MIT",
+  "keywords": ["browser", "browser-agent", "web-automation", "playwright", "firefox", "computer-use"],
+  "logo": "assets/aihawk-icon-400.png"
+}

--- a/README.md
+++ b/README.md
@@ -166,6 +166,28 @@ This automates a browser under your control. Read the terms of the sites you
 point it at, respect their rate limits, and do not submit anything a human has
 not read.
 
+## Privacy Policy
+
+AIHawk runs on your machine and has no server of its own. What leaves your
+computer, and to whom:
+
+- **The sites you visit** see the browser, as they would any Firefox.
+- **Your model provider.** The web UI sends the conversation and what the agent
+  reads on the page to OpenRouter under your key. Over MCP, the client you
+  plugged it into does the same with whichever model it uses.
+- **GitHub.** The engine is downloaded from a GitHub release by
+  `uvx invisible-playwright fetch`, and a GeoIP database is when a proxy is
+  set. Each browser launch also fetches a one-line counter file from a GitHub
+  release, which is how launches are counted: the request carries no
+  identifier and nothing of yours, and GitHub sees what any HTTPS request
+  shows, your IP address.
+
+Nothing else is collected and nothing is sent to the author. Sessions,
+profiles and screenshots are stored locally, under `AIHAWK_HOME` if set and
+otherwise in the application-data directory of your system, and are yours to
+delete; nothing is retained anywhere else. Questions go to the
+[issues](https://github.com/feder-cr/AIHawk/issues).
+
 ## License
 
 [MIT](https://github.com/feder-cr/AIHawk/blob/main/LICENSE). Everything

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,11 @@
+{
+  "name": "aihawk",
+  "version": "1.0.0",
+  "description": "AI browser agent: browses, clicks, types, and reads real web pages from plain-English instructions.",
+  "mcpServers": {
+    "aihawk": {
+      "command": "uvx",
+      "args": ["aihawk"]
+    }
+  }
+}

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "aihawk": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["aihawk"]
+    }
+  }
+}

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -16,6 +16,8 @@
   "homepage": "https://github.com/feder-cr/AIHawk",
   "documentation": "https://github.com/feder-cr/AIHawk/wiki",
   "support": "https://github.com/feder-cr/AIHawk/issues",
+  "icon": "https://raw.githubusercontent.com/feder-cr/AIHawk/main/assets/aihawk-icon-400.png",
+  "privacy_policies": ["https://github.com/feder-cr/AIHawk#privacy-policy"],
   "server": {
     "type": "python",
     "entry_point": "src/server.py",

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "aihawk",
   "display_name": "AIHawk",
-  "version": "0.44.0",
+  "version": "0.45.0",
   "description": "AI browser agent: browses, clicks, types, and reads real web pages from plain-English instructions.",
   "long_description": "AIHawk gives an MCP client a real browser to drive. The tools navigate, click, type, read and screenshot pages the way a person would, on a patched Firefox engine.\n\nThe engine is downloaded once, outside this bundle, with `uvx invisible-playwright fetch`. Until that has run, every browser tool reports that the engine is missing.",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -4,9 +4,9 @@
 # test in the suite refuses a release where the three disagree.
 [project]
 name = "aihawk-mcpb"
-version = "0.44.0"
+version = "0.45.0"
 description = "MCP bundle that runs the published aihawk package"
 requires-python = ">=3.11"
 dependencies = [
-    "aihawk==0.44.0",
+    "aihawk==0.45.0",
 ]

--- a/plugin.json
+++ b/plugin.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "aihawk",
+  "description": "AI browser agent: browses, clicks, types, and reads real web pages from plain-English instructions.",
+  "author": {
+    "name": "feder-cr",
+    "url": "https://github.com/feder-cr"
+  },
+  "homepage": "https://github.com/feder-cr/AIHawk/wiki/mcp-server",
+  "repository": "https://github.com/feder-cr/AIHawk",
+  "license": "MIT",
+  "keywords": ["browser", "browser-agent", "web-automation", "playwright", "firefox", "computer-use"]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "aihawk"
-version = "0.44.0"
+version = "0.45.0"
 description = "Drive a stealth browser with an LLM from one command"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/check_content.py
+++ b/scripts/check_content.py
@@ -230,7 +230,6 @@ def cli_commands(cli_path):
 #: reason beside each entry rather than being a mute list.
 NON_TOOL = {"session_id", "browser_id", "session_name", "browser_name"}
 TOOL_RE = re.compile(r"`((?:browser|session)_[a-z_]+)`")
-TOOL_DEF_RE = re.compile(r"@\w+\.tool\([^)]*\)\s*(?:async\s+)?def\s+(\w+)")
 
 #: (path, name) -> why that name may appear there without being one of ours.
 TOOL_MENTIONS_ALLOWED = {
@@ -245,9 +244,36 @@ TOOL_MENTIONS_ALLOWED = {
 }
 
 
+def tool_defs(server_path):
+    """(name, docstring) of every function the server decorates with `.tool`.
+
+    `ast` rather than a regex or an import. An import needs the server's
+    dependencies, which the content gate may not have. A regex was what this
+    used until 2026-09-13, `@\\w+\\.tool\\([^)]*\\)`, and it stopped at the
+    first `)` inside the decorator's arguments: the day the decorators gained
+    `annotations=ToolAnnotations(...)` it found no tool at all, and an empty
+    set reads downstream as "no server to check against", which switched the
+    tool-name check OFF without a word. A docstring is a literal in the file
+    either way, and the decorator is a node with or without nested calls.
+    """
+    import ast
+
+    tree = ast.parse(server_path.read_text(encoding="utf-8"))
+    out = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for dec in node.decorator_list:
+            target = dec.func if isinstance(dec, ast.Call) else dec
+            if isinstance(target, ast.Attribute) and target.attr == "tool":
+                out.append((node.name, ast.get_docstring(node, clean=False) or ""))
+                break
+    return out
+
+
 def mcp_tools(server_path):
-    """The tools the server actually declares (`@mcp.tool()` above a `def`)."""
-    return set(TOOL_DEF_RE.findall(server_path.read_text(encoding="utf-8")))
+    """The tools the server actually declares."""
+    return {name for name, _ in tool_defs(server_path)}
 
 
 #: ⛔ A PUBLISHED NUMBER GOES STALE AND NOTHING SAYS SO, which is the failure
@@ -293,26 +319,11 @@ def _surface_number(match):
 
 
 def tool_surface(server_path):
-    """(tool count, total description characters) read from the source.
-
-    `ast` rather than an import: the content gate runs where the server's
-    dependencies may not be installed, and a docstring is a literal in the
-    file either way.
-    """
-    import ast
-
-    tree = ast.parse(server_path.read_text(encoding="utf-8"))
-    count, chars = 0, 0
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        for dec in node.decorator_list:
-            target = dec.func if isinstance(dec, ast.Call) else dec
-            if isinstance(target, ast.Attribute) and target.attr == "tool":
-                count += 1
-                chars += len(ast.get_docstring(node, clean=False) or "")
-                break
-    return count, chars
+    """(tool count, total description characters) read from the source, by
+    the same walk `mcp_tools` uses, so the two cannot disagree about what a
+    tool is."""
+    defs = tool_defs(server_path)
+    return len(defs), sum(len(doc) for _, doc in defs)
 
 
 def check_surface(rel, text, count, chars):
@@ -473,9 +484,14 @@ def selftest():
         (root / "src" / "aihawk" / "mcp").mkdir(parents=True)
         # The docstrings have a KNOWN length, because the seventh check
         # compares published numbers against this measurement: 2 tools, 8
-        # characters.
+        # characters. One decorator carries a nested call, the shape the
+        # real file has had since the tools gained annotations: a reader that
+        # stops at the first `)` sees one tool here, and the "removed MCP
+        # tool" mutation below is then caught for the wrong reason or not at
+        # all - the surface figures ("2 tools", 8 characters) are what pin it.
         (root / "src" / "aihawk" / "mcp" / "server.py").write_bytes(
-            b'@mcp.tool()\nasync def browser_open(url):\n    """One."""\n'
+            b'@mcp.tool(annotations=_says("Open", destructive=True))\n'
+            b'async def browser_open(url):\n    """One."""\n'
             b'@mcp.tool()\ndef browser_click(selector):\n    """Two."""\n')
         # The README is the source the fifth check reads: one block, one
         # launcher, the same shape as the real page.

--- a/server.json
+++ b/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/feder-cr/AIHawk",
     "source": "github"
   },
-  "version": "0.44.0",
+  "version": "0.45.0",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "aihawk",
-      "version": "0.44.0",
+      "version": "0.45.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/src/aihawk/mcp/server.py
+++ b/src/aihawk/mcp/server.py
@@ -48,6 +48,7 @@ from contextlib import asynccontextmanager
 from typing import Literal
 
 from mcp.server.fastmcp import FastMCP, Image
+from mcp.types import ToolAnnotations
 
 from . import NOTHING_RUNNING, actions, identity, plan, store
 from .registry import BrowserRegistry
@@ -200,6 +201,26 @@ server does. There is no third browser and no way to get one from here -
 
 
 mcp = FastMCP("stealth", instructions=INSTRUCTIONS, lifespan=_lifespan)
+
+
+def _says(title: str, *, read_only: bool = False, destructive: bool = False,
+          open_world: bool = True) -> ToolAnnotations:
+    """What a client may assume about a tool before it calls it.
+
+    Every tool declares a title and one of the two hints a directory review
+    asks for: `read_only` (readOnlyHint) for a tool that changes nothing, so
+    a client may run it without asking each time, and `destructive`
+    (destructiveHint) for one that acts on the page or on a browser, which a
+    client confirms. Anything that types, clicks, navigates or closes is
+    `destructive` here: a form submitted or a page left behind cannot be
+    undone from this side. `open_world` says the tool reaches the live web.
+
+    The title lives in the annotations rather than on the tool because
+    `FastMCP.tool(title=)` exists from mcp 1.10 and this package's floor is
+    1.8, where annotations already carry one (measured on both wheels).
+    """
+    return ToolAnnotations(title=title, readOnlyHint=read_only,
+                           destructiveHint=destructive, openWorldHint=open_world)
 
 
 #: The browser a caller means when it names nothing. Callers that were written
@@ -599,7 +620,7 @@ async def _retrying(fn, *args, browser_id=None, **kwargs):
 
 # --- the two browsers -------------------------------------------------------
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Open a browser", destructive=True, open_world=False))
 async def browser_open(browser: Browser | None = None, seed: int | None = None,
                        proxy: str | None = None, profile: str | None = None) -> str:
     """Open `main` or `support`, or reopen one as somebody else.
@@ -693,7 +714,7 @@ async def browser_open(browser: Browser | None = None, seed: int | None = None,
     return "the %s browser is open. %s" % (role, plan.describe(registry.config(at) or {}))
 
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Close a browser", destructive=True, open_world=False))
 async def browser_close(browser: Browser | None = None) -> str:
     """Close one browser and free what it was holding.
 
@@ -714,7 +735,7 @@ async def browser_close(browser: Browser | None = None) -> str:
             % (name, ", ".join(left) if left else "none"))
 
 
-@mcp.tool()
+@mcp.tool(annotations=_says("List the browsers", read_only=True, open_world=False))
 async def browser_list() -> str:
     """Which of the two browsers are open, where each one is, and which one
     the commands that name none go to.
@@ -789,7 +810,7 @@ async def browser_list() -> str:
 
 # --- who is browsing ---------------------------------------------------------
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Who is browsing", read_only=True, open_world=False))
 async def browser_status(browser: Browser | None = None) -> str:
     """Who is browsing right now: the identity, the exit, the profile and the page.
 
@@ -855,7 +876,7 @@ async def browser_status(browser: Browser | None = None) -> str:
 
 # --- reading ---------------------------------------------------------------
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Go to a URL", destructive=True))
 async def browser_navigate(url: str, wait_until: str = "domcontentloaded",
                            browser: Browser | None = None) -> str:
     """Go to a url in this browser's page, opening it if none exists.
@@ -876,7 +897,7 @@ async def browser_navigate(url: str, wait_until: str = "domcontentloaded",
                            browser_id=browser)
 
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Read the page text", read_only=True))
 async def browser_read_text(selector: str = "body", max_chars: int = 6000,
                             browser: Browser | None = None) -> str:
     """The visible text of an element, with the markup gone.
@@ -894,7 +915,7 @@ async def browser_read_text(selector: str = "body", max_chars: int = 6000,
         selector, max_chars)
 
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Snapshot the page", read_only=True))
 async def browser_snapshot(max_chars: int = 0, browser: Browser | None = None) -> str:
     """Title, url, and the interactive elements that are actually visible.
 
@@ -918,7 +939,7 @@ async def browser_snapshot(max_chars: int = 0, browser: Browser | None = None) -
         await ready(browser), max_chars)
 
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Read the page HTML", read_only=True))
 async def browser_read_html(mode: str = "form", browser: Browser | None = None) -> str:
     """The page's HTML, cleaned down to what is worth reading.
 
@@ -941,7 +962,7 @@ async def browser_read_html(mode: str = "form", browser: Browser | None = None) 
         await ready(browser), mode)
 
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Take a screenshot", read_only=True))
 async def browser_take_screenshot(browser: Browser | None = None) -> Image:
     """One screenshot of this browser's page, on demand.
 
@@ -951,7 +972,7 @@ async def browser_take_screenshot(browser: Browser | None = None) -> Image:
     return Image(data=png, format="png")
 
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Watch the browser window", read_only=True))
 async def browser_watch(browser: Browser | None = None) -> Image:
     """The whole browser window as a person at the machine sees it: tab strip,
     address bar, the page and the pointer, from a live capture kept running on
@@ -978,7 +999,7 @@ async def browser_watch(browser: Browser | None = None) -> Image:
 
 # --- acting ----------------------------------------------------------------
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Click an element", destructive=True))
 async def browser_click(selector: str, browser: Browser | None = None) -> str:
     """Click the first element matching a CSS selector.
 
@@ -991,7 +1012,7 @@ async def browser_click(selector: str, browser: Browser | None = None) -> str:
         await ready(browser), selector)
 
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Click at a point", destructive=True))
 async def browser_click_at(x: float, y: float, hold_seconds: float = 0.0,
                            browser: Browser | None = None) -> Image:
     """Click (or press-and-hold) a raw viewport coordinate instead of a
@@ -1019,7 +1040,7 @@ async def browser_click_at(x: float, y: float, hold_seconds: float = 0.0,
     return Image(data=png, format="png")
 
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Type into a field", destructive=True))
 async def browser_type(selector: str, text: str, browser: Browser | None = None) -> str:
     """Fill a field, replacing whatever it holds.
 
@@ -1032,7 +1053,7 @@ async def browser_type(selector: str, text: str, browser: Browser | None = None)
         await ready(browser), selector, text)
 
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Choose a dropdown option", destructive=True))
 async def browser_select_option(selector: str, value: str,
                                 browser: Browser | None = None) -> str:
     """Choose an option in a dropdown (`<select>`), by its visible label or by
@@ -1048,7 +1069,7 @@ async def browser_select_option(selector: str, value: str,
         await ready(browser), selector, value)
 
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Press a key", destructive=True))
 async def browser_press_key(key: str, browser: Browser | None = None) -> str:
     """Press a key on whatever has focus: "Enter", "Tab", "Escape",
     "ArrowDown", "Control+a", or a single character.
@@ -1058,7 +1079,7 @@ async def browser_press_key(key: str, browser: Browser | None = None) -> str:
         await ready(browser), key)
 
 
-@mcp.tool()
+@mcp.tool(annotations=_says("Read the page with JavaScript", read_only=True))
 async def browser_evaluate(expression: str, browser: Browser | None = None) -> str:
     """READ from the page with JavaScript and get the result as JSON.
 

--- a/tests/mcp_server/test_every_tool_says_what_it_does.py
+++ b/tests/mcp_server/test_every_tool_says_what_it_does.py
@@ -1,0 +1,86 @@
+"""Every tool tells a client, before it is called, whether it only reads.
+
+A client decides from the annotations whether a call needs the person's
+confirmation: a tool marked read-only runs on its own, one marked destructive
+asks first, and one that says neither is treated as the worst case by careful
+clients and as the best case by careless ones. A directory review refuses a
+server whose tools carry no title or no hint, and that is where this was first
+asked of us (2026-09-13) - but the reason to keep it is the confirmation
+prompt, which is decided by these flags and by nothing else.
+
+Read from the server the way a client reads them, over `list_tools`, so what
+is asserted is what goes out on the wire. No browser is started. The check is a
+function over the tool list, and a second test feeds it known-bad tools: one
+with no annotations, one with no title, one saying nothing about what it
+does, and one saying both things at once.
+"""
+from __future__ import annotations
+
+import asyncio
+
+from mcp.types import Tool, ToolAnnotations
+
+from aihawk.mcp import server
+
+
+def findings(tools):
+    """Why a client could not tell what a tool does, or nothing."""
+    out = []
+    for t in tools:
+        a = t.annotations
+        if a is None:
+            out.append("%s: no annotations at all" % t.name)
+            continue
+        if not (a.title or "").strip():
+            out.append("%s: no title" % t.name)
+        if a.readOnlyHint and a.destructiveHint:
+            out.append("%s: read-only and destructive at once" % t.name)
+        elif not a.readOnlyHint and not a.destructiveHint:
+            out.append("%s: neither read-only nor destructive, so a client "
+                       "cannot tell whether to ask first" % t.name)
+    return out
+
+
+def _live_tools():
+    tools = asyncio.run(server.mcp.list_tools())
+    assert len(tools) >= 16, "found %d tools, so this is not looking at the server" % len(tools)
+    return tools
+
+
+def test_every_tool_carries_a_title_and_says_whether_it_only_reads():
+    assert findings(_live_tools()) == []
+
+
+def test_the_reading_tools_are_the_ones_that_read():
+    """The flags are not decoration: a tool that can change the page is not
+    marked read-only, and one that cannot is not marked destructive. Listed by
+    name, so a new tool has to be placed on one side or the other here."""
+    reads = {"browser_list", "browser_status", "browser_read_text", "browser_snapshot",
+             "browser_read_html", "browser_take_screenshot", "browser_watch",
+             "browser_evaluate"}
+    acts = {"browser_open", "browser_close", "browser_navigate", "browser_click",
+            "browser_click_at", "browser_type", "browser_select_option",
+            "browser_press_key"}
+    by_name = {t.name: t.annotations for t in _live_tools()}
+    assert set(by_name) == reads | acts, sorted(set(by_name) ^ (reads | acts))
+    for name in reads:
+        assert by_name[name].readOnlyHint is True and not by_name[name].destructiveHint, name
+    for name in acts:
+        assert by_name[name].destructiveHint is True and not by_name[name].readOnlyHint, name
+
+
+def _tool(name, annotations):
+    return Tool(name=name, description="x", inputSchema={"type": "object"},
+                annotations=annotations)
+
+
+def test_the_check_refuses_known_bad_tools():
+    assert findings(_live_tools()) == []
+    assert findings([_tool("bare", None)]) == ["bare: no annotations at all"]
+    assert findings([_tool("untitled", ToolAnnotations(readOnlyHint=True))]) == ["untitled: no title"]
+    assert findings([_tool("mute", ToolAnnotations(title="Mute"))]) == [
+        "mute: neither read-only nor destructive, so a client cannot tell whether to ask first"]
+    assert findings([_tool("both", ToolAnnotations(title="Both", readOnlyHint=True,
+                                                    destructiveHint=True))]) == [
+        "both: read-only and destructive at once"]
+    assert findings([_tool("fine", ToolAnnotations(title="Fine", destructiveHint=True))]) == []

--- a/tests/test_publishing_surfaces.py
+++ b/tests/test_publishing_surfaces.py
@@ -19,6 +19,18 @@ and one token that must match a name. Each pair was written by hand on
 publish.yml runs on the tag, which is after the bump, and would only find out
 at the end of a release. This test finds out on the pull request.
 
+  3. Since 2026-09-13, five manifests at the root are read by plugin loaders
+     and directory crawlers: `.claude-plugin/plugin.json` (Claude Code plugin,
+     which points at `mcp.json`), `plugin.json` and `mcp.json` (the Agent
+     Plugins standard, which cursor.directory scans for), `.cursor-plugin/
+     plugin.json` (Cursor's marketplace) and `gemini-extension.json` (the
+     Gemini CLI gallery, which crawls the `gemini-cli-extension` topic). None
+     of them carries the package version - a manifest that just says `uvx
+     aihawk` does not change per release - but every one of them repeats the
+     package name, the one-line description and the launch command, and the
+     bundle manifest repeats the description too. Those are the copies this
+     file makes agree.
+
 Every check is a function over strings and dicts, and a second test feeds them
 known-bad input: a check that has only ever said "consistent" is not a check.
 """
@@ -44,7 +56,62 @@ def _load():
         "server": json.loads((ROOT / "server.json").read_text(encoding="utf-8")),
         "manifest": json.loads((ROOT / "mcpb" / "manifest.json").read_text(encoding="utf-8")),
         "bundle_pyproject": tomllib.loads((ROOT / "mcpb" / "pyproject.toml").read_text(encoding="utf-8")),
+        "plugins": {rel: json.loads((ROOT / rel).read_text(encoding="utf-8")) for rel in PLUGIN_FILES},
     }
+
+
+PLUGIN_FILES = (".claude-plugin/plugin.json", "plugin.json", "mcp.json",
+                ".cursor-plugin/plugin.json", "gemini-extension.json")
+LAUNCH = {"command": "uvx", "args": ["aihawk"]}
+
+
+def plugin_findings(package_name, manifest, plugins):
+    """Why a plugin loader or a crawler would read something other than what
+    ships, or nothing. `manifest` is the bundle's, whose description is the
+    one the others must repeat."""
+    out = []
+    description = manifest.get("description")
+    for rel in PLUGIN_FILES:
+        if rel not in plugins:
+            out.append("%s is missing" % rel)
+    for rel, doc in plugins.items():
+        if rel.endswith("plugin.json") or rel == "gemini-extension.json":
+            if doc.get("name") != package_name:
+                out.append("%s names %r, the project is %r" % (rel, doc.get("name"), package_name))
+            if doc.get("description") != description:
+                out.append("%s describes the package differently from the bundle manifest" % rel)
+    claude = plugins.get(".claude-plugin/plugin.json") or {}
+    if claude.get("mcpServers") != "./mcp.json":
+        out.append("the Claude plugin does not point at ./mcp.json, so it would carry a second server config")
+    agent = plugins.get("plugin.json") or {}
+    if agent.get("$schema") != "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json":
+        out.append("plugin.json does not declare the Agent Plugins 1.0.0 schema, and a client rejects it")
+    for rel, key in (("mcp.json", "aihawk"), ("gemini-extension.json", "aihawk")):
+        servers = (plugins.get(rel) or {}).get("mcpServers") or {}
+        entry = servers.get(key) or {}
+        if {k: entry.get(k) for k in LAUNCH} != LAUNCH:
+            out.append("%s launches the server with %r, the README launches it with `uvx aihawk`"
+                       % (rel, entry))
+    mcp = plugins.get("mcp.json") or {}
+    if mcp.get("$schema") != "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json":
+        out.append("mcp.json does not declare the Agent Plugins 1.0.0 schema")
+    if ((mcp.get("mcpServers") or {}).get("aihawk") or {}).get("type") != "stdio":
+        out.append("mcp.json does not say the transport is stdio, which the Agent Plugins schema requires")
+    logo = (plugins.get(".cursor-plugin/plugin.json") or {}).get("logo")
+    if not logo or not (ROOT / logo).is_file():
+        out.append("the Cursor plugin's logo %r is not a file in the repository" % logo)
+    # The two manifests that carry a version carry the MANIFEST's version, not
+    # the package's: `uvx aihawk` does not change per release. One number in
+    # two files, so they are held equal here; bump both when the config changes.
+    gemini = plugins.get("gemini-extension.json") or {}
+    if not gemini.get("version"):
+        out.append("gemini-extension.json has no version, which the gallery requires")
+    if claude.get("version") != gemini.get("version"):
+        out.append("the Claude plugin is at %r and the Gemini extension at %r; one config, one version"
+                   % (claude.get("version"), gemini.get("version")))
+    if not manifest.get("privacy_policies") or "#privacy-policy" not in manifest["privacy_policies"][0]:
+        out.append("the bundle manifest does not point at the README's Privacy Policy section")
+    return out
 
 
 def registry_findings(package_name, version, readme, server):
@@ -114,6 +181,19 @@ def test_the_bundle_installs_the_version_that_ships():
     assert bundle_findings(d["package_name"], d["version"], d["manifest"], d["bundle_pyproject"]) == []
 
 
+def test_the_plugin_manifests_launch_the_package_that_ships():
+    d = _load()
+    assert plugin_findings(d["package_name"], d["manifest"], d["plugins"]) == []
+
+
+def test_the_readme_has_the_privacy_section_the_bundle_points_at():
+    """The bundle manifest's `privacy_policies` URL is the README anchor; a
+    heading renamed or removed leaves the bundle pointing at nothing, and a
+    directory review rejects it outright."""
+    d = _load()
+    assert re.search(r"^## Privacy Policy\s*$", d["readme"], re.M), "README.md has no `## Privacy Policy` heading"
+
+
 def test_the_checks_refuse_known_bad_input():
     d = _load()
     good = registry_findings(d["package_name"], d["version"], d["readme"], d["server"])
@@ -143,3 +223,35 @@ def test_the_checks_refuse_known_bad_input():
 
     p = copy.deepcopy(d["bundle_pyproject"]); p["project"]["dependencies"] = ["aihawk>=0.1"]
     assert bundle_findings(d["package_name"], d["version"], d["manifest"], p)
+
+    assert plugin_findings(d["package_name"], d["manifest"], d["plugins"]) == []
+
+    g = copy.deepcopy(d["plugins"]); del g["gemini-extension.json"]
+    assert plugin_findings(d["package_name"], d["manifest"], g)
+
+    g = copy.deepcopy(d["plugins"]); g["plugin.json"]["description"] = "something else"
+    assert plugin_findings(d["package_name"], d["manifest"], g)
+
+    g = copy.deepcopy(d["plugins"]); g[".cursor-plugin/plugin.json"]["name"] = "ai-hawk"
+    assert plugin_findings(d["package_name"], d["manifest"], g)
+
+    g = copy.deepcopy(d["plugins"]); g["mcp.json"]["mcpServers"]["aihawk"]["command"] = "python"
+    assert plugin_findings(d["package_name"], d["manifest"], g)
+
+    g = copy.deepcopy(d["plugins"]); g["gemini-extension.json"]["mcpServers"]["aihawk"]["args"] = ["aihawk", "ui"]
+    assert plugin_findings(d["package_name"], d["manifest"], g)
+
+    g = copy.deepcopy(d["plugins"]); g["mcp.json"]["mcpServers"]["aihawk"].pop("type")
+    assert plugin_findings(d["package_name"], d["manifest"], g)
+
+    g = copy.deepcopy(d["plugins"]); g[".claude-plugin/plugin.json"]["mcpServers"] = {"aihawk": LAUNCH}
+    assert plugin_findings(d["package_name"], d["manifest"], g)
+
+    g = copy.deepcopy(d["plugins"]); g[".cursor-plugin/plugin.json"]["logo"] = "assets/missing.png"
+    assert plugin_findings(d["package_name"], d["manifest"], g)
+
+    g = copy.deepcopy(d["plugins"]); g["gemini-extension.json"]["version"] = "9.9.9"
+    assert plugin_findings(d["package_name"], d["manifest"], g)
+
+    m = copy.deepcopy(d["manifest"]); m.pop("privacy_policies")
+    assert plugin_findings(d["package_name"], m, d["plugins"])


### PR DESCRIPTION
Four directories index a server from files in its repository rather than from a form: Claude Code plugins (`.claude-plugin/plugin.json`), cursor.directory and Cursor's marketplace (the Agent Plugins layout: `plugin.json` + `mcp.json`, and `.cursor-plugin/plugin.json`), and the Gemini CLI gallery (`gemini-extension.json`, crawled under the `gemini-cli-extension` topic). This adds the five files. They all say `uvx aihawk` over stdio, and `test_publishing_surfaces` holds them to the package name, the bundle's description and that command, with a known-bad case per field. `claude plugin validate .` passes.

Every tool gets a title and a readOnlyHint or destructiveHint, which is what a client uses to decide whether a call needs confirmation and what the Anthropic connectors review asks for. The title is in the annotations, not on the tool: `FastMCP.tool(title=)` is mcp 1.10 and our floor is 1.8, where annotations already carry one (measured on both wheels). New test reads the tools over `list_tools` and is fed the four bad shapes; run against main's un-annotated server it reports all 16.

The content gate found tools with a regex that stopped at the first `)` inside the decorator, so with a nested `ToolAnnotations(...)` call it would have found none and skipped the tool-name check silently. It now uses the same ast walk `tool_surface` already did, and the selftest server has one nested decorator.

The bundle manifest gains `icon` and `privacy_policies`, and the README a Privacy Policy section stating what leaves the machine: the sites visited, the model provider, GitHub for the engine and GeoIP downloads and the per-launch counter fetch (no identifier). Both are hard requirements for the connectors directory.

Full suite: 595 passed, 8 skipped, 3 xfailed. Content gate and its selftest clean, english gate clean.

After merge: add the `gemini-cli-extension` topic (through `check_repo_metadata.py`), rescan on cursor.directory, submit the plugin at platform.claude.com/plugins/submit and the bundle through the desktop-extension form. The annotations reach `uvx aihawk` users only with the next release.